### PR TITLE
Prevent recursion on `WKWebViewSetNativationDelegateSwizzler`

### DIFF
--- a/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService.swift
@@ -120,8 +120,12 @@ struct WKWebViewSetNativationDelegateSwizzler: Swizzlable {
     func install() throws {
         try swizzleInstanceMethod { originalImplementation -> BlockImplementationType in
             return { webView, delegate in
-                proxy.originalDelegate = delegate
-                originalImplementation(webView, Self.selector, proxy)
+                if !(webView.navigationDelegate is WKNavigationDelegateProxy) {
+                    proxy.originalDelegate = delegate
+                    originalImplementation(webView, Self.selector, proxy)
+                } else {
+                    originalImplementation(webView, Self.selector, delegate)
+                }
             }
         }
     }

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
@@ -34,6 +34,20 @@ class WebViewCaptureServiceTests: XCTestCase {
         XCTAssert(service.proxy.originalDelegate!.isKind(of: MockWKNavigationDelegate.self))
     }
 
+    func test_setNavigationDelegate_ShouldntGenerateRecursion() throws {
+        // given a webView already "swizzled"
+        let webView = WKWebView()
+        let originalDelegate = MockWKNavigationDelegate()
+        webView.navigationDelegate = originalDelegate
+
+        // When Setting a new delegate for the same webview
+        let secondDelegate = MockWKNavigationDelegate()
+        webView.navigationDelegate = secondDelegate
+
+        // Then the proxy class added during in the swizzled method should be removed to prevent any potential recursion.
+        XCTAssertTrue(try XCTUnwrap(webView.navigationDelegate).isKind(of: MockWKNavigationDelegate.self))
+    }
+
     func test_spanEvent() {
         // given a webview
         let webView = WKWebView()


### PR DESCRIPTION
# Problem
When a `WKWebView` sets a `navigationDelegate`, our `WKWebViewSetNavigationDelegateSwizzler` sets our `WKNavigationDelegateProxy` as the delegate while retaining a reference to the original delegate to forward messages. 
However, if a proxy is manually set for some reason, this setup could result in recursion.

# Solution
Ensure that we do not set ourselves as the `navigationDelegate` multiple times to prevent recursion.