### PR TITLE
Setting status as `error` for crashed session spans

### DIFF
--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -258,4 +258,3 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
         }
     }
 }
-

--- a/Sources/EmbraceCore/Internal/Embrace+Config.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Config.swift
@@ -50,7 +50,6 @@ extension Embrace {
             userAgent: EmbraceMeta.userAgent
         )
 
-        let usedDigits = UInt(6)
         return RemoteConfig(
             options: options,
             logger: logger

--- a/Sources/EmbraceCore/Payload/Spans/SpanPayload.swift
+++ b/Sources/EmbraceCore/Payload/Spans/SpanPayload.swift
@@ -38,7 +38,7 @@ struct SpanPayload: Encodable {
         self.spanId = span.spanId.hexString
         self.parentSpanId = span.parentSpanId?.hexString
         self.name = span.name
-        self.status = failed ? Status.sessionCrashedError().name : span.status.name
+        self.status = span.status == .ok ? span.status.name : (failed ? Status.sessionCrashedError().name : span.status.name)
         self.startTime = span.startTime.nanosecondsSince1970Truncated
         self.events = span.events.map { SpanEventPayload(from: $0) }
         self.links = span.links.map { SpanLinkPayload(from: $0) }

--- a/Sources/EmbraceCore/Payload/Spans/SpanPayload.swift
+++ b/Sources/EmbraceCore/Payload/Spans/SpanPayload.swift
@@ -5,6 +5,7 @@
 import Foundation
 import EmbraceOTelInternal
 import EmbraceSemantics
+import OpenTelemetryApi
 import OpenTelemetrySdk
 
 struct SpanPayload: Encodable {
@@ -37,7 +38,7 @@ struct SpanPayload: Encodable {
         self.spanId = span.spanId.hexString
         self.parentSpanId = span.parentSpanId?.hexString
         self.name = span.name
-        self.status = span.status.name
+        self.status = failed ? Status.sessionCrashedError().name : span.status.name
         self.startTime = span.startTime.nanosecondsSince1970Truncated
         self.events = span.events.map { SpanEventPayload(from: $0) }
         self.links = span.links.map { SpanLinkPayload(from: $0) }
@@ -54,6 +55,7 @@ struct SpanPayload: Encodable {
         if failed {
             attributeArray.append(Attribute(key: SpanSemantics.keyErrorCode, value: "failure"))
         }
+
         self.attributes = attributeArray
     }
 

--- a/Sources/EmbraceCore/Payload/Spans/SpanPayload.swift
+++ b/Sources/EmbraceCore/Payload/Spans/SpanPayload.swift
@@ -38,10 +38,15 @@ struct SpanPayload: Encodable {
         self.spanId = span.spanId.hexString
         self.parentSpanId = span.parentSpanId?.hexString
         self.name = span.name
-        self.status = span.status == .ok ? span.status.name : (failed ? Status.sessionCrashedError().name : span.status.name)
         self.startTime = span.startTime.nanosecondsSince1970Truncated
         self.events = span.events.map { SpanEventPayload(from: $0) }
         self.links = span.links.map { SpanLinkPayload(from: $0) }
+
+        if span.status == .ok || !failed {
+            self.status = span.status.name
+        } else {
+            self.status = Status.sessionCrashedError().name
+        }
 
         if let endTime = endTime {
             self.endTime = endTime.nanosecondsSince1970Truncated

--- a/Sources/EmbraceCore/Public/Metadata/MetadataHandler+User.swift
+++ b/Sources/EmbraceCore/Public/Metadata/MetadataHandler+User.swift
@@ -38,7 +38,7 @@ import EmbraceStorageInternal
     /// Will be set permanently until explicitly unset via the `clearUserProperties()` method.
     /// - Note: No validation is done on the identifier. Be sure it matches or
     ///         can be mapped to a record in your system
-    @objc public var userIdentifier: String? {
+    public var userIdentifier: String? {
         get {
             value(for: .identifier)
         }
@@ -49,7 +49,7 @@ import EmbraceStorageInternal
 
     /// Clear all user properties.
     /// This will clear all user properties set via the `userName`, `userEmail` and `userIdentifier` properties.
-    @objc public func clearUserProperties() {
+    public func clearUserProperties() {
         do {
             try storage?.removeAllMetadata(keys: UserResourceKey.allValues, lifespan: .permanent)
         } catch {

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -58,7 +58,7 @@ fileprivate extension SpanPayload {
         self.spanId = session.spanId
         self.parentSpanId = nil
         self.name = SpanSemantics.Session.name
-        self.status = Status.ok.name
+        self.status = session.crashReportId != nil ? Status.sessionCrashedError().name : Status.ok.name
         self.startTime = session.startTime.nanosecondsSince1970Truncated
         self.endTime = session.endTime?.nanosecondsSince1970Truncated ??
                        session.lastHeartbeatTime.nanosecondsSince1970Truncated
@@ -126,5 +126,11 @@ fileprivate extension SpanPayload {
             self.events = []
             self.links = []
         }
+    }
+}
+
+internal extension OpenTelemetryApi.Status {
+    static func sessionCrashedError() -> Status {
+        return Status.error(description: "Session crashed!")
     }
 }

--- a/Tests/EmbraceCoreTests/Internal/Logs/Exporter/StorageEmbraceLogExporterTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/Exporter/StorageEmbraceLogExporterTests.swift
@@ -67,7 +67,7 @@ class StorageEmbraceLogExporterTests: XCTestCase {
             str += "."
         }
         whenInvokingExport(withLogs: [randomLogData(body: str)])
-        
+
         thenBatchAdded(count: 0)
         thenResult(is: .success)
     }

--- a/Tests/EmbraceCoreTests/Payload/SpansPayloadBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/SpansPayloadBuilderTests.swift
@@ -49,6 +49,7 @@ final class SpansPayloadBuilderTests: XCTestCase {
             name: name ?? "test-span",
             kind: .internal,
             startTime: startTime,
+            status: endTime == nil ? .unset : .ok,
             endTime: endTime ?? Date(),
             hasEnded: endTime != nil
         )
@@ -264,6 +265,33 @@ final class SpansPayloadBuilderTests: XCTestCase {
         // then the error code attribute was added
         let attribute = closed[1].attributes.first { $0.key == "emb.error_code" }
         XCTAssertEqual(attribute!.value, "failure")
+    }
+
+    func test_closedSpan_withinCrashedSession() throws {
+        // given a crashed session
+        sessionRecord.crashReportId = "test"
+
+        // given a open span that started after the crashed session
+        let span = try addSpan(
+            startTime: Date(timeIntervalSince1970: 55),
+            endTime: Date(timeIntervalSince1970: 60)
+        )
+        let payload = SpanPayload(from: span, endTime: Date(timeIntervalSince1970: 60), failed: false)
+
+        // when building the spans payload
+        let (closed, open) = SpansPayloadBuilder.build(for: sessionRecord, storage: storage)
+
+        // then the spans are retrieved correctly
+        XCTAssertEqual(closed.count, 2)
+        XCTAssertEqual(closed[0].name, "emb-session") // session span always first
+        XCTAssertEqual(closed[0].status, "error")
+        XCTAssertEqual(closed[1], payload)
+        XCTAssertEqual(closed[1].status, "ok")
+        XCTAssertEqual(open.count, 0)
+
+        // then the error code attribute was added
+        let attribute = closed[1].attributes.first { $0.key == "emb.error_code" }
+        XCTAssertNil(attribute)
     }
 
     func test_hardLimit() throws {

--- a/Tests/EmbraceCoreTests/Payload/SpansPayloadBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/SpansPayloadBuilderTests.swift
@@ -229,7 +229,9 @@ final class SpansPayloadBuilderTests: XCTestCase {
         // then the spans are retrieved correctly
         XCTAssertEqual(closed.count, 2)
         XCTAssertEqual(closed[0].name, "emb-session") // session span always first
+        XCTAssertEqual(closed[0].status, "error")
         XCTAssertEqual(closed[1], payload)
+        XCTAssertEqual(closed[1].status, "error")
         XCTAssertEqual(open.count, 0)
 
         // then the error code attribute was added
@@ -254,7 +256,9 @@ final class SpansPayloadBuilderTests: XCTestCase {
         // then the spans are retrieved correctly
         XCTAssertEqual(closed.count, 2)
         XCTAssertEqual(closed[0].name, "emb-session") // session span always first
+        XCTAssertEqual(closed[0].status, "error")
         XCTAssertEqual(closed[1], payload)
+        XCTAssertEqual(closed[1].status, "error")
         XCTAssertEqual(open.count, 0)
 
         // then the error code attribute was added

--- a/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
@@ -149,7 +149,7 @@ final class SessionSpanUtilsTests: XCTestCase {
         XCTAssertEqual(payload.traceId, TestConstants.traceId)
         XCTAssertEqual(payload.spanId, TestConstants.spanId)
         XCTAssertNil(payload.parentSpanId)
-        XCTAssertEqual(payload.status, Status.ok.name)
+        XCTAssertEqual(payload.status, "error")
         XCTAssertEqual(payload.startTime, TestConstants.date.nanosecondsSince1970Truncated)
         XCTAssertEqual(payload.endTime, endTime.nanosecondsSince1970Truncated)
         XCTAssertEqual(payload.events.count, 0)
@@ -199,6 +199,46 @@ final class SessionSpanUtilsTests: XCTestCase {
             $0.key == "emb.crash_id"
         }
         XCTAssertEqual(crashIdAttribute!.value, "test")
+    }
+
+    func test_status() {
+        // test ok status
+        var session = SessionRecord(
+            id: TestConstants.sessionId,
+            state: .foreground,
+            processId: TestConstants.processId,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: TestConstants.date,
+            endTime: Date(),
+            lastHeartbeatTime: Date(),
+            crashReportId: nil,
+            coldStart: true,
+            cleanExit: false,
+            appTerminated: true
+        )
+
+        var payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        XCTAssertEqual(payload.status, "ok")
+
+        // test error status
+        session = SessionRecord(
+            id: TestConstants.sessionId,
+            state: .foreground,
+            processId: TestConstants.processId,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: TestConstants.date,
+            endTime: Date(),
+            lastHeartbeatTime: Date(),
+            crashReportId: "test",
+            coldStart: true,
+            cleanExit: false,
+            appTerminated: true
+        )
+
+        payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        XCTAssertEqual(payload.status, "error")
     }
 
     func test_payloadFromSession_shouldAddCustomePropertiesWithPrefixedKey() {


### PR DESCRIPTION
This affects the session span itself and all the open spans within it.
This does NOT affect spans that had already ended successfully before the crash.