### PR TITLE
Fix reentrancy in `upsertSpan`

### DIFF
--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -231,7 +231,6 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
         guard config.isSDKEnabled else {
             return nil
         }
-
         return sessionController.currentSession?.id.toString
     }
 

--- a/Sources/EmbraceCore/Internal/Tracing/EmbraceSpanProcessor+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Tracing/EmbraceSpanProcessor+Setup.swift
@@ -9,7 +9,12 @@ import EmbraceStorageInternal
 extension Collection where Element == SpanProcessor {
     static func processors(for storage: EmbraceStorage, export: OpenTelemetryExport?) -> [SpanProcessor] {
         var processors: [SpanProcessor] = [
-            SingleSpanProcessor(spanExporter: StorageSpanExporter(options: .init(storage: storage)))
+            SingleSpanProcessor(
+                spanExporter: StorageSpanExporter(
+                    options: .init(storage: storage),
+                    logger: Embrace.logger
+                )
+            )
         ]
 
         if let external = export?.spanExporter {

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -7,7 +7,12 @@ import EmbraceCommonInternal
 import EmbraceOTelInternal
 
 extension Embrace: EmbraceOpenTelemetry {
-    private var exporter: EmbraceSpanExporter { StorageSpanExporter(options: .init(storage: storage)) }
+    private var exporter: EmbraceSpanExporter {
+        StorageSpanExporter(
+            options: .init(storage: storage),
+            logger: Embrace.logger
+        )
+    }
 
     private var otel: EmbraceOTel { EmbraceOTel() }
 

--- a/Sources/EmbraceStorageInternal/EmbraceStorageError.swift
+++ b/Sources/EmbraceStorageInternal/EmbraceStorageError.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import GRDB
+
+public enum EmbraceStorageError: Error, Equatable {
+    case cannotUpsertSpan(spanName: String, message: String)
+    // TODO: Add missing errors in here
+}
+
+extension EmbraceStorageError: LocalizedError, CustomNSError {
+    public static var errorDomain: String {
+        return "Embrace"
+    }
+
+    public var errorCode: Int {
+        switch self {
+        case .cannotUpsertSpan:
+            return -1
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .cannotUpsertSpan(let spanName, let message):
+            return "Failed upsertSpan `\(spanName)`: \(message)"
+        }
+    }
+
+    public var localizedDescription: String {
+        return self.errorDescription ?? "No Matching Error"
+    }
+}

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
@@ -51,12 +51,15 @@ extension EmbraceStorage {
     /// Adds or updates a `SpanRecord` to the storage synchronously.
     /// - Parameter record: `SpanRecord` to upsert
     public func upsertSpan(_ span: SpanRecord) throws {
-        try dbQueue.write { [weak self] db in
-            do {
+        do {
+            try dbQueue.write { [weak self] db in
                 try self?.upsertSpan(db: db, span: span)
-            } catch let e as DatabaseError {
-                self?.logger.error("Failed upsertSpan `\(span.name)`: \(e.message ?? "[empty message]")")
             }
+        } catch let exception as DatabaseError {
+            throw EmbraceStorageError.cannotUpsertSpan(
+                spanName: span.name,
+                message: exception.message ?? "[empty message]"
+            )
         }
     }
 

--- a/Tests/EmbraceCoreTests/IntegrationTests/EmbraceOTelStorageIntegration/SpanStorageIntegrationTests.swift
+++ b/Tests/EmbraceCoreTests/IntegrationTests/EmbraceOTelStorageIntegration/SpanStorageIntegrationTests.swift
@@ -17,7 +17,7 @@ final class SpanStorageIntegrationTests: IntegrationTestCase {
 
     override func setUpWithError() throws {
         storage = try EmbraceStorage.createInMemoryDb()
-        let exporter = StorageSpanExporter(options: .init(storage: storage))
+        let exporter = StorageSpanExporter(options: .init(storage: storage), logger: MockLogger())
 
         EmbraceOTel.setup(spanProcessors: [SingleSpanProcessor(spanExporter: exporter)])
     }

--- a/Tests/EmbraceCoreTests/Internal/EmbraceSpanProcessor+StorageTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/EmbraceSpanProcessor+StorageTests.swift
@@ -7,6 +7,7 @@ import XCTest
 @testable import EmbraceCore
 @testable import EmbraceOTelInternal
 import EmbraceStorageInternal
+import TestSupport
 
 final class EmbraceSpanProcessor_StorageTests: XCTestCase {
 
@@ -15,7 +16,12 @@ final class EmbraceSpanProcessor_StorageTests: XCTestCase {
         defer {
             try? storage.teardown()
         }
-        let processor = SingleSpanProcessor(spanExporter: StorageSpanExporter(options: .init(storage: storage)))
+        let processor = SingleSpanProcessor(
+            spanExporter: StorageSpanExporter(
+                options: .init(storage: storage),
+                logger: MockLogger()
+            )
+        )
         XCTAssert(processor.spanExporter is StorageSpanExporter)
     }
 }

--- a/Tests/EmbraceCoreTests/Internal/StorageSpanExporterTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/StorageSpanExporterTests.swift
@@ -9,12 +9,13 @@ import XCTest
 @testable import OpenTelemetrySdk
 import OpenTelemetryApi
 import EmbraceStorageInternal
+import TestSupport
 
 final class StorageSpanExporterTests: XCTestCase {
     func test_DB_preventsClosedSpan_fromUpdatingEndTime() throws {
         // Given
         let storage = try EmbraceStorage.createInMemoryDb()
-        let exporter = StorageSpanExporter(options: .init(storage: storage))
+        let exporter = StorageSpanExporter(options: .init(storage: storage), logger: MockLogger())
 
         let traceId = TraceId.random()
         let spanId = SpanId.random()
@@ -57,7 +58,7 @@ final class StorageSpanExporterTests: XCTestCase {
     func test_DB_allowsOpenSpan_toUpdateAttributes() throws {
         // Given
         let storage = try EmbraceStorage.createInMemoryDb()
-        let exporter = StorageSpanExporter(options: .init(storage: storage))
+        let exporter = StorageSpanExporter(options: .init(storage: storage), logger: MockLogger())
 
         let traceId = TraceId.random()
         let spanId = SpanId.random()


### PR DESCRIPTION
# Overview
When an exception was raised inside the `EmbraceStorage.upsertSpan` method, we were inadvertently calling the `DefaultInternalLogger` within the same (write) block (which, in turn, calls back to the storage layer to do some reading), leading to a reentrancy crash.

This PR addresses that issue by handling the exception outside the `db.write` block and throwing an already typified error. Subsequently, the consumer of the method can either log the error (as demonstrated in this PR) or respond to the thrown exception accordingly.

## Details
In this PR, the `EmbraceStorageError` enum was introduced to begin typifying all errors thrown/generated within `EmbraceStorage`. However, for the sake of simplicity, the migration of all other existing errors (particularly those related to migrations and database corruptions) will be deferred to a subsequent PR.

