### PR TITLE
Added `StackTraceBehavior` to `log` API

### DIFF
--- a/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
+++ b/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		7BCB66282AC4742800ABD33A /* MenuList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB66272AC4742800ABD33A /* MenuList.swift */; };
 		7BCB662A2AC4767B00ABD33A /* MainMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB66292AC4767B00ABD33A /* MainMenu.swift */; };
 		7BCB662E2AC476BC00ABD33A /* NetworkStressTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB662D2AC476BC00ABD33A /* NetworkStressTest.swift */; };
+		FA1114462C8A4EE30026499D /* StackTraceBehavior+AsString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1114452C8A4EE30026499D /* StackTraceBehavior+AsString.swift */; };
 		FA3B0A112C3C2A5600315578 /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A102C3C2A5600315578 /* EmbraceCore */; };
 		FA3B0A132C3C2A5600315578 /* EmbraceCrash in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A122C3C2A5600315578 /* EmbraceCrash */; };
 		FA3B0A152C3C2A5600315578 /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A142C3C2A5600315578 /* EmbraceCrashlyticsSupport */; };
@@ -134,6 +135,7 @@
 		7BCB66272AC4742800ABD33A /* MenuList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuList.swift; sourceTree = "<group>"; };
 		7BCB66292AC4767B00ABD33A /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
 		7BCB662D2AC476BC00ABD33A /* NetworkStressTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStressTest.swift; sourceTree = "<group>"; };
+		FA1114452C8A4EE30026499D /* StackTraceBehavior+AsString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StackTraceBehavior+AsString.swift"; sourceTree = "<group>"; };
 		FA4C5F322C486E13005C0371 /* CreateSpanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSpanView.swift; sourceTree = "<group>"; };
 		FA4C5F342C487B45005C0371 /* AttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesView.swift; sourceTree = "<group>"; };
 		FA4FA4F92C62DBB600E66300 /* NoSpacesTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSpacesTextField.swift; sourceTree = "<group>"; };
@@ -452,6 +454,7 @@
 			isa = PBXGroup;
 			children = (
 				FA9505152B86640F00562A4C /* LoggingView.swift */,
+				FA1114452C8A4EE30026499D /* StackTraceBehavior+AsString.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 				7B3143C62AFF1E7D00BA0D2F /* ReflexGameModel.swift in Sources */,
 				FAFDA3D72C34273100AD17CF /* MemoryPressureSimulatorView.swift in Sources */,
 				7B5630A52AC1331000E0DF39 /* Color+Random.swift in Sources */,
+				FA1114462C8A4EE30026499D /* StackTraceBehavior+AsString.swift in Sources */,
 				7B62AD952B0040FE0087C2AE /* Minigame.swift in Sources */,
 				7BBBCD582BD0205C00BC289A /* StdoutLogExporter.swift in Sources */,
 				7BCB66282AC4742800ABD33A /* MenuList.swift in Sources */,

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/LoggingView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/LoggingView.swift
@@ -9,6 +9,7 @@ import EmbraceCommonInternal
 struct LoggingView: View {
     @State private var logMessage: String = "This is the log message..."
     @State private var severity: Int = LogSeverity.info.rawValue
+    @State private var behavior: Int = StackTraceBehavior.default.rawValue
     @State private var key: String = ""
     @State private var value: String = ""
     @State private var attributes: [String: String] = [:]
@@ -18,18 +19,36 @@ struct LoggingView: View {
         [.info, .warn, .error]
     }()
 
+    private let behaviors: [StackTraceBehavior] = {
+        [.default, .notIncluded]
+    }()
+
     var body: some View {
         VStack(alignment: .center) {
             VStack(alignment: .leading) {
                 TextField("Message", text: $logMessage)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
-                Picker("Severity", selection: $severity) {
-                    ForEach(severities, id: \.rawValue) {
-                        Text($0.text)
-                    }
+                
+                VStack(alignment: .leading) {
+                    Text("Severity")
+                        .bold()
+                    Picker("Severity", selection: $severity) {
+                        ForEach(severities, id: \.rawValue) {
+                            Text($0.text)
+                        }
+                    }.pickerStyle(SegmentedPickerStyle())
                 }
-                .pickerStyle(SegmentedPickerStyle())
-                .padding(.bottom)
+                .padding(.vertical)
+
+                VStack(alignment: .leading) {
+                    Text("Stacktrace Behavior").bold()
+                    Picker("Stacktrace Behavior", selection: $behavior) {
+                        ForEach(behaviors, id: \.rawValue) {
+                            Text($0.asString())
+                        }
+                    }.pickerStyle(SegmentedPickerStyle())
+                }
+
                 AttributesView(key: $key, value: $value, attributes: $attributes)
             }.padding()
             Toggle(isOn: $shouldCleanUp) {
@@ -67,7 +86,11 @@ private extension LoggingView {
             print("Wrong severity number")
             return
         }
-        Embrace.client?.log(logMessage, severity: severity, attributes: attributes)
+        guard let behavior = StackTraceBehavior(rawValue: behavior) else {
+            print("Wrong behavior")
+            return
+        }
+        Embrace.client?.log(logMessage, severity: severity, attributes: attributes, stackTraceBehavior: behavior)
         cleanUpFields()
     }
 

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/StackTraceBehavior+AsString.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/StackTraceBehavior+AsString.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import EmbraceCommonInternal
+
+extension StackTraceBehavior {
+    func asString() -> String {
+        switch self {
+        case .default:
+            return "Default"
+        case .notIncluded:
+            return "Not Included"
+        }
+    }
+}

--- a/Sources/EmbraceCommonInternal/Enums/StackTraceBehavior.swift
+++ b/Sources/EmbraceCommonInternal/Enums/StackTraceBehavior.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Describes the behavior for automatically capturing stack traces.
+public enum StackTraceBehavior: Int {
+    /// Stack traces are not automatically captured.
+    case notIncluded
+
+    /// The default behavior for automatically capturing stack traces.
+    case `default`
+}

--- a/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
@@ -138,7 +138,8 @@ class NetworkPayloadCaptureHandler {
                     LogSemantics.NetworkCapture.keyEncryptedKey: result.key,
                     LogSemantics.NetworkCapture.keyKeyAlgorithm: result.keyAlgorithm,
                     LogSemantics.NetworkCapture.keyAesIv: result.iv
-                ]
+                ],
+                stackTraceBehavior: .default
             )
 
             // flag rule as triggered

--- a/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
@@ -135,7 +135,8 @@ class DefaultInternalLogger: InternalLogger {
             message,
             severity: level.severity,
             type: .internal,
-            attributes: attributes
+            attributes: attributes,
+            stackTraceBehavior: .default
         )
 
         // update count

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -169,7 +169,8 @@ class UnsentDataHandler {
             severity: .fatal,
             type: .crash,
             timestamp: timestamp,
-            attributes: attributes
+            attributes: attributes,
+            stackTraceBehavior: .default
         )
 
         return attributes

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -30,7 +30,8 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         _ message: String,
         severity: LogSeverity,
         type: LogType,
-        attributes: [String: String]
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior
     )
 
     func log(
@@ -38,6 +39,7 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         severity: LogSeverity,
         type: LogType,
         timestamp: Date,
-        attributes: [String: String]
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior
     )
 }

--- a/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
@@ -58,9 +58,17 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
         _ message: String,
         severity: LogSeverity,
         type: LogType = .message,
-        attributes: [String: String]
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior = .default
     ) {
-        log(message, severity: severity, type: type, timestamp: Date(), attributes: attributes)
+        log(
+            message,
+            severity: severity,
+            type: type,
+            timestamp: Date(),
+            attributes: attributes,
+            stackTraceBehavior: stackTraceBehavior
+        )
     }
 
     public func log(
@@ -68,7 +76,8 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
         severity: LogSeverity,
         type: LogType = .message,
         timestamp: Date,
-        attributes: [String: String]
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior = .default
     ) {
 
         var attributes = attributes


### PR DESCRIPTION
# Overview
Added a new parameter to the `log` public api: `stackTraceBehavior`. This parameter is of type `StackTraceBehavior` which has two options:
- `default`: as it works today (warn & errors attach stacktraces)
- `never`: don't capture stacktraces, no matter what.

By default, the public API adds the `.default` as the default `StackTraceBehavior`.