### PR TITLE
Fixing log validator tests

### DIFF
--- a/Tests/EmbraceCoreTests/Internal/Logs/Exporter/StorageEmbraceLogExporterTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/Exporter/StorageEmbraceLogExporterTests.swift
@@ -61,7 +61,13 @@ class StorageEmbraceLogExporterTests: XCTestCase {
 
     func test_havingActiveLogExporter_onExport_whenInvalidBody_exportSucceedsButNotAddedToBatch() {
         givenStorageEmbraceLogExporter(initialState: .active)
-        whenInvokingExport(withLogs: [randomLogData(body: nil)])
+
+        var str = ""
+        for _ in 1...4001 {
+            str += "."
+        }
+        whenInvokingExport(withLogs: [randomLogData(body: str)])
+        
         thenBatchAdded(count: 0)
         thenResult(is: .success)
     }
@@ -77,7 +83,12 @@ class StorageEmbraceLogExporterTests: XCTestCase {
     func test_havingActiveLogExporter_onExportManyLogs_someValidSomeInvalid_shouldInvokeBatcherForEveryValidLog() {
         let validAmount = Int.random(in: 1..<10)
         let validLogs = randomLogs(quantity: validAmount, body: "example")
-        let invalidLogs = randomLogs(quantity: Int.random(in: 1..<10))
+
+        var str = ""
+        for _ in 1...4001 {
+            str += "."
+        }
+        let invalidLogs = randomLogs(quantity: Int.random(in: 1..<10), body: str)
 
         givenStorageEmbraceLogExporter(initialState: .active)
         whenInvokingExport(withLogs: (validLogs + invalidLogs).shuffled())

--- a/Tests/EmbraceCoreTests/Internal/Logs/Exporter/Validation/Validators/LengthOfBodyValidatorTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/Exporter/Validation/Validators/LengthOfBodyValidatorTests.swift
@@ -21,14 +21,19 @@ final class LengthOfBodyValidatorTests: XCTestCase {
 
     func test_validate_init_defaultsToCorrect_allowedCharacterCount() {
         let validator = LengthOfBodyValidator()
-        XCTAssertEqual(validator.allowedCharacterCount, 1...4000)
+        XCTAssertEqual(validator.allowedCharacterCount, 0...4000)
     }
 
-    func test_validate_isInvalid_ifBodyIsNil() {
+    func test_validate_isInvalid_ifBodySizeIsOutOfRange() {
         let validator = LengthOfBodyValidator()
 
-        var invalidNil = logData(body: nil)
-        let result = validator.validate(data: &invalidNil)
+        var str = ""
+        for _ in 1...4001 {
+            str += "."
+        }
+
+        var invalidLog = logData(body: str)
+        let result = validator.validate(data: &invalidLog)
         XCTAssertFalse(result)
     }
 


### PR DESCRIPTION
These were not updated when the validator was changed in 6.4.2, so doing it now.