### PR TITLE
Fixing `CaptureServiceBuilder` interface

### DIFF
--- a/Sources/EmbraceIO/Capture/CaptureServiceBuilder.swift
+++ b/Sources/EmbraceIO/Capture/CaptureServiceBuilder.swift
@@ -17,15 +17,21 @@ public class CaptureServiceBuilder: NSObject {
 
     /// Adds the given `CaptureService`.
     /// - Note: If there was another `CaptureService` already added of the same type, it will be replaced with the new one.
-    @objc public func add(_ service: CaptureService) {
+    @discardableResult
+    @objc public func add(_ service: CaptureService) -> Self {
         remove(ofType: type(of: service))
         services.append(service)
+
+        return self
     }
 
     /// Removes a previously added `CaptureService` of the given type, if any.
     /// - Parameter type: Type of the `CaptureService` to remove.
-    @objc public func remove(ofType type: AnyClass) {
+    @discardableResult
+    @objc public func remove(ofType type: AnyClass) -> Self {
         services.removeAll(where: { $0.isKind(of: type) })
+
+        return self
     }
 
     /// Adds the default `CaptureServices` using their corresponding default options.

--- a/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
@@ -199,6 +199,39 @@ class CaptureServiceBuilderTests: XCTestCase {
         let service = list[0] as! PushNotificationCaptureService
         XCTAssert(service.options.captureData)
     }
+
+    func test_add_returnValue() throws {
+        // given a builder
+        let builder = CaptureServiceBuilder()
+
+        // when adding a service
+        let builder2 = builder.add(.lowMemoryWarning())
+
+        // then the builder is returned
+        XCTAssert(builder == builder2)
+    }
+
+    func test_remove_returnValue() throws {
+        // given a builder
+        let builder = CaptureServiceBuilder()
+
+        // when removing a service
+        let builder2 = builder.remove(ofType: LowMemoryWarningCaptureService.self)
+
+        // then the builder is returned
+        XCTAssert(builder == builder2)
+    }
+
+    func test_addDefaults_returnValue() throws {
+        // given a builder
+        let builder = CaptureServiceBuilder()
+
+        // when adding the default services
+        let builder2 = builder.addDefaults()
+
+        // then the builder is returned
+        XCTAssert(builder == builder2)
+    }
 }
 
 // swiftlint:enable force_cast


### PR DESCRIPTION
* The `add` and `remove` methods were not returning self which made the class not function like a normal builder.