### PR TITLE
Fix macOS can't connect because of an error 400

### DIFF
--- a/Sources/EmbraceObjCUtils/source/EMBDevice.m
+++ b/Sources/EmbraceObjCUtils/source/EMBDevice.m
@@ -337,7 +337,12 @@ typedef NS_ENUM(NSInteger, EMBReleaseMode) {
 #if UIKIT_AVAILABLE
     return [UIDevice currentDevice].systemVersion;
 #else
-    return @"";
+    NSOperatingSystemVersion operatingSystemVersion = [NSProcessInfo processInfo].operatingSystemVersion;
+    if (operatingSystemVersion.patchVersion == 0) {
+        return [NSString stringWithFormat: @"%i.%i", operatingSystemVersion.majorVersion, operatingSystemVersion.minorVersion];
+    } else {
+        return [NSString stringWithFormat: @"%i.%i.%i", operatingSystemVersion.majorVersion, operatingSystemVersion.minorVersion, operatingSystemVersion.patchVersion];
+    }
 #endif
 }
 


### PR DESCRIPTION
Return the correct value for `EMBDevice.operatingSystemVersion` when on macOS. Fixes an issue where macOS Embrace can't connect because of an error 400:

```
{
  "error": {
    "msg": "Missing required parameter: appVersion",
    "code": 1
  }
}
```