### PR TITLE
Replaced internal fork of xcresulttool action with original

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: bin/test | xcpretty && exit ${PIPESTATUS[0]}
         timeout-minutes: 30
 
-      - uses: embrace-io/xcresulttool@v1
+      - uses: kishikawakatsumi/xcresulttool@v1
         if: always()
         with:
           path: .build/test/output.xcresult


### PR DESCRIPTION
# Overview
As we're open source, using a private fork now is unnecessary. It's also generating conflicts when somebody forks our repository and contributes back to it (like [here](https://github.com/embrace-io/embrace-apple-sdk/pull/85) and [here](https://github.com/embrace-io/embrace-apple-sdk/pull/63)).
This PR replaces the usage of the `embrace-io/xcresulttool` to use the original `kishikawakatsumi/xcresulttool` action.