### PR TITLE
Added Session Attribute View to BrandGame

### DIFF
--- a/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
+++ b/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		FA3B0A172C3C2A5600315578 /* EmbraceIO in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A162C3C2A5600315578 /* EmbraceIO */; };
 		FA4C5F332C486E13005C0371 /* CreateSpanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4C5F322C486E13005C0371 /* CreateSpanView.swift */; };
 		FA4C5F352C487B45005C0371 /* AttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4C5F342C487B45005C0371 /* AttributesView.swift */; };
+		FA4FA4FA2C62DBB600E66300 /* NoSpacesTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4FA4F92C62DBB600E66300 /* NoSpacesTextField.swift */; };
 		FA716C7E2C45B94A00AD0161 /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA716C7D2C45B94A00AD0161 /* EmbraceCore */; };
 		FA716C802C45B94A00AD0161 /* EmbraceCrash in Frameworks */ = {isa = PBXBuildFile; productRef = FA716C7F2C45B94A00AD0161 /* EmbraceCrash */; };
 		FA716C822C45B94A00AD0161 /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FA716C812C45B94A00AD0161 /* EmbraceCrashlyticsSupport */; };
@@ -57,6 +58,7 @@
 		FA9505162B86640F00562A4C /* LoggingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9505152B86640F00562A4C /* LoggingView.swift */; };
 		FAB41A9F2C49492200972BA9 /* PopUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB41A9E2C49492200972BA9 /* PopUpView.swift */; };
 		FAB41AA22C49556100972BA9 /* PopUpViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB41AA12C49556100972BA9 /* PopUpViewModifier.swift */; };
+		FABF7EE12C627A8C00E84140 /* SessionAttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABF7EE02C627A8C00E84140 /* SessionAttributesView.swift */; };
 		FADB905E2C333B8B00079005 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADB905D2C333B8B00079005 /* WebView.swift */; };
 		FADB90602C333BBA00079005 /* BrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADB905F2C333BBA00079005 /* BrowserView.swift */; };
 		FAF85DF52C45B1C6002306FF /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FAF85DF42C45B1C6002306FF /* EmbraceCore */; };
@@ -128,10 +130,12 @@
 		7BCB662D2AC476BC00ABD33A /* NetworkStressTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStressTest.swift; sourceTree = "<group>"; };
 		FA4C5F322C486E13005C0371 /* CreateSpanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSpanView.swift; sourceTree = "<group>"; };
 		FA4C5F342C487B45005C0371 /* AttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesView.swift; sourceTree = "<group>"; };
+		FA4FA4F92C62DBB600E66300 /* NoSpacesTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSpacesTextField.swift; sourceTree = "<group>"; };
 		FA910EF02C4835B100C2E2E4 /* OpenTelemetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTelemetryView.swift; sourceTree = "<group>"; };
 		FA9505152B86640F00562A4C /* LoggingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingView.swift; sourceTree = "<group>"; };
 		FAB41A9E2C49492200972BA9 /* PopUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpView.swift; sourceTree = "<group>"; };
 		FAB41AA12C49556100972BA9 /* PopUpViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpViewModifier.swift; sourceTree = "<group>"; };
+		FABF7EE02C627A8C00E84140 /* SessionAttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAttributesView.swift; sourceTree = "<group>"; };
 		FADB905D2C333B8B00079005 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		FADB905F2C333BBA00079005 /* BrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserView.swift; sourceTree = "<group>"; };
 		FAFDA3CF2C333FC900AD17CF /* NetworkRequestBuilderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkRequestBuilderView.swift; sourceTree = "<group>"; };
@@ -369,6 +373,7 @@
 		7BCB66252AC4726100ABD33A /* Menu */ = {
 			isa = PBXGroup;
 			children = (
+				FABF7EDF2C627A7A00E84140 /* SessionAttributes */,
 				7B3143C02AFDECE900BA0D2F /* Minigames */,
 				FA910EEF2C48359900C2E2E4 /* OpenTelemetry */,
 				7B4FFC312B1E8104006239F7 /* UserInfo */,
@@ -413,6 +418,14 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		FA4FA4F82C62DBAA00E66300 /* TextFields */ = {
+			isa = PBXGroup;
+			children = (
+				FA4FA4F92C62DBB600E66300 /* NoSpacesTextField.swift */,
+			);
+			path = TextFields;
+			sourceTree = "<group>";
+		};
 		FA910EEF2C48359900C2E2E4 /* OpenTelemetry */ = {
 			isa = PBXGroup;
 			children = (
@@ -433,6 +446,7 @@
 		FAB41A9D2C4948F900972BA9 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				FA4FA4F82C62DBAA00E66300 /* TextFields */,
 				FAB41AA02C49555300972BA9 /* PopUp */,
 			);
 			path = Components;
@@ -445,6 +459,14 @@
 				FAB41AA12C49556100972BA9 /* PopUpViewModifier.swift */,
 			);
 			path = PopUp;
+			sourceTree = "<group>";
+		};
+		FABF7EDF2C627A7A00E84140 /* SessionAttributes */ = {
+			isa = PBXGroup;
+			children = (
+				FABF7EE02C627A8C00E84140 /* SessionAttributesView.swift */,
+			);
+			path = SessionAttributes;
 			sourceTree = "<group>";
 		};
 		FADB905C2C333B6400079005 /* Browser */ = {
@@ -612,6 +634,7 @@
 				7BCB662E2AC476BC00ABD33A /* NetworkStressTest.swift in Sources */,
 				7B005D762AD72E080073CAC4 /* App+Embrace.swift in Sources */,
 				7B62AD9B2B005FE20087C2AE /* AppSettings.swift in Sources */,
+				FA4FA4FA2C62DBB600E66300 /* NoSpacesTextField.swift in Sources */,
 				7BBBCD5B2BD07CE000BC289A /* GitInfo+InfoPlist.swift in Sources */,
 				FAB41A9F2C49492200972BA9 /* PopUpView.swift in Sources */,
 				7B62ADA52B0068960087C2AE /* SimonGameModel.swift in Sources */,
@@ -620,6 +643,7 @@
 				7BBBCD5D2BD07DE600BC289A /* App+GitInfo.swift in Sources */,
 				FAFDA3D32C333FC900AD17CF /* RequestResponseDetail.swift in Sources */,
 				7B5630A22AC1291D00E0DF39 /* BrandIconShape.swift in Sources */,
+				FABF7EE12C627A8C00E84140 /* SessionAttributesView.swift in Sources */,
 				7B62AD932B0027280087C2AE /* ReflexMinigameView.swift in Sources */,
 				FAB41AA22C49556100972BA9 /* PopUpViewModifier.swift in Sources */,
 				7B3143BF2AFDECCF00BA0D2F /* Icon+Meta.swift in Sources */,

--- a/Examples/BrandGame/BrandGame/BrandGameApp.swift
+++ b/Examples/BrandGame/BrandGame/BrandGameApp.swift
@@ -19,8 +19,8 @@ struct BrandGameApp: App {
 
             addGitInfoProperties()
             smokeTestIfNecessary()
-        } catch let e {
-            print("Error starting Embrace \(e.localizedDescription)")
+        } catch let exception {
+            print("Error starting Embrace \(exception.localizedDescription)")
         }
     }
 

--- a/Examples/BrandGame/BrandGame/View/Components/TextFields/NoSpacesTextField.swift
+++ b/Examples/BrandGame/BrandGame/View/Components/TextFields/NoSpacesTextField.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import SwiftUI
+
+struct NoSpacesTextField: View {
+    @Binding var text: String
+    var placeholder: String
+    private let replacementChar: String
+    private let autocorrectionEnabled: Bool
+
+    init(
+        _ placeholder: String,
+        text: Binding<String>,
+        replacementChar: String = "_",
+        autocorrectionEnabled: Bool = false
+    ) {
+        self._text = text
+        self.placeholder = placeholder
+        self.replacementChar = replacementChar
+        self.autocorrectionEnabled = autocorrectionEnabled
+    }
+
+    var body: some View {
+        TextField(placeholder, text: $text)
+            .onChange(of: text) { newValue, oldValue in
+                let modifiedString = newValue.replacingOccurrences(of: " ", with: replacementChar)
+                if modifiedString != oldValue {
+                    text = modifiedString
+                }
+            }
+            .textInputAutocapitalization(.never)
+            .disableAutocorrection(!autocorrectionEnabled)
+    }
+}

--- a/Examples/BrandGame/BrandGame/View/Menu/MenuList.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/MenuList.swift
@@ -15,7 +15,9 @@ struct MenuList: View {
                NavigationLink(destination: LazyView(UserInfo())) {
                    Text("User Information")
                }
-               .contentShape(Rectangle())
+                NavigationLink(destination: SessionAttributesView()) {
+                    Text("Session Attributes")
+                }
             }
 
             Section("Mini-Games") {

--- a/Examples/BrandGame/BrandGame/View/Menu/OpenTelemetry/CreateSpanView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/OpenTelemetry/CreateSpanView.swift
@@ -84,7 +84,7 @@ struct CreateSpanView: View {
     }
 
     private func isValidForm() -> Bool {
-        guard !name.isEmpty else { 
+        guard !name.isEmpty else {
             return false
         }
         guard startTime <= endTime else {

--- a/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
@@ -9,6 +9,7 @@ struct SessionAttributesView: View {
     @State private var property = Property()
     @State private var action: Action = .add
     @State private var appliesToAllAttributes: Bool = false
+    @State private var showPopUp: Bool = false
 
     private var metadataLifespan: MetadataLifespan {
         return property.lifespan.toMetadataLifespan()
@@ -63,6 +64,7 @@ struct SessionAttributesView: View {
                 }
             }
         }
+        .popUp("\(property.type.rawValue) was \(action.rawValue)ed", shouldShow: $showPopUp)
         .navigationBarTitle("Session Attributes", displayMode: .inline)
     }
 }
@@ -88,6 +90,9 @@ private extension SessionAttributesView {
             case .delete:
                 try deleteProperty()
             }
+            showPopUp = true
+            property.key = ""
+            property.value = ""
         } catch let exception {
             print(exception.localizedDescription)
         }

--- a/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
@@ -133,15 +133,23 @@ private extension SessionAttributesView {
         let metadata = Embrace.client?.metadata
         switch property.type {
         case .resource:
-            try metadata?.removeResource(
-                key: property.key,
-                lifespan: metadataLifespan
-            )
+            if appliesToAllAttributes {
+                try metadata?.removeAllResources(lifespans: [metadataLifespan])
+            } else {
+                try metadata?.removeResource(
+                    key: property.key,
+                    lifespan: metadataLifespan
+                )
+            }
         case .sessionProperty:
-            try metadata?.removeProperty(
-                key: property.key,
-                lifespan: metadataLifespan
-            )
+            if appliesToAllAttributes {
+                try metadata?.removeAllProperties(lifespans: [metadataLifespan])
+            } else {
+                try metadata?.removeProperty(
+                    key: property.key,
+                    lifespan: metadataLifespan
+                )
+            }
         }
     }
 

--- a/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
@@ -1,0 +1,201 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import SwiftUI
+import EmbraceIO
+
+struct SessionAttributesView: View {
+    @State private var property = Property()
+    @State private var action: Action = .add
+    @State private var appliesToAllAttributes: Bool = false
+
+    private var metadataLifespan: MetadataLifespan {
+        return property.lifespan.toMetadataLifespan()
+    }
+
+    var body: some View {
+        Form {
+            Picker("Type", selection: $action) {
+                ForEach(Action.allCases) { action in
+                    Text(action.rawValue).tag(action)
+                }
+            }.pickerStyle(SegmentedPickerStyle())
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets(top: -12, leading: 0, bottom: 0, trailing: 0))
+
+            Section(header: Text("Property Details")) {
+                Picker("Type", selection: $property.type) {
+                    ForEach(AttributeType.allCases) { type in
+                        Text(type.rawValue).tag(type)
+                    }
+                }
+
+                Picker("Lifespan", selection: $property.lifespan) {
+                    ForEach(Lifespan.allCases) { lifespan in
+                        Text(lifespan.rawValue).tag(lifespan)
+                    }
+                }
+
+                if action == .delete {
+                    Toggle(isOn: $appliesToAllAttributes, label: {
+                        Text("\(action.rawValue) all?")
+                    })
+                }
+
+                if !(action == .delete && appliesToAllAttributes) {
+                    NoSpacesTextField("Key", text: $property.key)
+                }
+
+                if action != .delete {
+                    NoSpacesTextField("Value", text: $property.value)
+                }
+            }
+
+            Section {
+                Button("Execute") {
+                    execute()
+                }
+                .disabled(isExecuteDisabled())
+
+                Button("Reset Fields", role: .destructive) {
+                    resetFields()
+                }
+            }
+        }
+        .navigationBarTitle("Session Attributes", displayMode: .inline)
+    }
+}
+
+// MARK: - Private Methods / Logic
+private extension SessionAttributesView {
+    func isExecuteDisabled() -> Bool {
+        switch action {
+        case .add, .update:
+            return property.key.isEmpty || property.value.isEmpty
+        case .delete:
+            return property.key.isEmpty && !appliesToAllAttributes
+        }
+    }
+
+    func execute() {
+        do {
+            switch action {
+            case .add:
+                try addProperty()
+            case .update:
+                try updateProperty()
+            case .delete:
+                try deleteProperty()
+            }
+        } catch let exception {
+            print(exception.localizedDescription)
+        }
+    }
+
+    func addProperty() throws {
+        let metadata = Embrace.client?.metadata
+        switch property.type {
+        case .resource:
+            try metadata?.addResource(
+                key: property.key,
+                value: property.value,
+                lifespan: metadataLifespan
+            )
+        case .sessionProperty:
+            try metadata?.addProperty(
+                key: property.key,
+                value: property.value,
+                lifespan: metadataLifespan
+            )
+        }
+    }
+
+    func updateProperty() throws {
+        let metadata = Embrace.client?.metadata
+        switch property.type {
+        case .resource:
+            try metadata?.updateResource(
+                key: property.key,
+                value: property.value,
+                lifespan: metadataLifespan
+            )
+        case .sessionProperty:
+            try metadata?.updateProperty(
+                key: property.key,
+                value: property.value,
+                lifespan: metadataLifespan
+            )
+        }
+    }
+
+    func deleteProperty () throws {
+        let metadata = Embrace.client?.metadata
+        switch property.type {
+        case .resource:
+            try metadata?.removeResource(
+                key: property.key,
+                lifespan: metadataLifespan
+            )
+        case .sessionProperty:
+            try metadata?.removeProperty(
+                key: property.key,
+                lifespan: metadataLifespan
+            )
+        }
+    }
+
+    func resetFields() {
+        property = Property()
+        action = .add
+        appliesToAllAttributes = false
+    }
+}
+
+// MARK: - Types
+private extension SessionAttributesView {
+    enum AttributeType: String, CaseIterable, Identifiable {
+        case sessionProperty = "Session Property"
+        case resource = "Resource"
+
+        var id: String { self.rawValue }
+    }
+
+    enum Lifespan: String, CaseIterable, Identifiable {
+        case session = "Session"
+        case process = "Process"
+        case permanent = "Permanent"
+
+        var id: String { self.rawValue }
+
+        func toMetadataLifespan() -> MetadataLifespan {
+            switch self {
+            case .session:
+                return .session
+            case .process:
+                return .process
+            case .permanent:
+                return .permanent
+            }
+        }
+    }
+
+    enum Action: String, CaseIterable, Identifiable {
+        case add = "Add"
+        case update = "Update"
+        case delete = "Delete"
+
+        var id: String { self.rawValue }
+    }
+
+    struct Property {
+        var type: AttributeType = .sessionProperty
+        var lifespan: Lifespan = .session
+        var key: String = ""
+        var value: String = ""
+    }
+}
+
+#Preview {
+    SessionAttributesView()
+}

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Browser/BrowserView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Browser/BrowserView.swift
@@ -63,7 +63,7 @@ struct BrowserView: View {
                 .buttonStyle(.borderedProminent)
             }
             .padding(.horizontal)
-        }
+        }.navigationTitle("WebView Usage")
     }
 
     private func loadURL() {

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/CrashExample/CrashExampleTest.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/CrashExample/CrashExampleTest.swift
@@ -40,7 +40,7 @@ struct CrashExampleTest: View {
             Text("Submitting this form will cause the app to crash")
                 .foregroundStyle(Color.secondary)
                 .listRowBackground(Color.clear)
-        }
+        }.navigationTitle("Crash Examples")
     }
 
     func title(for example: ExampleCrash) -> String {

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/LoggingView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/LoggingView.swift
@@ -21,9 +21,6 @@ struct LoggingView: View {
     var body: some View {
         VStack(alignment: .center) {
             VStack(alignment: .leading) {
-                Text("Logging")
-                    .font(.title)
-                    .bold()
                 TextField("Message", text: $logMessage)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                 Picker("Severity", selection: $severity) {
@@ -49,7 +46,7 @@ struct LoggingView: View {
             }
             .buttonStyle(.borderedProminent)
             .padding()
-        }
+        }.navigationTitle("Logging")
     }
 }
 

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/MemoryWarning/MemoryPressureSimulatorView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/MemoryWarning/MemoryPressureSimulatorView.swift
@@ -9,12 +9,6 @@ struct MemoryPressureSimulatorView: View {
 
     var body: some View {
         VStack {
-            Text("Memory Pressure Simulator")
-                .padding(.horizontal)
-                .font(.largeTitle)
-                .bold()
-                .minimumScaleFactor(0.1)
-                .lineLimit(1)
             Spacer()
             Text("Memory Used: \(simulator.totalMemoryBytes / 1024 / 1024) MB")
                 .font(.title2)
@@ -40,7 +34,7 @@ struct MemoryPressureSimulatorView: View {
             }
             .buttonStyle(.borderedProminent)
             .padding(.horizontal)
-        }
+        }.navigationTitle("Memory Pressure Simulator")
     }
 
     private func executeMemoryWarning() {

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Network/NetworkStressTest.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Network/NetworkStressTest.swift
@@ -62,8 +62,8 @@ struct NetworkStressTest: View {
                         Text("Round Trip Times")
                             .bold()
 
-                        Chart(responses) { r in
-                            BarMark(x: .value("idx", r.id), y: .value("rtt", r.rtt))
+                        Chart(responses) { response in
+                            BarMark(x: .value("idx", response.id), y: .value("rtt", response.rtt))
                         }
                         .chartXAxis(.hidden)
                         .padding(.vertical)
@@ -87,8 +87,8 @@ struct NetworkStressTest: View {
             responses = []
             let group = DispatchGroup()
 
-            for i in 0..<inputCount {
-                if let request = NetworkRequest(string: inputURL, idx: i) {
+            for index in 0..<inputCount {
+                if let request = NetworkRequest(string: inputURL, idx: index) {
                     group.enter()
                     request.execute { response in
                         DispatchQueue.main.async {
@@ -105,7 +105,7 @@ struct NetworkStressTest: View {
                 didSubmit = false
             }
         }
-        .navigationTitle("Network Stress")
+        .navigationTitle("Network Requests")
 
     }
 }

--- a/Examples/BrandGame/BrandGame/View/Menu/UserInfo/UserInfo.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/UserInfo/UserInfo.swift
@@ -115,7 +115,7 @@ struct UserInfo: View {
             if newPhase == .active {
                 user.refresh()
             }
-        }
+        }.navigationTitle("User Information")
 
     }
 

--- a/Tests/EmbraceCoreTests/Payload/ResourcePayloadTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/ResourcePayloadTests.swift
@@ -39,9 +39,9 @@ class ResourcePayloadTests: XCTestCase {
             // session counter
             MetadataRecord.createResourceRecord(key: SessionPayloadBuilder.resourceName, value: "10"),
 
-            // Random properties that shouldn't be used
-            MetadataRecord.userMetadata(key: "random_user_metadata_property", value: "value"),
-            MetadataRecord.createResourceRecord(key: "random_resource_property", value: "value")
+            // Random properties that should be used
+            MetadataRecord.userMetadata(key: "random_user_metadata_property", value: "value1"),
+            MetadataRecord.createResourceRecord(key: "random_resource_property", value: "value2")
         ])
 
         let jsonData = try JSONEncoder().encode(payloadStruct)
@@ -73,15 +73,9 @@ class ResourcePayloadTests: XCTestCase {
 
         let jsonKeys = Set(json.keys)
         let expectedKeys = Set(ResourcePayload.CodingKeys.allCases.map { $0.rawValue })
-
-        XCTAssertEqual(
-            jsonKeys,
-            expectedKeys,
-            "Unexpected keys: \(jsonKeys.subtracting(expectedKeys)) Missing keys: \(expectedKeys.subtracting(jsonKeys))"
-        )
-
-        XCTAssertNil(json["random_user_metadata_property"])
-        XCTAssertNil(json["random_resource_property"])
+        XCTAssertTrue(jsonKeys.isSuperset(of: expectedKeys))
+        XCTAssertEqual(json["random_user_metadata_property"] as? String, "value1")
+        XCTAssertEqual(json["random_resource_property"] as? String, "value2")
     }
 
     func test_encodeToJSON_alwaysHasBundleId() throws {

--- a/bin/test
+++ b/bin/test
@@ -79,6 +79,7 @@ xcodebuild \
     -derivedDataPath $DERIVED_DATA_PATH \
     -resultBundlePath $XCRESULT_PATH \
     -retry-tests-on-failure \
+    -test-iterations 2 \
     test
 
 # If we created a new simulator, delete it


### PR DESCRIPTION
# Overview
This new view in BrandGame helps testing some `MetadataHandler` (aka. `Embrace.client?.metadata`) APIs:
- `addProperty(key:value:lifespan)`
- `addResource(key:value:lifespan)`
- `updateProperty(key:value:lifespan)`
- `updateResource(key:value:lifespan)`
- `removeProperty(key:lifespan)`
- `removeResource(key:lifespan)`
- `removeAllProperties()`
- `removeAllResources()`