### PR TITLE
Adds example of session personas to UserInfo view in BrandGame

### DIFF
--- a/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
+++ b/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7B3143C62AFF1E7D00BA0D2F /* ReflexGameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3143C52AFF1E7D00BA0D2F /* ReflexGameModel.swift */; };
 		7B3229DC2B2950D500664F04 /* BubbleMinigameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B56309F2ABF323400E0DF39 /* BubbleMinigameView.swift */; };
 		7B3BD2192BBC5A1600938444 /* StdoutExporter in Frameworks */ = {isa = PBXBuildFile; productRef = 7B3BD2182BBC5A1600938444 /* StdoutExporter */; };
+		7B3CBA0A2C52E67600688E7B /* PersonaGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3CBA092C52E67600688E7B /* PersonaGrid.swift */; };
 		7B4C0BDF2BA9F93400F0BC37 /* App+SmokeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C0BDE2BA9F93400F0BC37 /* App+SmokeTest.swift */; };
 		7B4FFC2D2B1E5B7B006239F7 /* Endpoints+InfoPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4FFC2C2B1E5B7B006239F7 /* Endpoints+InfoPlist.swift */; };
 		7B4FFC332B1E811B006239F7 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4FFC322B1E811B006239F7 /* UserInfo.swift */; };
@@ -33,6 +34,7 @@
 		7B62ADA32B0068280087C2AE /* SimonMinigameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B62ADA22B0068280087C2AE /* SimonMinigameView.swift */; };
 		7B62ADA52B0068960087C2AE /* SimonGameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B62ADA42B0068960087C2AE /* SimonGameModel.swift */; };
 		7B7341E12BD4AD100026D8B8 /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7341E02BD4AD100026D8B8 /* LazyView.swift */; };
+		7B8BE3F92C5154BC006B0BF3 /* PillText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8BE3F82C5154BC006B0BF3 /* PillText.swift */; };
 		7BBBCD582BD0205C00BC289A /* StdoutLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBCD572BD0205C00BC289A /* StdoutLogExporter.swift */; };
 		7BBBCD5B2BD07CE000BC289A /* GitInfo+InfoPlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBCD5A2BD07CE000BC289A /* GitInfo+InfoPlist.swift */; };
 		7BBBCD5D2BD07DE600BC289A /* App+GitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBCD5C2BD07DE600BC289A /* App+GitInfo.swift */; };
@@ -89,6 +91,7 @@
 		7B3143B82AFDC8EC00BA0D2F /* RightBracketShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightBracketShape.swift; sourceTree = "<group>"; };
 		7B3143BE2AFDECCE00BA0D2F /* Icon+Meta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Icon+Meta.swift"; sourceTree = "<group>"; };
 		7B3143C52AFF1E7D00BA0D2F /* ReflexGameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflexGameModel.swift; sourceTree = "<group>"; };
+		7B3CBA092C52E67600688E7B /* PersonaGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaGrid.swift; sourceTree = "<group>"; };
 		7B4C0BDE2BA9F93400F0BC37 /* App+SmokeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App+SmokeTest.swift"; sourceTree = "<group>"; };
 		7B4FFC2C2B1E5B7B006239F7 /* Endpoints+InfoPlist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Endpoints+InfoPlist.swift"; sourceTree = "<group>"; };
 		7B4FFC2E2B1E5D0F006239F7 /* embrace.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = embrace.xcconfig; sourceTree = "<group>"; };
@@ -111,6 +114,7 @@
 		7B62ADA22B0068280087C2AE /* SimonMinigameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimonMinigameView.swift; sourceTree = "<group>"; };
 		7B62ADA42B0068960087C2AE /* SimonGameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimonGameModel.swift; sourceTree = "<group>"; };
 		7B7341E02BD4AD100026D8B8 /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
+		7B8BE3F82C5154BC006B0BF3 /* PillText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillText.swift; sourceTree = "<group>"; };
 		7BBBCD4D2BCEC14000BC289A /* run.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = run.sh; sourceTree = "<group>"; };
 		7BBBCD4E2BCEC14000BC289A /* upload */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = upload; sourceTree = "<group>"; };
 		7BBBCD572BD0205C00BC289A /* StdoutLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdoutLogExporter.swift; sourceTree = "<group>"; };
@@ -213,6 +217,8 @@
 			isa = PBXGroup;
 			children = (
 				7B4FFC322B1E811B006239F7 /* UserInfo.swift */,
+				7B8BE3F82C5154BC006B0BF3 /* PillText.swift */,
+				7B3CBA092C52E67600688E7B /* PersonaGrid.swift */,
 			);
 			path = UserInfo;
 			sourceTree = "<group>";
@@ -622,6 +628,7 @@
 				7B62AD9F2B00608A0087C2AE /* AppSettings+Environment.swift in Sources */,
 				7B5630902ABE743400E0DF39 /* ContentView.swift in Sources */,
 				FA4C5F332C486E13005C0371 /* CreateSpanView.swift in Sources */,
+				7B8BE3F92C5154BC006B0BF3 /* PillText.swift in Sources */,
 				7B3143C62AFF1E7D00BA0D2F /* ReflexGameModel.swift in Sources */,
 				FAFDA3D72C34273100AD17CF /* MemoryPressureSimulatorView.swift in Sources */,
 				7B5630A52AC1331000E0DF39 /* Color+Random.swift in Sources */,
@@ -632,6 +639,7 @@
 				FAFDA3D42C333FC900AD17CF /* Request.swift in Sources */,
 				7B4C0BDF2BA9F93400F0BC37 /* App+SmokeTest.swift in Sources */,
 				7B3143B72AFDC52D00BA0D2F /* RightDotShape.swift in Sources */,
+				7B3CBA0A2C52E67600688E7B /* PersonaGrid.swift in Sources */,
 				FA9505162B86640F00562A4C /* LoggingView.swift in Sources */,
 				7B3143B92AFDC8EC00BA0D2F /* RightBracketShape.swift in Sources */,
 				7B3143B52AFDC50E00BA0D2F /* LeftDotShape.swift in Sources */,

--- a/Examples/BrandGame/BrandGame/View/Menu/UserInfo/PersonaGrid.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/UserInfo/PersonaGrid.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import SwiftUI
+import EmbraceIO
+
+struct PersonaGrid: View {
+
+    let lifespan: MetadataLifespan
+    @ObservedObject var user: UserInfo.EmbraceUser
+
+    var body: some View {
+        Grid(verticalSpacing: 6.0) {
+            ForEach(personaGridRows(), id: \.self) { row in
+                GridRow {
+                    ForEach(row) { personaOption in
+                        PillText(
+                            personaOption.rawValue,
+                            selected: user.hasPersona(personaOption),
+                            style: colorForPersona(persona: personaOption)
+                        ).onTapGesture {
+                            user.toggle(persona: personaOption, lifespan: lifespan)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func personaGridRows(size: Int = 3) -> [[PersonaTag]] {
+        let count = Self.quickPersonas.count
+
+        return stride(from: 0, to: count, by: size).map {
+            Array(Self.quickPersonas[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+
+    func colorForPersona(persona: PersonaTag) -> Color {
+        let idx = persona.rawValue.count % Self.personaColors.count
+        return Self.personaColors[idx]
+    }
+}
+
+extension PersonaGrid {
+    static var quickPersonas: [PersonaTag] {
+        [
+            PersonaTag.free,
+            PersonaTag.preview,
+            PersonaTag.subscriber,
+            PersonaTag.payer,
+            PersonaTag.guest,
+            PersonaTag.pro,
+            PersonaTag.mvp,
+            PersonaTag.vip
+        ]
+    }
+
+    static var personaColors: [Color] {
+        [
+            Color.embraceLead,
+            Color.embracePink,
+            Color.embracePurple,
+            Color.embraceSilver
+        ]
+    }
+}
+
+#Preview {
+    PersonaGrid(lifespan: .session, user: .init())
+}

--- a/Examples/BrandGame/BrandGame/View/Menu/UserInfo/PillText.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/UserInfo/PillText.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct PillText<S: ShapeStyle>: View {
+    let text: String
+    let selected: Bool
+    let cornerSize: CGSize
+    let style: S
+
+    init(
+        _ text: String,
+        selected: Bool = false,
+        style: S = Color.primary,
+        cornerSize: CGSize = .init(width: 24.0, height: 24.0)
+    ) {
+
+        self.text = text
+        self.selected = selected
+        self.cornerSize = cornerSize
+        self.style = style
+    }
+
+    var body: some View {
+        Text(text)
+            .padding(.horizontal, cornerSize.width / 2)
+            .padding(.vertical, cornerSize.height / 4)
+            .background( style.opacity(selected ? 1 : 0))
+            .clipShape(RoundedRectangle(cornerSize: cornerSize))
+            .overlay(
+                RoundedRectangle(cornerSize: cornerSize)
+                    .stroke(style, lineWidth: 2)
+            ) // Border
+    }
+}
+
+#Preview("Unselected") {
+    PillText("Text", selected: false, style: Color.embracePink)
+}
+
+#Preview("Selected") {
+    PillText("Text", selected: true, style: Color.embracePink)
+}

--- a/Sources/EmbraceCore/Public/Metadata/MetadataHandler+User.swift
+++ b/Sources/EmbraceCore/Public/Metadata/MetadataHandler+User.swift
@@ -78,7 +78,7 @@ extension MetadataHandler {
                     value: .string(value),
                     type: .customProperty,
                     lifespan: .permanent,
-                    lifespanId: ""
+                    lifespanId: MetadataRecord.lifespanIdForPermanent
                 )
 
                 _ = try storage?.addMetadata(record)
@@ -92,7 +92,7 @@ extension MetadataHandler {
 
     private func remove(_ key: UserResourceKey) {
         do {
-            try storage?.removeMetadata(key: key.rawValue, type: .customProperty, lifespan: .permanent)
+            try remove(key: key.rawValue, type: .customProperty, lifespan: .permanent)
         } catch {
             Embrace.logger.warning("An error occurred when removing this user resource key: \(key)")
         }

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -147,21 +147,17 @@ extension EmbraceStorage {
         key: String,
         type: MetadataRecordType,
         lifespan: MetadataRecordLifespan,
-        lifespanId: String = ""
+        lifespanId: String
     ) throws {
-        try dbQueue.write { db in
-            guard let record = try MetadataRecord
+        _ = try dbQueue.write { db in
+            try MetadataRecord
                 .filter(
                     MetadataRecord.Schema.key == key &&
                     MetadataRecord.Schema.type == type.rawValue &&
                     MetadataRecord.Schema.lifespan == lifespan.rawValue &&
                     MetadataRecord.Schema.lifespanId == lifespanId
                 )
-                .fetchOne(db) else {
-                return
-            }
-
-            try record.delete(db)
+                .deleteAll(db)
         }
     }
 

--- a/Sources/EmbraceStorageInternal/Records/MetadataRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/MetadataRecord.swift
@@ -82,3 +82,7 @@ extension MetadataRecord: Equatable {
         return lhs.key == rhs.key
     }
 }
+
+extension MetadataRecord {
+    public static let lifespanIdForPermanent = ""
+}

--- a/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandler+PersonaTagTests.swift
+++ b/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandler+PersonaTagTests.swift
@@ -203,7 +203,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             lifespanId: sessionController.currentSession!.id.toString
         )
 
-        try storage.removeMetadata(key: "permanent", type: .personaTag, lifespan: .permanent)
+        try storage.removeMetadata(key: "permanent", type: .personaTag, lifespan: .permanent, lifespanId: "")
 
         // when fetching the current persona tags
         let tags = handler.currentPersonas
@@ -242,12 +242,12 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
         )
 
         // when removing a persona tag
-        try handler.remove(persona: "permanent", lifespan: .permanent)
+        try handler.remove(persona: "session", lifespan: .session)
 
         // then the persona tag is removed
         let tags = try storage.fetchPersonaTagsForSessionId(sessionController.currentSession!.id)
         XCTAssertEqual(tags.count, 2)
-        XCTAssertEqual(Set(tags.map(\.key)), Set(["process", "session"]))
+        XCTAssertEqual(Set(tags.map(\.key)), Set(["permanent", "process"]))
     }
 
     func test_removePersona_doesNotRemove_whenLifespanDoesNotMatch() throws {


### PR DESCRIPTION
This PR also fixes a bug when removing metadata in the MetadataHandler. 

The `lifespanId` was not being passed in correctly so only `permanent` records could be removed.