### PR TITLE
Update EmbraceOpenTelemetry to expose `LogType` on `log` methods.

### DIFF
--- a/Sources/EmbraceCommonInternal/EmbraceType/LogType+Declarations.swift
+++ b/Sources/EmbraceCommonInternal/EmbraceType/LogType+Declarations.swift
@@ -2,8 +2,29 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
+import Foundation
+
+// MARK: - Primary categories
+extension LogType {
+    public static let system = LogType(primary: .system)
+}
+
 // MARK: - System
 extension LogType {
-    public static let `default` = LogType(system: "log")
+
+    /// Used for Embrace Log messages. Use this type for common application logs 
+    public static let message = LogType(system: "log")
+
+    /// Used for crash reports
+    public static let crash = LogType(system: "ios.crash")
+
+    /// Used for exception messages
+    public static let exception = LogType(system: "exception")
+
+    /// Used to leave small messages to hint the path a user has taken.
+    public static let breadcrumb = LogType(system: "breadcrumb")
+
+    /// Used for internal messages about the operation of the Embrace SDK itself
+    /// * Note: This should be used for observation of the Embrace SDK only.
     public static let `internal` = LogType(system: "internal")
 }

--- a/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
@@ -133,8 +133,8 @@ class DefaultInternalLogger: InternalLogger {
         // send log
         otel?.log(
             message,
-            type: .default,
             severity: level.severity,
+            type: .internal,
             attributes: attributes
         )
 

--- a/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
@@ -133,6 +133,7 @@ class DefaultInternalLogger: InternalLogger {
         // send log
         otel?.log(
             message,
+            type: .default,
             severity: level.severity,
             attributes: attributes
         )

--- a/Sources/EmbraceCore/Internal/Logs/Exporter/StorageEmbraceLogExporter.swift
+++ b/Sources/EmbraceCore/Internal/Logs/Exporter/StorageEmbraceLogExporter.swift
@@ -33,7 +33,7 @@ class StorageEmbraceLogExporter: EmbraceLogRecordExporter {
         for var log in logRecords where validation.execute(log: &log) {
 
             // do not export crash logs
-            guard log.attributes[LogSemantics.keyEmbraceType] != .string(LogType.crash.rawValue) else {
+            guard !log.isEmbType(LogType.crash) else {
                 continue
             }
 

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -104,10 +104,11 @@ extension Embrace: EmbraceOpenTelemetry {
     ///   - attributes: Attributes for the log
     public func log(
         _ message: String,
+        type: LogType,
         severity: LogSeverity,
         attributes: [String: String] = [:]
     ) {
-        log(message, severity: severity, timestamp: Date(), attributes: attributes)
+        log(message, type: type, severity: severity, timestamp: Date(), attributes: attributes)
     }
 
     /// Creates and adds a log for the current session span
@@ -118,6 +119,7 @@ extension Embrace: EmbraceOpenTelemetry {
     ///   - attributes: Attributes for the log
     public func log(
         _ message: String,
+        type: LogType,
         severity: LogSeverity,
         timestamp: Date,
         attributes: [String: String]

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -7,6 +7,7 @@ import EmbraceCommonInternal
 import EmbraceOTelInternal
 
 extension Embrace: EmbraceOpenTelemetry {
+
     private var exporter: EmbraceSpanExporter { StorageSpanExporter(options: .init(storage: storage)) }
 
     private var otel: EmbraceOTel { EmbraceOTel() }
@@ -104,11 +105,11 @@ extension Embrace: EmbraceOpenTelemetry {
     ///   - attributes: Attributes for the log
     public func log(
         _ message: String,
-        type: LogType,
         severity: LogSeverity,
+        type: LogType = .message,
         attributes: [String: String] = [:]
     ) {
-        log(message, type: type, severity: severity, timestamp: Date(), attributes: attributes)
+        log(message, severity: severity, type: type, timestamp: Date(), attributes: attributes)
     }
 
     /// Creates and adds a log for the current session span
@@ -119,8 +120,8 @@ extension Embrace: EmbraceOpenTelemetry {
     ///   - attributes: Attributes for the log
     public func log(
         _ message: String,
-        type: LogType,
         severity: LogSeverity,
+        type: LogType = .message,
         timestamp: Date,
         attributes: [String: String]
     ) {
@@ -141,7 +142,7 @@ extension Embrace: EmbraceOpenTelemetry {
 
         let finalAttributes = attributesBuilder
             .addStackTrace(stackTrace)
-            .addLogType(.default)
+            .addLogType(type)
             .addApplicationState()
             .addApplicationProperties()
             .addSessionIdentifier()

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -166,6 +166,7 @@ class UnsentDataHandler {
 
         otel?.log(
             "",
+            type: .default,
             severity: .fatal,
             timestamp: timestamp,
             attributes: attributes

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -166,8 +166,8 @@ class UnsentDataHandler {
 
         otel?.log(
             "",
-            type: .default,
             severity: .fatal,
+            type: .crash,
             timestamp: timestamp,
             attributes: attributes
         )

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -30,6 +30,7 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         _ message: String,
         type: LogType,
         severity: LogSeverity,
+        type: LogType,
         attributes: [String: String]
     )
 
@@ -37,6 +38,7 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         _ message: String,
         type: LogType,
         severity: LogSeverity,
+        type: LogType,
         timestamp: Date,
         attributes: [String: String]
     )

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -28,7 +28,6 @@ public protocol EmbraceOpenTelemetry: AnyObject {
 
     func log(
         _ message: String,
-        type: LogType,
         severity: LogSeverity,
         type: LogType,
         attributes: [String: String]
@@ -36,31 +35,9 @@ public protocol EmbraceOpenTelemetry: AnyObject {
 
     func log(
         _ message: String,
-        type: LogType,
         severity: LogSeverity,
         type: LogType,
         timestamp: Date,
         attributes: [String: String]
     )
-}
-
-extension EmbraceOpenTelemetry {
-    public func log(
-        _ message: String,
-        type: LogType = .default,
-        severity: LogSeverity,
-        attributes: [String: String]
-    ) {
-        log(message, type: type, severity: severity, attributes: attributes)
-    }
-
-    public func log(
-        _ message: String,
-        type: LogType = .default,
-        severity: LogSeverity,
-        timestamp: Date,
-        attributes: [String: String]
-    ) {
-        log(message, type: type, severity: severity, timestamp: timestamp, attributes: attributes)
-    }
 }

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -28,14 +28,37 @@ public protocol EmbraceOpenTelemetry: AnyObject {
 
     func log(
         _ message: String,
+        type: LogType,
         severity: LogSeverity,
         attributes: [String: String]
     )
 
     func log(
         _ message: String,
+        type: LogType,
         severity: LogSeverity,
         timestamp: Date,
         attributes: [String: String]
     )
+}
+
+extension EmbraceOpenTelemetry {
+    public func log(
+        _ message: String,
+        type: LogType = .default,
+        severity: LogSeverity,
+        attributes: [String: String]
+    ) {
+        log(message, type: type, severity: severity, attributes: attributes)
+    }
+
+    public func log(
+        _ message: String,
+        type: LogType = .default,
+        severity: LogSeverity,
+        timestamp: Date,
+        attributes: [String: String]
+    ) {
+        log(message, type: type, severity: severity, timestamp: timestamp, attributes: attributes)
+    }
 }

--- a/Sources/EmbraceOTelInternal/Logs/EmbraceSemantics/LogRecord+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Logs/EmbraceSemantics/LogRecord+Embrace.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceSemantics
+import EmbraceCommonInternal
+
+extension ReadableLogRecord {
+    public var embType: LogType? {
+        switch attributes[LogSemantics.keyEmbraceType] {
+        case let .string(value):
+            return LogType(rawValue: value)
+        default:
+            return nil
+        }
+    }
+
+    public func isEmbType(_ type: LogType) -> Bool {
+        return embType == type
+    }
+}

--- a/Sources/EmbraceSemantics/Logs/LogSemantics+Crash.swift
+++ b/Sources/EmbraceSemantics/Logs/LogSemantics+Crash.swift
@@ -2,6 +2,15 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceCommonInternal
+
+extension LogType {
+
+    /// Used for crash reports provided by the Crash Reporter
+    public static let crash = LogType(system: "ios.crash")
+
+}
+
 public extension LogSemantics {
     struct Crash {
         public static let keyId = "log.record.uid"

--- a/Sources/EmbraceSemantics/Logs/LogSemantics.swift
+++ b/Sources/EmbraceSemantics/Logs/LogSemantics.swift
@@ -4,10 +4,6 @@
 
 import EmbraceCommonInternal
 
-public extension LogType {
-    static let crash = LogType(system: "ios.crash")
-}
-
 public struct LogSemantics {
     public static let keyEmbraceType = "emb.type"
     public static let keyId = "log.record.uid"

--- a/Sources/EmbraceSemantics/Logs/LogType+Declarations.swift
+++ b/Sources/EmbraceSemantics/Logs/LogType+Declarations.swift
@@ -2,21 +2,13 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
-import Foundation
-
-// MARK: - Primary categories
-extension LogType {
-    public static let system = LogType(primary: .system)
-}
+import EmbraceCommonInternal
 
 // MARK: - System
 extension LogType {
 
     /// Used for Embrace Log messages. Use this type for common application logs 
     public static let message = LogType(system: "log")
-
-    /// Used for crash reports
-    public static let crash = LogType(system: "ios.crash")
 
     /// Used for exception messages
     public static let exception = LogType(system: "exception")

--- a/Tests/EmbraceCommonInternalTests/LogType/LogTypeDeclarationTests.swift
+++ b/Tests/EmbraceCommonInternalTests/LogType/LogTypeDeclarationTests.swift
@@ -18,12 +18,12 @@ class LogTypeDeclarationTests: XCTestCase {
         XCTAssertEqual(LogType.system.rawValue, "sys")
     }
 
-    // MARK: - Default
-    func test_logTypeDefault_isSysLogString() {
-        XCTAssertEqual(LogType.default.rawValue, "sys.log")
+    // MARK: - Message
+    func test_logTypeMessage_isSysLogString() {
+        XCTAssertEqual(LogType.message.rawValue, "sys.log")
     }
 
-    func test_logTypeDefault_isPrimarySystemAndSecondaryLog() {
-        XCTAssertEqual(LogType.default, .init(primary: .system, secondary: "log"))
+    func test_logTypeMessage_isPrimarySystemAndSecondaryLog() {
+        XCTAssertEqual(LogType.message, .init(primary: .system, secondary: "log"))
     }
 }

--- a/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
@@ -153,10 +153,10 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         givenMetadataFetcher()
         givenEmbraceLogAttributesBuilder()
 
-        whenInvokingAddLogType(.default)
+        whenInvokingAddLogType(.message)
         whenInvokingBuild()
 
-        thenResultingAttributes(is: ["emb.type": LogType.default.rawValue])
+        thenResultingAttributes(is: ["emb.type": LogType.message.rawValue])
     }
 
     func test_onAddLogType_whenAlreadySet_doesNotChangeValue() {
@@ -164,7 +164,7 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         givenMetadataFetcher()
         givenEmbraceLogAttributesBuilder(withInitialAttributes: ["emb.type": LogType.crash.rawValue])
 
-        whenInvokingAddLogType(.default)
+        whenInvokingAddLogType(.message)
         whenInvokingBuild()
 
         thenResultingAttributes(is: ["emb.type": LogType.crash.rawValue])

--- a/Tests/EmbraceOTelInternalTests/EmbraceOTelTests.swift
+++ b/Tests/EmbraceOTelInternalTests/EmbraceOTelTests.swift
@@ -183,6 +183,6 @@ final class EmbraceOTelTests: XCTestCase {
         XCTAssertNotNil(record)
         XCTAssertEqual(record?.body, "example message")
         XCTAssertEqual(record?.timestamp, logTime)
-        XCTAssertEqual(record?.attributes, ["foo" : .string("bar")])
+        XCTAssertEqual(record?.attributes, ["foo": .string("bar")])
     }
 }

--- a/Tests/EmbraceStorageInternalTests/FetchMethods/EmbraceStorage+SpanForSessionRecordTests.swift
+++ b/Tests/EmbraceStorageInternalTests/FetchMethods/EmbraceStorage+SpanForSessionRecordTests.swift
@@ -4,8 +4,8 @@
 
 import XCTest
 
-@testable import EmbraceStorage
-import EmbraceCommon
+@testable import EmbraceStorageInternal
+import EmbraceCommonInternal
 import OpenTelemetryApi
 
 fileprivate extension Date {

--- a/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
@@ -56,12 +56,19 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
     public func log(
         _ message: String,
         severity: LogSeverity,
+        type: LogType = .message,
         attributes: [String: String]
     ) {
-        log(message, severity: severity, timestamp: Date(), attributes: attributes)
+        log(message, severity: severity, type: type, timestamp: Date(), attributes: attributes)
     }
 
-    public func log(_ message: String, severity: LogSeverity, timestamp: Date, attributes: [String: String]) {
+    public func log(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType = .message,
+        timestamp: Date,
+        attributes: [String: String]
+    ) {
 
         var otelAttributes: [String: AttributeValue] = [:]
         for (key, value) in attributes {


### PR DESCRIPTION
Also renames `LogType.default` to `LogType.message`

This PR is to allow clients to send different LogTypes when creating a log message. 