### PR TITLE
Add @objc to Embrace client metadata

### DIFF
--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -58,7 +58,7 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
     }
 
     /// Returns the current `MetadataHandler` used to store resources and session properties.
-    public let metadata: MetadataHandler
+    @objc public let metadata: MetadataHandler
 
     let config: EmbraceConfig?
     let storage: EmbraceStorage


### PR DESCRIPTION
## Description
`MetadataHandler` is defined as an ObjC class but not exposed to ObjC - Adding `@objc` to `metadata` prop in Embrace client to use in ObjC.

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage - Not sure if this is applicable as I just added one tiny change to prop
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
