### PR TITLE
Using `2.0.4` of `KSCrash`

### DIFF
--- a/Examples/BombApp/BombApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/BombApp/BombApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f35065f67c35655933e2b4ed841314daab70232fc79185162a3eea7fe1831c3b",
+  "originHash" : "d471a26f48de52ea4ca90915729c04354c0c18d83f037e7ebf7731d1e72c2bc2",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "fbf295e9228fa9e4c9aa0334dfe8347f0987d071",
-        "version" : "2.0.3"
+        "revision" : "17ad4c5159145ed550acb04b1cff48e826547265",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Examples/DemoObjectiveC/DemoObjectiveC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/DemoObjectiveC/DemoObjectiveC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "30bf3f1af4d312afac34bcff9ba35cc3f452c81988789fae8ce52c8747bfec81",
+  "originHash" : "c4c0f33afe19377a25be65e4f8dc7067a26455fa853852bf4727cbcf617d8bda",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "fbf295e9228fa9e4c9aa0334dfe8347f0987d071",
-        "version" : "2.0.3"
+        "revision" : "17ad4c5159145ed550acb04b1cff48e826547265",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "fbf295e9228fa9e4c9aa0334dfe8347f0987d071",
-        "version" : "2.0.3"
+        "revision" : "17ad4c5159145ed550acb04b1cff48e826547265",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     dependencies: [
         .package(
              url: "https://github.com/embrace-io/KSCrash.git",
-             exact: "2.0.3"
+             exact: "2.0.4"
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -21,7 +21,7 @@
     {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/groue/GRDB.swift.git",
+      "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
         "revision" : "dd6b98ce04eda39aa22f066cd421c24d7236ea8a",
         "version" : "6.29.1"
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "fbf295e9228fa9e4c9aa0334dfe8347f0987d071",
-        "version" : "2.0.3"
+        "revision" : "17ad4c5159145ed550acb04b1cff48e826547265",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/embrace-io/KSCrash.git",
-            exact: "2.0.3"
+            exact: "2.0.4"
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",

--- a/bin/dependencies/build_kscrash.sh
+++ b/bin/dependencies/build_kscrash.sh
@@ -46,9 +46,11 @@ tuist install -p "$REPO_DIR"
 tuist generate --no-open -p "$REPO_DIR"
 
 create_xcframework KSCrashCore
-create_xcframework KSCrashFilters
-create_xcframework KSCrashSinks
-create_xcframework KSCrashInstallations 
 create_xcframework KSCrashRecordingCore
-create_xcframework KSCrashReportingCore
 create_xcframework KSCrashRecording
+
+# Commented this as they're not necessary to build them right now.
+#create_xcframework KSCrashFilters
+#create_xcframework KSCrashSinks
+#create_xcframework KSCrashInstallations
+#create_xcframework KSCrashReportingCore


### PR DESCRIPTION
# Overview
Updated `KSCrash` dependency to version `2.0.4`, which now uses `dynamic` instead of `static` linking in SPM. Previously, `static` linking of `KSCrash` during the creation of XCFrameworks resulted in duplicated symbols.

Also, building XCFrameworks for unnecessary products from `KSCrash` has been removed in the `build_kscrash.sh` script