### PR TITLE
Adds `W3C.traceparent` helper methods

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -174,19 +174,13 @@ final class DefaultURLSessionTaskHandler: URLSessionTaskHandler {
         }
 
         // ignore if header is already present
-        let headerName = "traceparent"
-
-        let previousValue = task.originalRequest?.value(forHTTPHeaderField: headerName)
+        let previousValue = task.originalRequest?.value(forHTTPHeaderField: W3C.traceparentHeaderName)
         guard previousValue == nil else {
             return previousValue
         }
 
-        // set traceparent request header
-        // Docs: https://www.w3.org/TR/trace-context-1/#trace-context-http-headers-format
-        // Note: Version hardcoded to "00"
-        // Note: Flags hardcoded to "01" (means "sampled")
-        let value = "00-\(span.context.traceId.hexString)-\(span.context.spanId.hexString)-01"
-        if task.injectHeader(withKey: headerName, value: value) {
+        let value = W3C.traceparent(from: span.context)
+        if task.injectHeader(withKey: W3C.traceparentHeaderName, value: value) {
             return value
         }
 

--- a/Sources/EmbraceCore/Utils/W3C/W3C+TraceParent.swift
+++ b/Sources/EmbraceCore/Utils/W3C/W3C+TraceParent.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceOTelInternal
+
+public extension W3C {
+    /// Creates a W3C [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header) header value.
+    /// - Parameters:
+    ///     - span: The span to create the traceparent header from
+    static func traceparent(from span: Span) -> String {
+        return traceparent(from: span.context)
+    }
+
+    /// Creates a W3C [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header) header value.
+    /// - Parameters:
+    ///    - context:   The span context to create the traceparent header from
+    static func traceparent(from context: SpanContext) -> String {
+        return traceparent(
+            traceId: context.traceId.hexString,
+            spanId: context.spanId.hexString,
+            sampled: context.traceFlags.sampled
+        )
+    }
+
+    /// Creates a W3C [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header) header value.
+    /// Will generate a version `00` traceparent.
+    ///  - Parameters:
+    ///     - traceId: The Span's traceId
+    ///     - spanId: The Span's spanId
+    ///     - sampled: Whether the trace is sampled
+    static func traceparent(traceId: String, spanId: String, sampled: Bool = false) -> String {
+        return [
+            "00",
+            traceId,
+            spanId,
+            sampled ? "01" : "00"
+        ].joined(separator: "-")
+    }
+
+}

--- a/Sources/EmbraceCore/Utils/W3C/W3C+TraceParent.swift
+++ b/Sources/EmbraceCore/Utils/W3C/W3C+TraceParent.swift
@@ -5,6 +5,8 @@
 import EmbraceOTelInternal
 
 public extension W3C {
+    static let traceparentHeaderName = "traceparent"
+
     /// Creates a W3C [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header) header value.
     /// - Parameters:
     ///     - span: The span to create the traceparent header from

--- a/Sources/EmbraceCore/Utils/W3C/W3C.swift
+++ b/Sources/EmbraceCore/Utils/W3C/W3C.swift
@@ -1,0 +1,7 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+public struct W3C {
+    private init() { }
+}

--- a/Sources/EmbraceOTelInternal/Trace/Tracer/OpenTelemetryTypes.swift
+++ b/Sources/EmbraceOTelInternal/Trace/Tracer/OpenTelemetryTypes.swift
@@ -14,6 +14,10 @@ public typealias SpanId = OpenTelemetryApi.SpanId
 
 public typealias SpanContext = OpenTelemetryApi.SpanContext
 
+public typealias TraceFlags = OpenTelemetryApi.TraceFlags
+
+public typealias TraceState = OpenTelemetryApi.TraceState
+
 public typealias Span=OpenTelemetryApi.Span
 
 public typealias SpanBuilder=OpenTelemetryApi.SpanBuilder

--- a/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
@@ -27,8 +27,6 @@ final class W3C_TraceParentTests: XCTestCase {
             .buildSpan(name: "example", type: .performance)
             .startSpan()
 
-        print("TYPE OF SPAN: \(type(of: span)) \t\t SPAN: \(span)")
-
         let traceparent = W3C.traceparent(from: span)
         XCTAssertEqual(traceparent, "00-\(span.context.traceId.hexString)-\(span.context.spanId.hexString)-00")
     }

--- a/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
@@ -6,8 +6,13 @@ import XCTest
 import EmbraceCore
 
 import EmbraceOTelInternal
+import OpenTelemetryApi
 
 final class W3C_TraceParentTests: XCTestCase {
+
+    override func setUp() async throws {
+        OpenTelemetry.registerTracerProvider(tracerProvider: DefaultTracerProvider.instance)
+    }
 
     func test_w3c_traceparent_returnsCorrectValue() {
         let unsampled = W3C.traceparent(traceId: "exampletraceid", spanId: "examplespanid", sampled: false)

--- a/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+import EmbraceCore
+
+import EmbraceOTelInternal
+
+final class W3C_TraceParentTests: XCTestCase {
+
+    func test_w3c_traceparent_returnsCorrectValue() {
+        let unsampled = W3C.traceparent(traceId: "exampletraceid", spanId: "examplespanid", sampled: false)
+        let sampled = W3C.traceparent(traceId: "exampletraceid", spanId: "examplespanid", sampled: true)
+
+        XCTAssertEqual(unsampled, "00-exampletraceid-examplespanid-00")
+        XCTAssertEqual(sampled, "00-exampletraceid-examplespanid-01")
+    }
+
+    func test_w3c_traceparent_fromSpan_returnsCorrectValue() {
+        let span = EmbraceOTel()
+            .buildSpan(name: "example", type: .performance)
+            .startSpan()
+        let traceparent = W3C.traceparent(from: span)
+
+        XCTAssertEqual(traceparent, "00-\(span.context.traceId.hexString)-\(span.context.spanId.hexString)-00")
+    }
+
+    func test_w3c_traceparent_fromSpanContext_returnsCorrectValue() {
+        let unsampled = SpanContext.create(
+            traceId: .random(),
+            spanId: .random(),
+            traceFlags: .init(),
+            traceState: .init()
+        )
+
+        XCTAssertEqual(
+            W3C.traceparent(from: unsampled),
+            "00-\(unsampled.traceId.hexString)-\(unsampled.spanId.hexString)-00"
+        )
+
+        let sampled = SpanContext.create(
+            traceId: .random(),
+            spanId: .random(),
+            traceFlags: .init(fromByte: 0x1),
+            traceState: .init()
+        )
+
+        XCTAssertEqual(
+            W3C.traceparent(from: sampled),
+            "00-\(sampled.traceId.hexString)-\(sampled.spanId.hexString)-01"
+        )
+    }
+
+}

--- a/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/W3C/W3C+TraceParentTests.swift
@@ -21,8 +21,10 @@ final class W3C_TraceParentTests: XCTestCase {
         let span = EmbraceOTel()
             .buildSpan(name: "example", type: .performance)
             .startSpan()
-        let traceparent = W3C.traceparent(from: span)
 
+        print("TYPE OF SPAN: \(type(of: span)) \t\t SPAN: \(span)")
+
+        let traceparent = W3C.traceparent(from: span)
         XCTAssertEqual(traceparent, "00-\(span.context.traceId.hexString)-\(span.context.spanId.hexString)-00")
     }
 


### PR DESCRIPTION
These helper methods are intended to be used when manually instrumenting network requests. 