### PR TITLE
Fix recordCompletedSpan to set Span.Status consistently with other `end` methods

### DIFF
--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -60,6 +60,7 @@ extension Embrace: EmbraceOpenTelemetry {
         let builder = otel
             .buildSpan(name: name, type: type, attributes: attributes)
             .setStartTime(time: startTime)
+
         if let parent = parent { builder.setParent(parent) }
         let span = builder.startSpan()
 
@@ -67,7 +68,7 @@ extension Embrace: EmbraceOpenTelemetry {
             span.addEvent(name: event.name, attributes: event.attributes, timestamp: event.timestamp)
         }
 
-        span.end(time: endTime)
+        span.end(errorCode: errorCode, time: endTime)
     }
 
     /// Adds a list of SpanEvent objects to the current session span

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/ErrorCode.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/ErrorCode.swift
@@ -3,7 +3,7 @@
 //
 
 /// Embrace specific error status for spans
-public enum ErrorCode {
+public enum ErrorCode: String {
     /// Span ended in an expected, but less than optimal state
     case failure
 

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/Span+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/Span+Embrace.swift
@@ -21,11 +21,11 @@ extension Span {
         setAttribute(key: SpanSemantics.keyIsPrivateSpan, value: "true")
     }
 
-    public func end(errorCode: SpanErrorCode? = nil, time: Date = Date()) {
+    public func end(errorCode: ErrorCode? = nil, time: Date = Date()) {
         end(error: nil, errorCode: errorCode, time: time)
     }
 
-    public func end(error: Error?, errorCode: SpanErrorCode? = nil, time: Date = Date()) {
+    public func end(error: Error?, errorCode: ErrorCode? = nil, time: Date = Date()) {
         var errorCode = errorCode
 
         // get attributes from error

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/SpanData+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/SpanData+Embrace.swift
@@ -20,11 +20,11 @@ extension SpanData {
         return .performance
     }
 
-    var errorCode: SpanErrorCode? {
+    var errorCode: ErrorCode? {
         guard let value = attributes[SpanSemantics.keyErrorCode] else {
             return nil
         }
-        return SpanErrorCode(rawValue: value.description)
+        return ErrorCode(rawValue: value.description)
     }
 
     public func toJSON() throws -> Data {

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/SpanErrorCode.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/SpanErrorCode.swift
@@ -1,9 +1,0 @@
-//
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
-//
-
-public enum SpanErrorCode: String {
-    case failure
-    case userAbandon
-    case unknown
-}

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/SpanBuilder/SpanBuilder+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/SpanBuilder/SpanBuilder+Embrace.swift
@@ -20,7 +20,7 @@ extension SpanBuilder {
         setAttribute(key: SpanSemantics.keyIsKeySpan, value: "true")
     }
 
-    @discardableResult public func error(errorCode: SpanErrorCode) -> Self {
+    @discardableResult public func error(errorCode: ErrorCode) -> Self {
         setAttribute(key: SpanSemantics.keyErrorCode, value: errorCode.rawValue)
     }
 

--- a/Sources/EmbraceOTelInternal/Trace/Tracer/OpenTelemetryTypes.swift
+++ b/Sources/EmbraceOTelInternal/Trace/Tracer/OpenTelemetryTypes.swift
@@ -20,6 +20,8 @@ public typealias TraceState = OpenTelemetryApi.TraceState
 
 public typealias Span=OpenTelemetryApi.Span
 
+public typealias Status=OpenTelemetryApi.Status
+
 public typealias SpanBuilder=OpenTelemetryApi.SpanBuilder
 
 public typealias AttributeValue=OpenTelemetryApi.AttributeValue

--- a/Tests/EmbraceCoreTests/IntegrationTests/Embrace+OTelIntegrationTests.swift
+++ b/Tests/EmbraceCoreTests/IntegrationTests/Embrace+OTelIntegrationTests.swift
@@ -1,0 +1,82 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+import EmbraceCore
+import EmbraceOTelInternal
+import TestSupport
+
+final class Embrace_OTelIntegrationTests: IntegrationTestCase {
+
+// MARK: recordCompletedSpan
+    func test_recordCompletedSpan_setsStatus_toOk() throws {
+        try XCTSkipInCI()
+
+        let exporter = InMemorySpanExporter()
+        let embrace = try Embrace.setup(options: .init(
+            appId: "myApp",
+            captureServices: [],
+            crashReporter: nil,
+            export: .init(spanExporter: exporter)
+        )).start()
+
+        embrace.recordCompletedSpan(
+            name: "my-example-span",
+            type: .performance,
+            parent: nil,
+            startTime: Date(),
+            endTime: Date(),
+            attributes: [:],
+            events: [],
+            errorCode: nil
+        )
+
+        let expectation = expectation(description: "export completes")
+        exporter.onExportComplete {
+            if let result = exporter.exportedSpans.values.first(where: { value in
+                value.name == "my-example-span"
+            }) {
+                XCTAssertEqual(result.status, .ok)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 6.0)
+    }
+
+    func test_recordCompletedSpan_withErrorCode_setsStatus_toError() throws {
+        try XCTSkipInCI()
+
+        let exporter = InMemorySpanExporter()
+        let embrace = try Embrace.setup(options: .init(
+            appId: "myApp",
+            captureServices: [],
+            crashReporter: nil,
+            export: .init(spanExporter: exporter)
+        ))
+
+        embrace.recordCompletedSpan(
+            name: "my-example-span",
+            type: .performance,
+            parent: nil,
+            startTime: Date(),
+            endTime: Date(),
+            attributes: [:],
+            events: [],
+            errorCode: .userAbandon
+        )
+
+        let expectation = expectation(description: "export completes")
+        exporter.onExportComplete {
+            if let result = exporter.exportedSpans.values.first(where: { value in
+                value.name == "my-example-span"
+            }) {
+                XCTAssertEqual(result.status, .error(description: "userAbandon"))
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 6.0)
+    }
+
+}

--- a/Tests/EmbraceOTelInternalTests/Trace/Tracer/Span/Processor/SingleSpanProcessorTests.swift
+++ b/Tests/EmbraceOTelInternalTests/Trace/Tracer/Span/Processor/SingleSpanProcessorTests.swift
@@ -123,7 +123,7 @@ final class SingleSpanProcessorTests: XCTestCase {
 
         let span = createSpanData(processor: processor)
 
-        span.setAttribute(key: "emb.error_code", value: SpanErrorCode.unknown.rawValue)
+        span.setAttribute(key: "emb.error_code", value: ErrorCode.unknown.rawValue)
         let endTime = Date().addingTimeInterval(2)
         span.end(time: endTime)
 

--- a/Tests/TestSupport/Mocks/SpanExporter/InMemorySpanExporter.swift
+++ b/Tests/TestSupport/Mocks/SpanExporter/InMemorySpanExporter.swift
@@ -5,25 +5,27 @@
 import EmbraceOTelInternal
 import OpenTelemetryApi
 
-class InMemorySpanExporter: EmbraceSpanExporter {
+public class InMemorySpanExporter: EmbraceSpanExporter {
 
-    private(set) var exportedSpans: [SpanId: SpanData] = [:]
+    public private(set) var exportedSpans: [SpanId: SpanData] = [:]
+
+    public private(set) var isShutdown = false
 
     private var onExportComplete: (() -> Void)?
 
     private var onFlush: (() -> Void)?
 
-    private(set) var isShutdown = false
+    public init() { }
 
-    func onExportComplete(completion: (() -> Void)?) {
+    public func onExportComplete(completion: (() -> Void)?) {
         self.onExportComplete = completion
     }
 
-    func onFlush(completion: (() -> Void)?) {
+    public func onFlush(completion: (() -> Void)?) {
         self.onFlush = completion
     }
 
-    func export(spans: [SpanData]) -> SpanExporterResultCode {
+    public func export(spans: [SpanData]) -> SpanExporterResultCode {
         spans.forEach { data in
             exportedSpans[data.spanId] = data
         }
@@ -32,12 +34,12 @@ class InMemorySpanExporter: EmbraceSpanExporter {
         return .success
     }
 
-    func flush() -> SpanExporterResultCode {
+    public func flush() -> SpanExporterResultCode {
         onFlush?()
         return .success
     }
 
-    func shutdown() {
+    public func shutdown() {
         isShutdown = true
     }
 }

--- a/Tests/TestSupport/XCTSkip+Helpers.swift
+++ b/Tests/TestSupport/XCTSkip+Helpers.swift
@@ -1,0 +1,15 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+extension XCTestCase {
+    public func XCTSkipInCI(message: String? = "Skipping test in CI") throws {
+        let envCI = ProcessInfo.processInfo.environment["CI"] ?? ""
+
+        guard envCI.isEmpty else {
+            throw XCTSkip(message)
+        }
+    }
+}


### PR DESCRIPTION
Updates recordCompletedSpan to use the `end(errorCode:time:)` method and properly set `Span.Status`

Status will be `OK` if `errorCode` is `nil`, otherwise it will be `ERROR`.

Fixes duplication of `SpanErrorCode` and `ErrorCode` definitions