### PR TITLE
Fixing network body capture logs not being exported

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
@@ -48,6 +48,12 @@ class NetworkPayloadCaptureHandler {
         )
 
         updateRules(Embrace.client?.config?.networkPayloadCaptureRules)
+
+        // check if a session is already started
+        if let sessionId = Embrace.client?.currentSessionId() {
+            active = true
+            currentSessionId = SessionIdentifier(string: sessionId)
+        }
     }
 
     deinit {

--- a/Sources/EmbraceCore/Internal/Logs/Exporter/Validation/Validators/LengthOfBodyValidator.swift
+++ b/Sources/EmbraceCore/Internal/Logs/Exporter/Validation/Validators/LengthOfBodyValidator.swift
@@ -13,7 +13,7 @@ class LengthOfBodyValidator: LogDataValidator {
 
     let allowedCharacterCount: ClosedRange<Int>
 
-    init(allowedCharacterCount: ClosedRange<Int> = 1...4000) {
+    init(allowedCharacterCount: ClosedRange<Int> = 0...4000) {
         self.allowedCharacterCount = allowedCharacterCount
     }
 


### PR DESCRIPTION
* The handler would start inactive if there was an ongoing session already
* The exporter was ignoring logs with empty bodies