### PR TITLE
Removes swiftlint from the Package.swift as a dependency and build tool plugin

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,7 +14,7 @@ SWIFT_LINT=swiftlint
 AUTO_CORRECT=1
 
 # stage fixed files automatically
-AUTO_STAGE=1
+AUTO_STAGE=0
 
 ####################################################################################################
 
@@ -45,7 +45,7 @@ fi
 
 export SCRIPT_INPUT_FILE_COUNT=$FILE_COUNT
 
-# autocorrect modified files 
+# autocorrect modified files
 if [ "$AUTO_CORRECT" -eq 1 ]; then
     FIX_RESULT=$($SWIFT_LINT lint --fix --strict --use-script-input-files --force-exclude)
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,2 @@
 brew "danger/tap/danger-swift", tag: "3.15.0"
+brew "swiftlint"

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -7,6 +7,45 @@
         "options": {
           "tag": "3.15.0"
         }
+      },
+      "swiftlint": {
+        "version": "0.57.0",
+        "bottle": {
+          "rebuild": 0,
+          "root_url": "https://ghcr.io/v2/homebrew/core",
+          "files": {
+            "arm64_sequoia": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:fd8609da0dbf8e9396f9f5697b2650c35217f6d5443310ab8b3aeb095cadc32e",
+              "sha256": "fd8609da0dbf8e9396f9f5697b2650c35217f6d5443310ab8b3aeb095cadc32e"
+            },
+            "arm64_sonoma": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:cb14bb58a7fa8e390030b9890378c097385ac0d6bd50b1003946d24feb230b72",
+              "sha256": "cb14bb58a7fa8e390030b9890378c097385ac0d6bd50b1003946d24feb230b72"
+            },
+            "arm64_ventura": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:52e8789623ac1ec907079762083591e1f21d90ff751da9754b3db52badfe94bc",
+              "sha256": "52e8789623ac1ec907079762083591e1f21d90ff751da9754b3db52badfe94bc"
+            },
+            "sonoma": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:30e8f88c492f67ce3d08181044c5849f1b9075ad00aac615551a42aa253cbed9",
+              "sha256": "30e8f88c492f67ce3d08181044c5849f1b9075ad00aac615551a42aa253cbed9"
+            },
+            "ventura": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:fe9e50ce478538598d5e85875ea9c0a1d61c24d83352362de02141f1467b5262",
+              "sha256": "fe9e50ce478538598d5e85875ea9c0a1d61c24d83352362de02141f1467b5262"
+            },
+            "x86_64_linux": {
+              "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:dec908e0f1cd2b332bcf678edc36e10f7030cfc9414e733629e763283b0ada40",
+              "sha256": "dec908e0f1cd2b332bcf678edc36e10f7030cfc9414e733629e763283b0ada40"
+            }
+          }
+        }
       }
     }
   },
@@ -19,6 +58,14 @@
         "CLT": "14.3.1.0.1.1683849156",
         "Xcode": "15.1",
         "macOS": "13.5.1"
+      },
+      "sonoma": {
+        "HOMEBREW_VERSION": "4.4.0",
+        "HOMEBREW_PREFIX": "/opt/homebrew",
+        "Homebrew/homebrew-core": "api",
+        "CLT": "15.3.0.0.1.1708646388",
+        "Xcode": "15.4",
+        "macOS": "14.5"
       }
     }
   }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,24 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "32f641cf24fc7abc1c591a2025e9f2f572648b0f",
-        "version" : "1.7.2"
-      }
-    },
-    {
       "identity" : "grdb.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
@@ -64,24 +46,6 @@
       }
     },
     {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
-        "version" : "0.34.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -97,24 +61,6 @@
       "state" : {
         "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
         "version" : "1.1.2"
-      }
-    },
-    {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "branch" : "main",
-        "revision" : "3aad4aabc42835f09f600bb17070f6a11bc84180"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
       }
     },
     {
@@ -199,15 +145,6 @@
       }
     },
     {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
-      }
-    },
-    {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
@@ -217,48 +154,12 @@
       }
     },
     {
-      "identity" : "swiftlint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint",
-      "state" : {
-        "revision" : "6d2e58271ebc14c37bf76d7c9f4082cc15bad718",
-        "version" : "0.53.0"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
-        "version" : "7.0.2"
-      }
-    },
-    {
       "identity" : "thrift-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/undefinedlabs/Thrift-Swift",
       "state" : {
         "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
         "version" : "1.1.2"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -4,15 +4,6 @@
 import Foundation
 import PackageDescription
 
-var targetPlugins: [Target.PluginUsage] = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
-// Work around for plugin dependency being included in iOS target when using `xcodebuild test`
-// (See bin/xctest)
-// https://forums.swift.org/t/xcode-attempts-to-build-plugins-for-ios-is-there-a-workaround/57029
-if ProcessInfo.processInfo.environment["IS_XCTEST"] != nil ||
-    ProcessInfo.processInfo.environment["IS_ARCHIVE"] != nil {
-    targetPlugins.removeAll()
-}
-
 let package = Package(
     name: "EmbraceIO",
     platforms: [
@@ -37,14 +28,6 @@ let package = Package(
         .package(
             url: "https://github.com/groue/GRDB.swift",
             exact: "6.29.1"
-        ),
-        .package(
-            url: "https://github.com/realm/SwiftLint",
-            from: "0.53.0"
-        ),
-        .package(
-            url: "https://github.com/apple/swift-docc-plugin",
-            branch: "main"
         )
     ],
     targets: [
@@ -57,8 +40,7 @@ let package = Package(
                 "EmbraceCommonInternal",
                 "EmbraceCrash",
                 "EmbraceSemantics"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         .testTarget(
@@ -69,8 +51,7 @@ let package = Package(
                 "EmbraceCrash",
                 "TestSupport",
                 .product(name: "GRDB", package: "GRDB.swift")
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // core ----------------------------------------------------------------------
@@ -89,8 +70,7 @@ let package = Package(
             ],
             resources: [
                 .copy("PrivacyInfo.xcprivacy")
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         .testTarget(
@@ -102,22 +82,19 @@ let package = Package(
             ],
             resources: [
                 .copy("Mocks/")
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // common --------------------------------------------------------------------
         .target(
-            name: "EmbraceCommonInternal",
-            plugins: targetPlugins
+            name: "EmbraceCommonInternal"
         ),
         .testTarget(
             name: "EmbraceCommonInternalTests",
             dependencies: [
                 "EmbraceCommonInternal",
                 "TestSupport"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // semantics -----------------------------------------------------------------
@@ -125,8 +102,7 @@ let package = Package(
             name: "EmbraceSemantics",
             dependencies: [
                 "EmbraceCommonInternal"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // capture service -----------------------------------------------------------
@@ -135,31 +111,27 @@ let package = Package(
             dependencies: [
                 "EmbraceOTelInternal",
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift")
-            ],
-            plugins: targetPlugins
+            ]
         ),
         .testTarget(
             name: "EmbraceCaptureServiceTests",
             dependencies: [
                 "EmbraceCaptureService",
                 "TestSupport"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // config --------------------------------------------------------------------
         .target(
             name: "EmbraceConfiguration",
-            dependencies: [],
-            plugins: targetPlugins
+            dependencies: []
         ),
 
         .testTarget(
             name: "EmbraceConfigurationTests",
             dependencies: [
                 "EmbraceConfiguration"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         .target(
@@ -167,8 +139,7 @@ let package = Package(
             dependencies: [
                 "EmbraceCommonInternal",
                 "EmbraceConfiguration"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         .testTarget(
@@ -179,8 +150,7 @@ let package = Package(
             ],
             resources: [
                 .copy("Fixtures")
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // OTel ----------------------------------------------------------------------
@@ -190,16 +160,14 @@ let package = Package(
                 "EmbraceCommonInternal",
                 "EmbraceSemantics",
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift")
-            ],
-            plugins: targetPlugins
+            ]
         ),
         .testTarget(
             name: "EmbraceOTelInternalTests",
             dependencies: [
                 "EmbraceOTelInternal",
                 "TestSupport"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // storage -------------------------------------------------------------------
@@ -209,16 +177,14 @@ let package = Package(
                 "EmbraceCommonInternal",
                 "EmbraceSemantics",
                 .product(name: "GRDB", package: "GRDB.swift")
-            ],
-            plugins: targetPlugins
+            ]
         ),
         .testTarget(
             name: "EmbraceStorageInternalTests",
             dependencies: ["EmbraceStorageInternal", "TestSupport"],
             resources: [
                 .copy("Mocks/")
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // upload --------------------------------------------------------------------
@@ -228,8 +194,7 @@ let package = Package(
                 "EmbraceCommonInternal",
                 "EmbraceOTelInternal",
                 .product(name: "GRDB", package: "GRDB.swift")
-            ],
-            plugins: targetPlugins
+            ]
         ),
         .testTarget(
             name: "EmbraceUploadInternalTests",
@@ -237,8 +202,7 @@ let package = Package(
                 "EmbraceUploadInternal",
                 "EmbraceOTelInternal",
                 "TestSupport"
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // crashes -------------------------------------------------------------------
@@ -247,16 +211,14 @@ let package = Package(
             dependencies: [
                 "EmbraceCommonInternal",
                 .product(name: "Recording", package: "KSCrash")
-            ],
-            plugins: targetPlugins
+            ]
         ),
         .testTarget(
             name: "EmbraceCrashTests",
             dependencies: ["EmbraceCrash", "TestSupport"],
             resources: [
                 .copy("Mocks/")
-            ],
-            plugins: targetPlugins
+            ]
         ),
 
         // crashlytics support  -------------------------------------------------------
@@ -265,23 +227,19 @@ let package = Package(
             dependencies: [
                 "EmbraceCommonInternal"
             ],
-            path: "Sources/ThirdParty/EmbraceCrashlyticsSupport",
-            plugins: targetPlugins
+            path: "Sources/ThirdParty/EmbraceCrashlyticsSupport"
         ),
         .testTarget(
             name: "EmbraceCrashlyticsSupportTests",
             dependencies: ["EmbraceCrashlyticsSupport", "EmbraceCommonInternal", "TestSupport"],
-            path: "Tests/ThirdParty/EmbraceCrashlyticsSupportTests",
-            plugins: targetPlugins
+            path: "Tests/ThirdParty/EmbraceCrashlyticsSupportTests"
         ),
 
         // Utilities
-        .target(name: "EmbraceObjCUtilsInternal",
-                plugins: targetPlugins),
+        .target(name: "EmbraceObjCUtilsInternal"),
         .testTarget(
             name: "EmbraceObjCUtilsInternalTests",
-            dependencies: ["EmbraceObjCUtilsInternal", "TestSupport"],
-            plugins: targetPlugins
+            dependencies: ["EmbraceObjCUtilsInternal", "TestSupport"]
         ),
 
         // test support --------------------------------------------------------------
@@ -293,8 +251,7 @@ let package = Package(
                 "EmbraceCommonInternal",
                 .product(name: "OpenTelemetrySdk", package: "opentelemetry-swift")
             ],
-            path: "Tests/TestSupport",
-            plugins: targetPlugins
+            path: "Tests/TestSupport"
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project represents a shift from the previous Embrace SDK in that it adopts 
 supports the [OpenTelemetry](https://opentelemetry.io/) standard. We have also added features that extend OpenTelemetry to
 better support mobile apps.
 
-Telemetry recorded through this SDK can be consumed on the Embrace platform for Embrace customers, but it can also be used by those who are not Embrace customers to export collected data directly to any OTel Collector, either one that they host or is hosted by other vendors. In effect, this SDK is an alternative to using the [OpenTelemetry Swift SDK](https://github.com/open-telemetry/opentelemetry-swift) directly for iOS apps that want to leverage the OpenTelemetry ecosystem for observability, but also want all the advanced telemetry capture that Embrace is known for. 
+Telemetry recorded through this SDK can be consumed on the Embrace platform for Embrace customers, but it can also be used by those who are not Embrace customers to export collected data directly to any OTel Collector, either one that they host or is hosted by other vendors. In effect, this SDK is an alternative to using the [OpenTelemetry Swift SDK](https://github.com/open-telemetry/opentelemetry-swift) directly for iOS apps that want to leverage the OpenTelemetry ecosystem for observability, but also want all the advanced telemetry capture that Embrace is known for.
 
 Currently, only Spans and Logs are supported, but other signals will be added in the future.
 
@@ -16,7 +16,7 @@ More documentation and examples can be found at [https://embrace.io/docs/](https
 ### Currently Supported Key Features
 
 * Session capture
-* Crash capture 
+* Crash capture
 * Network capture
 * OTel trace capture
 * Custom breadcrumbs
@@ -24,12 +24,11 @@ More documentation and examples can be found at [https://embrace.io/docs/](https
 * OpenTelemetry Export
 * Session properties
 * Automatic view tracking
+* Network payload capture
 
 ### Key Features Coming Soon
 
 * Metrickit capture
-* Network payload capture
-* Extensions insights
 
 ## Getting Started
 
@@ -161,12 +160,18 @@ bin/test | xcpretty
 
 ## Linting and Guidelines
 
-We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce them and every pull request must satisfy them to be merged.
-SwiftLint is used as a plugin in all of our targets to get warnings and errors directly in Xcode.
+We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce consistency and every pull request must pass a lint check to be merged.
 
-You can run the swiftlint plugin from the CLI as well:
+You can install SwiftLint by following the instructions in their [README](https://github.com/realm/SwiftLint/blob/main/README.md).
+We recommend homebrew:
+
 ```sh
-swift run swiftlint --fix
+brew install swiftlint
+```
+
+Once `swiftlint` is in your PATH, you can run the linter:
+```sh
+swiftlint --fix
 ```
 
 ### Using SwiftLint
@@ -182,8 +187,11 @@ For this first you'll need to install SwiftLint in your local environment. Follo
 We strongly recommend to use a pre-commit hook to make sure all the modified files follow the guidelines before pushing.
 We have provided an example pre-commit hook in `.githooks/pre-commit`. Note that depending on your local environment, you might need to edit the pre-commit file to set the path to `swiftlint`.
 
+```sh
+cp .githooks/pre-commit .git/hooks/pre-commit
+```
+
 **Alternatives on how to setup the hook:**
-* Simply copy `.githooks/pre-commit` into `.git/hooks/pre-commit`.
 * Use the `core.hooksPath` setting to change the hooks path (`git config core.hooksPath .githooks`)
 
 
@@ -209,9 +217,9 @@ To test that your changes fixed the auth issue, attempt to fetch the dependencie
 > WatchOS support does not currently include the Embrace Crash Reporter. Instrumentation and observability will be possible but the SDK will not be able to collect crash reports.
 >
 
-## Support 
+## Support
 
-We appreciate any feedback you have on the SDK and the APIs that it provides. 
+We appreciate any feedback you have on the SDK and the APIs that it provides.
 
 To contribute to this project please see our [Contribution Guidelines](https://github.com/embrace-io/embrace-apple-sdk/blob/main/CONTRIBUTING.md). After completing the Individual Contributor License Agreement (CLA), you'll be able to submit a feature request, create a bug report, or submit a pull request.
 


### PR DESCRIPTION

This type of installation was leaking into client projects and was not intended. Moving forward, the prescribed way to run swiftlint will be by installing swiftlint directly (via homebrew)

Also updated README with directions on how to install a pre-commit hook to automate this process as best as possible

