### PR TITLE
Fixed an inconsistency while generating xcframeworks

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "e83f3eb25ef4d5a36a13dbee98f8ac67e24e5c8f",
-        "version" : "6.16.0"
+        "revision" : "dd6b98ce04eda39aa22f066cd421c24d7236ea8a",
+        "version" : "6.29.1"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/groue/GRDB.swift",
-            exact: "6.16.0"
+            exact: "6.29.1"
         ),
         .package(
             url: "https://github.com/realm/SwiftLint",


### PR DESCRIPTION
# Overview
This fixes the following crash on startup:
```
dyld[62300]: Symbol not found: _$s4GRDB8DatabaseC7columns2inSayAA10ColumnInfoVGSS_tKF
  Referenced from: <CA263879-3869-37DD-A70C-7165471F2790> /Users/USER/Library/Developer/CoreSimulator/Devices/96FB73FB-6369-4183-B73A-9A5F2DA79B37/data/Containers/Bundle/Application/EF1ABF48-3EF4-4C46-B916-0F4C730A764E/an_app.app/Frameworks/EmbraceStorageInternal.framework/EmbraceStorageInternal
  Expected in:     <416F9AEC-D4AB-39F7-8FCE-90EB9B55A16C> /Users/USER/Library/Developer/CoreSimulator/Devices/96FB73FB-6369-4183-B73A-9A5F2DA79B37/data/Containers/Bundle/Application/EF1ABF48-3EF4-4C46-B916-0F4C730A764E/an_app.app/Frameworks/GRDB.framework/GRDB
```

# Description
The `build_dependencies` script that generates the XCFrameworks for our dependencies (`GRDB` and `OpenTelemetry`) uses the version resolved by our `Package.resolved`. We updated `GRDB` to `6.29.1` in [this PR](https://github.com/embrace-io/embrace-apple-sdk/pull/48). However, to build the rest of our XCFrameworks, we use the `build_xcframework` script with `Tuist`, which has its own `Package.swift` and `Package.resolved` inside the `Tuist` folder that we didn't update. The discrepancy between both sets of `Package.swift` and `Package.resolved` has resulted in building the XCFrameworks targeting an older version of `GRDB` (`6.16.0`), while the actual `GRDB` XCFramework generated was from the newer version (`6.29.1`).