### PR TITLE
Fixed bug that would create a request to `/v2/logs` endpoint w/o logs

### DIFF
--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -47,7 +47,7 @@ class LogController: LogControllable {
 extension LogController {
     func batchFinished(withLogs logs: [LogRecord]) {
         do {
-            guard let sessionId = sessionController?.currentSession?.id else {
+            guard let sessionId = sessionController?.currentSession?.id, logs.count > 0 else {
                 return
             }
             let resourcePayload = try createResourcePayload(sessionId: sessionId)

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -126,6 +126,12 @@ class LogControllerTests: XCTestCase {
         thenDoesntTryToUploadAnything()
     }
 
+    func testHavingSessionButNoLogs_onBatchFinished_wontTryToUploadAnything() {
+        givenLogController()
+        whenInvokingBatchFinished(withLogs: [])
+        thenDoesntTryToUploadAnything()
+    }
+
     func testHavingLogs_onBatchFinished_fetchesResourcesFromStorage() throws {
         givenLogController()
         whenInvokingBatchFinished(withLogs: [randomLogRecord()])


### PR DESCRIPTION
# Overview
Today when one or more logs are added, a batch is created. When that batch is closed at the end of the session, another batch without logs is generated. If the session ends without any logs being added to this new batch, it is being sent to the backend with no logs.
This PR fixes this issue and prevents backend calls when an empty batch is closed.