### PR TITLE
Use new name for embrace_symbol_upload binary.

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -59,7 +59,7 @@ jobs:
             fi
           fi
           echo "Production readiness determined: $IS_PRODUCTION_READY"
-          
+
       - name: Validate and Extract RC Version Number
         id: rc_version_extractor
         run: |
@@ -74,7 +74,7 @@ jobs:
               RC_VERSION=$TAG_VERSION
             fi
           fi
-          
+
           # Production-ready versions should always follow a "definitive" version format:
           # - xx.yy.zz
           # But, non-production-ready versions support having pre-release versions, like:
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+
       - name: Bump Version
         run: |
           echo "Bumping version to '$RC_VERSION'"
@@ -218,8 +218,8 @@ jobs:
         run: |
           DIR=$(pwd -P)
           mkdir artifacts
-          mv run.sh upload artifacts/
-          chmod +x artifacts/run.sh artifacts/upload
+          chmod +x run.sh embrace_symbol_upload.darwin
+          mv run.sh embrace_symbol_upload.darwin artifacts/
 
           cd artifacts; zip "$DIR/embrace_$RC_VERSION.zip" *; cd -;
           zip "$DIR/embrace_$RC_VERSION.zip" -r xcframeworks/*; cd -;
@@ -257,14 +257,14 @@ jobs:
           IS_PRODUCTION_READY: ${{ needs.extractor.outputs.is_production_ready }}
         run: |
           if gh release view --repo embrace-io/embrace-apple-sdk $RC_VERSION > /dev/null 2>&1; then
-            if [ "$IS_PRODUCTION_READY" == "false" ]; then 
+            if [ "$IS_PRODUCTION_READY" == "false" ]; then
               echo "Release $RC_VERSION already exists; editing..."
               gh release upload $RC_VERSION cocoapods/embrace_$RC_VERSION.zip --clobber --repo embrace-io/embrace-apple-sdk
             else
               echo "Cannot update a productive release"
               exit 1
             fi
-          else 
+          else
             echo "Creating Release $RC_VERSION in Github"
             PRERELEASE_FLAG=""
             if [ "$IS_PRODUCTION_READY" == "false" ]; then

--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.license                        = { :type => "Apache 2.0" }
   spec.author                         = "Embrace.io"
   spec.source                         = { "http" => "https://github.com/embrace-io/embrace-apple-sdk/releases/download/#{spec.version}/embrace_#{spec.version}.zip" }
-  spec.preserve_paths                 = [ "run.sh", "upload" ]
+  spec.preserve_paths                 = [ "run.sh", "embrace_symbol_upload.darwin" ]
   spec.requires_arc                   = true
   spec.ios.deployment_target          = "13.0"
   spec.default_subspec = "EmbraceIO"

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -207,8 +207,8 @@ In order to have stack traces in error logs or crashes be as readable as possibl
  to your project.
 
 First, download [our support utility](https://downloads.embrace.io/embrace_support.zip).
-This is an archive that contains the Embrace `upload` binary and also a shell script `run.sh`.
-These should be copied into your project at a known location like `embrace_support/upload`
+This is an archive that contains the Embrace `embrace_symbol_upload` binary and also a shell script `run.sh`.
+These should be copied into your project at a known location like `embrace_support/embrace_symbol_upload.darwin`
 and `embrace_support/run.sh`.
 
 Then, in your app target's Xcode Build Phases pane, add a new 'Run Script Phase' at the end of the list

--- a/bin/templates/EmbraceIO.podspec.tpl
+++ b/bin/templates/EmbraceIO.podspec.tpl
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.license                        = { :type => "Apache 2.0" }
   spec.author                         = "Embrace.io"
   spec.source                         = { "http" => "https://github.com/embrace-io/embrace-apple-sdk/releases/download/#{spec.version}/embrace_#{spec.version}.zip" }
-  spec.preserve_paths                 = [ "run.sh", "upload" ]
+  spec.preserve_paths                 = [ "run.sh", "embrace_symbol_upload.darwin" ]
   spec.requires_arc                   = true
   spec.ios.deployment_target          = "13.0"
   spec.default_subspec = "EmbraceIO"


### PR DESCRIPTION
The next release of embrace_support.zip will include embrace_symbol_upload.[platform] instead of just "upload" so that we can ship both Linux and macOS binaries. run.sh included inside that release will also use the new filename.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
