### PR TITLE
Update version requirement of swiftlint to avoid unnecessary conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/realm/SwiftLint",
-            exact: "0.53.0"
+            from: "0.53.0"
         ),
         .package(
             url: "https://github.com/apple/swift-docc-plugin",


### PR DESCRIPTION
To prevent cases where `SwiftLint` causes conflicts, we have changed the dependency definition to use `from` instead of `exact` in SPM.