### PR TITLE
Adds ability to initialize SDK without Embrace AppId

### DIFF
--- a/Sources/EmbraceCommonInternal/CrashReporter/CrashReporterContext.swift
+++ b/Sources/EmbraceCommonInternal/CrashReporter/CrashReporterContext.swift
@@ -7,13 +7,13 @@ import Foundation
 /// Object passed to the active crash reporter during setup
 @objc public final class CrashReporterContext: NSObject {
 
-    public let appId: String
+    public let appId: String?
     public let sdkVersion: String
     public let filePathProvider: FilePathProvider
     public let notificationCenter: NotificationCenter
 
     public init(
-        appId: String,
+        appId: String?,
         sdkVersion: String,
         filePathProvider: FilePathProvider,
         notificationCenter: NotificationCenter

--- a/Sources/EmbraceCore/Capture/CaptureServices.swift
+++ b/Sources/EmbraceCore/Capture/CaptureServices.swift
@@ -22,10 +22,14 @@ final class CaptureServices {
         services = CaptureServiceFactory.addRequiredServices(to: options.services.unique)
 
         // create context for crash reporter
+        let partitionIdentifier = options.appId ?? EmbraceFileSystem.defaultPartitionId
         context = CrashReporterContext(
             appId: options.appId,
             sdkVersion: EmbraceMeta.sdkVersion,
-            filePathProvider: EmbraceFilePathProvider(appId: options.appId, appGroupIdentifier: options.appGroupId),
+            filePathProvider: EmbraceFilePathProvider(
+                partitionId: partitionIdentifier,
+                appGroupId: options.appGroupId
+            ),
             notificationCenter: Embrace.notificationCenter
         )
         crashReporter = options.crashReporter

--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
@@ -69,7 +69,7 @@ public final class URLSessionCaptureService: CaptureService, URLSessionTaskHandl
 
     var injectTracingHeader: Bool {
         // check remote config
-        guard Embrace.client?.config.isNetworkSpansForwardingEnabled == true else {
+        guard Embrace.client?.config?.isNetworkSpansForwardingEnabled == true else {
             return false
         }
 

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -110,8 +110,7 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
                 return client
             }
 
-            try options.validateAppId()
-            try options.validateGroupId()
+            try options.validate()
 
             client = try Embrace(options: options)
             if let client = client {

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -60,7 +60,7 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
     /// Returns the current `MetadataHandler` used to store resources and session properties.
     public let metadata: MetadataHandler
 
-    let config: EmbraceConfig
+    let config: EmbraceConfig?
     let storage: EmbraceStorage
     let upload: EmbraceUpload?
     let captureServices: CaptureServices
@@ -189,7 +189,7 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
                 return
             }
 
-            guard config.isSDKEnabled else {
+            guard config == nil || config?.isSDKEnabled == true else {
                 Embrace.logger.warning("Embrace can't start when disabled!")
                 return
             }
@@ -228,9 +228,10 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
 
     /// Returns the current session identifier, if any.
     @objc public func currentSessionId() -> String? {
-        guard config.isSDKEnabled else {
+        guard config == nil || config?.isSDKEnabled == true else {
             return nil
         }
+
         return sessionController.currentSession?.id.toString
     }
 
@@ -261,6 +262,8 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
 
     /// Called everytime the remote config changes
     @objc private func onConfigUpdated() {
-        Embrace.logger.limits = InternalLogLimits(config: config)
+        if let config = config {
+            Embrace.logger.limits = InternalLogLimits(config: config)
+        }
     }
 }

--- a/Sources/EmbraceCore/ErrorManagement/EmbraceSetupError.swift
+++ b/Sources/EmbraceCore/ErrorManagement/EmbraceSetupError.swift
@@ -9,7 +9,7 @@ public enum EmbraceSetupError: Error, Equatable {
     case invalidAppGroupId(_ description: String)
     case invalidThread(_ description: String)
     case invalidOptions(_ description: String)
-    case failedStorageCreation(_ description: String)
+    case failedStorageCreation(partitionId: String, appGroupId: String?)
     case unableToInitialize(_ description: String)
     case initializationNotAllowed(_ description: String)
 }
@@ -52,8 +52,8 @@ extension EmbraceSetupError: LocalizedError, CustomNSError {
             return description
         case .unableToInitialize(let description):
             return description
-        case .failedStorageCreation(let description):
-            return description
+        case .failedStorageCreation(let partitionId, let appGroupId):
+            return "Failed to create Storage Directory. partitionId: '\(partitionId)' appGroupId: '\(appGroupId ?? "")'"
         case .initializationNotAllowed(let description):
             return description
         }

--- a/Sources/EmbraceCore/FileSystem/EmbraceFilePathProvider.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFilePathProvider.swift
@@ -19,7 +19,9 @@ class EmbraceFilePathProvider: FilePathProvider {
     }
 
     func directoryURL(for scope: String) -> URL? {
-        let captureURL = EmbraceFileSystem.captureDirectoryURL(appId: appId, appGroupId: appGroupIdentifier)
+        let captureURL = EmbraceFileSystem.captureDirectoryURL(
+            partitionIdentifier: appId,
+            appGroupId: appGroupIdentifier)
         return captureURL?.appendingPathComponent(scope)
     }
 }

--- a/Sources/EmbraceCore/FileSystem/EmbraceFilePathProvider.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFilePathProvider.swift
@@ -5,6 +5,9 @@
 import Foundation
 import EmbraceCommonInternal
 
+/// Class used to provide file paths to help when capturing data.
+/// It can be beneficial to pass a filepath to an external instrumentation, like crash reports,
+/// that can then be read from later.
 class EmbraceFilePathProvider: FilePathProvider {
     let partitionId: String
     let appGroupId: String?
@@ -17,10 +20,17 @@ class EmbraceFilePathProvider: FilePathProvider {
         self.appGroupId = appGroupId
     }
 
+    /// Returns a file URL for the given scope and name.
+    /// - Parameters:
+    ///   - scope: The directory scope to create this file URL in.
+    ///   - name: The name of the file.
     func fileURL(for scope: String, name: String) -> URL? {
         return directoryURL(for: scope)?.appendingPathComponent(name)
     }
 
+    /// Returns a directory URL for the given scope.
+    /// - Parameters:
+    ///   - scope: The directory scope to create a reference to
     func directoryURL(for scope: String) -> URL? {
         let captureURL = EmbraceFileSystem.captureDirectoryURL(
             partitionIdentifier: partitionId,

--- a/Sources/EmbraceCore/FileSystem/EmbraceFilePathProvider.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFilePathProvider.swift
@@ -6,12 +6,15 @@ import Foundation
 import EmbraceCommonInternal
 
 class EmbraceFilePathProvider: FilePathProvider {
-    let appId: String
-    let appGroupIdentifier: String?
+    let partitionId: String
+    let appGroupId: String?
 
-    init(appId: String, appGroupIdentifier: String?) {
-        self.appId = appId
-        self.appGroupIdentifier = appGroupIdentifier
+    /// - Parameters:
+    ///   - partitionId: The base directory this file path provider should use.
+    ///   - appGroupId: An optional app group identifier to use if the provider should create file paths in the app group container.
+    init(partitionId: String, appGroupId: String?) {
+        self.partitionId = partitionId
+        self.appGroupId = appGroupId
     }
 
     func fileURL(for scope: String, name: String) -> URL? {
@@ -20,8 +23,8 @@ class EmbraceFilePathProvider: FilePathProvider {
 
     func directoryURL(for scope: String) -> URL? {
         let captureURL = EmbraceFileSystem.captureDirectoryURL(
-            partitionIdentifier: appId,
-            appGroupId: appGroupIdentifier)
+            partitionIdentifier: partitionId,
+            appGroupId: appGroupId)
         return captureURL?.appendingPathComponent(scope)
     }
 }

--- a/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
@@ -48,42 +48,58 @@ public struct EmbraceFileSystem {
 
     /// Returns a subpath within the root directory of the Embrace SDK.
     /// ```
-    /// io.embrace.data/<version>/<app-id>/<name>
+    /// io.embrace.data/<version>/<partition-id>/<name>
     /// ```
-    static func directoryURL(name: String, appId: String, appGroupId: String? = nil) -> URL? {
+    /// - Parameters:
+    ///    - name: The name of the subdirectory
+    ///    - partitionIdentifier: The main paritition identifier to use
+    ///    - appGroupId: The app group identifier if using an app group container.
+    static func directoryURL(name: String, partitionIdentifier: String, appGroupId: String? = nil) -> URL? {
         guard let baseURL = systemDirectory(appGroupId: appGroupId) else {
             return nil
         }
 
-        let components = [rootDirectoryName, versionDirectoryName, appId, name]
+        let components = [rootDirectoryName, versionDirectoryName, partitionIdentifier, name]
         return baseURL.appendingPathComponent(components.joined(separator: "/"))
     }
 
     /// Returns the subdirectory for the storage
     /// ```
-    /// io.embrace.data/<version>/<app-id>/storage
+    /// io.embrace.data/<version>/<partition-id>/storage
     /// ```
     static func storageDirectoryURL(
-        appId: String,
+        partitionIdentifier: String,
         appGroupId: String? = nil) -> URL? {
-        return directoryURL(name: storageDirectoryName, appId: appId, appGroupId: appGroupId)
+        return directoryURL(
+            name: storageDirectoryName,
+            partitionIdentifier: partitionIdentifier,
+            appGroupId: appGroupId
+        )
     }
 
     /// Returns the subdirectory for upload data
     /// ```
-    /// io.embrace.data/<version>/<app-id>/uploads
+    /// io.embrace.data/<version>/<partition-id>/uploads
     /// ```
     static func uploadsDirectoryPath(
-        appId: String,
+        partitionIdentifier: String,
         appGroupId: String? = nil) -> URL? {
-        return directoryURL(name: uploadsDirectoryName, appId: appId, appGroupId: appGroupId)
+        return directoryURL(
+            name: uploadsDirectoryName,
+            partitionIdentifier: partitionIdentifier,
+            appGroupId: appGroupId
+        )
     }
 
     /// Returns the subdirectory for data capture
     /// ```
-    /// io.embrace.data/<version>/<app-id>/capture
+    /// io.embrace.data/<version>/<partition-id>/capture
     /// ```
-    static func captureDirectoryURL(appId: String, appGroupId: String? = nil) -> URL? {
-        return directoryURL(name: captureDirectoryName, appId: appId, appGroupId: appGroupId)
+    static func captureDirectoryURL(partitionIdentifier: String, appGroupId: String? = nil) -> URL? {
+        return directoryURL(
+            name: captureDirectoryName,
+            partitionIdentifier: partitionIdentifier,
+            appGroupId: appGroupId
+        )
     }
 }

--- a/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
@@ -12,6 +12,8 @@ public struct EmbraceFileSystem {
     static let crashesDirectoryName = "crashes"
     static let captureDirectoryName = "capture"
 
+    static let defaultPartitionId = "default"
+
     /// Returns the path to the system directory that is the root directory for storage.
     /// When `appGroupId` is present, will be a URL to an app group container
     /// If not present, will be a path to the user's applicaton support directory.
@@ -37,7 +39,6 @@ public struct EmbraceFileSystem {
         do {
             return try FileManager.default.url(for: directory, in: .userDomainMask, appropriateFor: nil, create: true)
         } catch {
-            // TODO: should we throw error and allow return type to be non-optional?
             return nil
         }
     }
@@ -54,12 +55,12 @@ public struct EmbraceFileSystem {
     ///    - name: The name of the subdirectory
     ///    - partitionIdentifier: The main paritition identifier to use
     ///    - appGroupId: The app group identifier if using an app group container.
-    static func directoryURL(name: String, partitionIdentifier: String, appGroupId: String? = nil) -> URL? {
+    static func directoryURL(name: String, partitionId: String, appGroupId: String? = nil) -> URL? {
         guard let baseURL = systemDirectory(appGroupId: appGroupId) else {
             return nil
         }
 
-        let components = [rootDirectoryName, versionDirectoryName, partitionIdentifier, name]
+        let components = [rootDirectoryName, versionDirectoryName, partitionId, name]
         return baseURL.appendingPathComponent(components.joined(separator: "/"))
     }
 
@@ -68,11 +69,11 @@ public struct EmbraceFileSystem {
     /// io.embrace.data/<version>/<partition-id>/storage
     /// ```
     static func storageDirectoryURL(
-        partitionIdentifier: String,
+        partitionId: String,
         appGroupId: String? = nil) -> URL? {
         return directoryURL(
             name: storageDirectoryName,
-            partitionIdentifier: partitionIdentifier,
+            partitionId: partitionId,
             appGroupId: appGroupId
         )
     }
@@ -86,7 +87,7 @@ public struct EmbraceFileSystem {
         appGroupId: String? = nil) -> URL? {
         return directoryURL(
             name: uploadsDirectoryName,
-            partitionIdentifier: partitionIdentifier,
+            partitionId: partitionIdentifier,
             appGroupId: appGroupId
         )
     }
@@ -98,7 +99,7 @@ public struct EmbraceFileSystem {
     static func captureDirectoryURL(partitionIdentifier: String, appGroupId: String? = nil) -> URL? {
         return directoryURL(
             name: captureDirectoryName,
-            partitionIdentifier: partitionIdentifier,
+            partitionId: partitionIdentifier,
             appGroupId: appGroupId
         )
     }

--- a/Sources/EmbraceCore/Internal/Embrace+Config.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Config.swift
@@ -11,10 +11,14 @@ extension Embrace {
     static func createConfig(
         options: Embrace.Options,
         deviceId: String
-    ) -> EmbraceConfig {
+    ) -> EmbraceConfig? {
+
+        guard let endpoints = options.endpoints else {
+            return nil
+        }
 
         let configOptions = EmbraceConfig.Options(
-            apiBaseUrl: options.endpoints.configBaseURL,
+            apiBaseUrl: endpoints.configBaseURL,
             queue: DispatchQueue(label: "com.embrace.config"),
             appId: options.appId,
             deviceId: deviceId,

--- a/Sources/EmbraceCore/Internal/Embrace+Config.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Config.swift
@@ -8,10 +8,16 @@ import EmbraceConfigInternal
 import EmbraceCommonInternal
 
 extension Embrace {
+
+    /// Creates `EmbraceConfig` object
     static func createConfig(
         options: Embrace.Options,
         deviceId: String
     ) -> EmbraceConfig? {
+
+        guard let appId = options.appId else {
+            return nil
+        }
 
         guard let endpoints = options.endpoints else {
             return nil
@@ -20,7 +26,7 @@ extension Embrace {
         let configOptions = EmbraceConfig.Options(
             apiBaseUrl: endpoints.configBaseURL,
             queue: DispatchQueue(label: "com.embrace.config"),
-            appId: options.appId,
+            appId: appId,
             deviceId: deviceId,
             osVersion: EMBDevice.appVersion ?? "",
             sdkVersion: EmbraceMeta.sdkVersion,

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -30,15 +30,18 @@ extension Embrace {
 
     static func createUpload(options: Embrace.Options, deviceId: String) -> EmbraceUpload? {
         // endpoints
-        let baseUrl = EMBDevice.isDebuggerAttached ?
-            options.endpoints.developmentBaseURL : options.endpoints.baseURL
+        guard let endpoints = options.endpoints else {
+            return nil
+        }
+
+        let baseUrl = EMBDevice.isDebuggerAttached ? endpoints.developmentBaseURL : endpoints.baseURL
         guard let spansURL = URL.spansEndpoint(basePath: baseUrl),
               let logsURL = URL.logsEndpoint(basePath: baseUrl) else {
             Embrace.logger.error("Failed to initialize endpoints!")
             return nil
         }
 
-        let endpoints = EmbraceUpload.EndpointOptions(spansURL: spansURL, logsURL: logsURL)
+        let uploadEndpoints = EmbraceUpload.EndpointOptions(spansURL: spansURL, logsURL: logsURL)
 
         // cache
         guard let cacheUrl = EmbraceFileSystem.uploadsDirectoryPath(
@@ -59,7 +62,7 @@ extension Embrace {
         )
 
         do {
-            let options = EmbraceUpload.Options(endpoints: endpoints, cache: cache, metadata: metadata)
+            let options = EmbraceUpload.Options(endpoints: uploadEndpoints, cache: cache, metadata: metadata)
             let queue = DispatchQueue(label: "com.embrace.upload", attributes: .concurrent)
 
             return try EmbraceUpload(options: options, logger: Embrace.logger, queue: queue)

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -12,7 +12,7 @@ import EmbraceObjCUtilsInternal
 extension Embrace {
     static func createStorage(options: Embrace.Options) throws -> EmbraceStorage {
         if let storageUrl = EmbraceFileSystem.storageDirectoryURL(
-            appId: options.appId,
+            partitionIdentifier: options.appId,
             appGroupId: options.appGroupId
         ) {
             do {
@@ -45,7 +45,7 @@ extension Embrace {
 
         // cache
         guard let cacheUrl = EmbraceFileSystem.uploadsDirectoryPath(
-            appId: options.appId,
+            partitionIdentifier: options.appId,
             appGroupId: options.appGroupId
         ),
               let cache = EmbraceUpload.CacheOptions(cacheBaseUrl: cacheUrl)

--- a/Sources/EmbraceCore/Options/Embrace+Options.swift
+++ b/Sources/EmbraceCore/Options/Embrace+Options.swift
@@ -15,7 +15,7 @@ extension Embrace {
         @objc public let appId: String
         @objc public let appGroupId: String?
         @objc public let platform: Platform
-        @objc public let endpoints: Embrace.Endpoints
+        @objc public let endpoints: Embrace.Endpoints?
         @objc public let services: [CaptureService]
         @objc public let crashReporter: CrashReporter?
         @objc public let logLevel: LogLevel
@@ -54,22 +54,50 @@ extension Embrace {
             self.logLevel = logLevel
             self.export = export
         }
+
+        /// Initializer for `Embrace.Options` that does not require an appId.
+        /// Use this initializer if you don't want the SDK to send data to Embrace's servers.
+        /// You must provide your own `OpenTelemetryExport` on this mode.
+        ///
+        /// - Parameters:
+        ///   - platform: `Platform` in which the app will run. Defaults to `.iOS`.
+        ///   - captureServices: The `CaptureServices` to be installed.
+        ///   - crashReporter: The `CrashReporter` to be installed.
+        ///   - logLevel: The `LogLevel` to use for console logs.
+        ///   - export: `OpenTelemetryExport` object to export telemetry outside of the Embrace backend.
+        @objc public init(
+            platform: Platform = .default,
+            captureServices: [CaptureService],
+            crashReporter: CrashReporter?,
+            logLevel: LogLevel = .default,
+            export: OpenTelemetryExport
+        ) {
+            self.appId = "no_id"
+            self.appGroupId = nil
+            self.platform = platform
+            self.endpoints = nil
+            self.services = captureServices
+            self.crashReporter = crashReporter
+            self.logLevel = logLevel
+            self.export = export
+        }
     }
 }
 
 internal extension Embrace.Options {
     func validateAppId() throws {
-        // this also covers if it's empty
-        if self.appId.count != 5 {
+        if appId.count != 5 {
             throw EmbraceSetupError.invalidAppId("App Id must be 5 characters in length")
         }
     }
 
     func validateGroupId() throws {
-        if let groupId = self.appGroupId {
-            if groupId.isEmpty {
-                throw EmbraceSetupError.invalidAppGroupId("group id must not be empty if provided")
-            }
+        guard let groupId = self.appGroupId else {
+            return
+        }
+
+        if groupId.isEmpty {
+            throw EmbraceSetupError.invalidAppGroupId("group id must not be empty if provided")
         }
     }
 }

--- a/Sources/EmbraceCore/Options/Embrace+Options.swift
+++ b/Sources/EmbraceCore/Options/Embrace+Options.swift
@@ -34,7 +34,7 @@ extension Embrace {
         ///   - captureServices: The `CaptureServices` to be installed.
         ///   - crashReporter: The `CrashReporter` to be installed.
         ///   - logLevel: The `LogLevel` to use for console logs.
-        ///   - export: `OpenTelemetryExport` object to export telemetry outside of the Embrace backend.
+        ///   - export: `OpenTelemetryExport` object to export telemetry using OpenTelemetry protocols
         @objc public init(
             appId: String,
             appGroupId: String? = nil,
@@ -57,20 +57,20 @@ extension Embrace {
 
         /// Initializer for `Embrace.Options` that does not require an appId.
         /// Use this initializer if you don't want the SDK to send data to Embrace's servers.
-        /// You must provide your own `OpenTelemetryExport` on this mode.
+        /// You must provide your own `OpenTelemetryExport`
         ///
         /// - Parameters:
+        ///   - export: `OpenTelemetryExport` object to export telemetry using OpenTelemetry protocols
         ///   - platform: `Platform` in which the app will run. Defaults to `.iOS`.
         ///   - captureServices: The `CaptureServices` to be installed.
         ///   - crashReporter: The `CrashReporter` to be installed.
         ///   - logLevel: The `LogLevel` to use for console logs.
-        ///   - export: `OpenTelemetryExport` object to export telemetry outside of the Embrace backend.
         @objc public init(
+            export: OpenTelemetryExport,
             platform: Platform = .default,
             captureServices: [CaptureService],
             crashReporter: CrashReporter?,
-            logLevel: LogLevel = .default,
-            export: OpenTelemetryExport
+            logLevel: LogLevel = .default
         ) {
             self.appId = nil
             self.appGroupId = nil

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -5,6 +5,7 @@
 import Foundation
 import EmbraceCommonInternal
 import EmbraceOTelInternal
+import EmbraceSemantics
 
 extension Embrace: EmbraceOpenTelemetry {
     private var exporter: EmbraceSpanExporter {

--- a/Sources/EmbraceCrash/EmbraceCrashReporter.swift
+++ b/Sources/EmbraceCrash/EmbraceCrashReporter.swift
@@ -24,7 +24,6 @@ public final class EmbraceCrashReporter: NSObject, CrashReporter {
     var logger: InternalLogger?
     private var queue: DispatchQueue = DispatchQueue(label: "com.embrace.crashreporter")
 
-    private var appId: String?
     public private(set) var basePath: String?
 
     /// Sets the current session identifier that will be included in a crash report.
@@ -72,10 +71,11 @@ public final class EmbraceCrashReporter: NSObject, CrashReporter {
 
         self.logger = logger
         sdkVersion = context.sdkVersion
-        appId = context.appId
         basePath = context.filePathProvider.directoryURL(for: "embrace_crash_reporter")?.path
 
-        ksCrash = KSCrash.sharedInstance(withBasePath: basePath, andBundleName: appId)
+        let bundleName = context.appId ?? "default"
+        ksCrash = KSCrash.sharedInstance(withBasePath: basePath, andBundleName: bundleName)
+
         updateKSCrashInfo()
         ksCrash?.install()
     }

--- a/Sources/EmbraceIO/Options/Options+CaptureService.swift
+++ b/Sources/EmbraceIO/Options/Options+CaptureService.swift
@@ -11,8 +11,8 @@ import EmbraceOTelInternal
 
 public extension Embrace.Options {
 
-    /// Convenience initializer for `Embrace.Options` that automatically includes the the default `CaptureServices` and `CrashReporter`,
-    /// You can see list of platform service defaults in ``CaptureServiceFactory.platformCaptureServices``.
+    /// Convenience initializer for `Embrace.Options` that automatically includes the default `CaptureServices` and `CrashReporter`,
+    /// You can see list of platform service defaults in ``CaptureServiceBuilder.addDefaults``.
     ///
     /// If you wish to customize which `CaptureServices` and `CrashReporter` are installed, please refer to the `Embrace.Options`
     /// initializer found in the `EmbraceCore` target.
@@ -44,8 +44,8 @@ public extension Embrace.Options {
         )
     }
 
-    /// Convenience initializer for `Embrace.Options` that automatically includes the the default `CaptureServices` and `CrashReporter`,
-    /// You can see list of platform service defaults in ``CaptureServiceFactory.platformCaptureServices``.
+    /// Convenience initializer for `Embrace.Options` that automatically includes the default `CaptureServices` and `CrashReporter`,
+    /// You can see list of platform service defaults in ``CaptureServiceBuilder.addDefaults``.
     ///
     /// If you wish to customize which `CaptureServices` and `CrashReporter` are installed, please refer to the `Embrace.Options`
     /// initializer found in the `EmbraceCore` target.
@@ -65,6 +65,25 @@ public extension Embrace.Options {
             platform: platform,
             captureServices: .automatic,
             crashReporter: EmbraceCrashReporter()
+        )
+    }
+
+    /// Initializer for `Embrace.Options` that does not require an appId but used the
+    /// Use this initializer if you don't want the SDK to send data to Embrace's servers.
+    /// You must provide your own `OpenTelemetryExport`
+    ///
+    /// If you wish to customize which `CaptureServices` and `CrashReporter` are installed, please refer to the `Embrace.Options`
+    /// initializer found in the `EmbraceCore` target.
+    ///
+    /// - Parameters:
+    ///   - export: `OpenTelemetryExport` object to export telemetry using OpenTelemetry protocols
+    ///   - logLevel: The `LogLevel` to use for console logs.
+    @objc convenience init(export: OpenTelemetryExport, logLevel: LogLevel = .default) {
+        self.init(
+            export: export,
+            captureServices: .automatic,
+            crashReporter: EmbraceCrashReporter(),
+            logLevel: logLevel
         )
     }
 }

--- a/Sources/EmbraceIO/Options/Options+CaptureService.swift
+++ b/Sources/EmbraceIO/Options/Options+CaptureService.swift
@@ -68,7 +68,8 @@ public extension Embrace.Options {
         )
     }
 
-    /// Initializer for `Embrace.Options` that does not require an appId but used the
+    /// Initializer for `Embrace.Options` that does not require an appId.
+    
     /// Use this initializer if you don't want the SDK to send data to Embrace's servers.
     /// You must provide your own `OpenTelemetryExport`
     ///

--- a/Tests/EmbraceCoreTests/IntegrationTests/Embrace+OTelIntegrationTests.swift
+++ b/Tests/EmbraceCoreTests/IntegrationTests/Embrace+OTelIntegrationTests.swift
@@ -11,7 +11,7 @@ final class Embrace_OTelIntegrationTests: IntegrationTestCase {
 
 // MARK: recordCompletedSpan
     func test_recordCompletedSpan_setsStatus_toOk() throws {
-        try XCTSkipInCI()
+        throw XCTSkip()
 
         let exporter = InMemorySpanExporter()
         let embrace = try Embrace.setup(options: .init(
@@ -46,7 +46,7 @@ final class Embrace_OTelIntegrationTests: IntegrationTestCase {
     }
 
     func test_recordCompletedSpan_withErrorCode_setsStatus_toError() throws {
-        try XCTSkipInCI()
+        throw XCTSkip()
 
         let exporter = InMemorySpanExporter()
         let embrace = try Embrace.setup(options: .init(

--- a/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
+++ b/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+import EmbraceCore
+
+final class Embrace_OptionsTests: XCTestCase {
+
+    func test_init_withAppId_setsAppId_andNotExport() throws {
+        let options = Embrace.Options(appId: "myApp", captureServices: [], crashReporter: nil)
+        XCTAssertEqual(options.appId, "myApp")
+        XCTAssertNil(options.export)
+    }
+
+    func test_init_withEndpoints_setsEndpoints() throws {
+        let endpoints = Embrace.Endpoints(baseURL: "base", developmentBaseURL: "base", configBaseURL: "config")
+        let options = Embrace.Options(appId: "myApp", endpoints: endpoints, captureServices: [], crashReporter: nil)
+        XCTAssertEqual(options.endpoints, endpoints)
+    }
+
+    func test_init_withExport_setsExport_andNotAppId() throws {
+        let export = OpenTelemetryExport()
+        let options = Embrace.Options(export: export, captureServices: [], crashReporter: nil)
+        XCTAssertEqual(options.export, export)
+        XCTAssertNil(options.appId)
+    }
+}

--- a/Tests/EmbraceCoreTests/Payload/LogPayloadBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/LogPayloadBuilderTests.swift
@@ -108,7 +108,7 @@ class LogPayloadBuilderTests: XCTestCase {
         XCTAssertEqual(payload.metadata.username, "test")
         XCTAssertEqual(payload.metadata.personas, ["tag1", "tag2"])
 
-        let logs = payload.data["logs"]!
+        let logs = try XCTUnwrap(payload.data["logs"])
         XCTAssertEqual(logs.count, 1)
         XCTAssertEqual(logs[0].body, "test")
         XCTAssertEqual(logs[0].timeUnixNano, String(timestamp.nanosecondsSince1970Truncated))


### PR DESCRIPTION
This PR adds a new setup method that doesn't take an appId.
The goal of this setup method is to have the SDK running without it interacting with Embrace's back end.
For this reason this setup method also doesn't take endpoints definitions and it requires that the implementer passes a valid instance of `OpenTelemetryExport`.

This results in the `EmbraceUpload` instance being nil as well as the `EmbraceConfig` instance being nil in the `Embrace` client.

Flagging this as a draft/PoC for now.