### PR TITLE
Fixed linking issue by upgrading KSCrash

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "17ad4c5159145ed550acb04b1cff48e826547265",
-        "version" : "2.0.4"
+        "revision" : "c5769c51706312803d33913778cc381fe6b4462c",
+        "version" : "2.0.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     dependencies: [
         .package(
              url: "https://github.com/embrace-io/KSCrash.git",
-             exact: "2.0.4"
+             exact: "2.0.5"
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",


### PR DESCRIPTION
# Overview
We did a fix in KSCrash to prevent an issue with static/dynamic linking in both SPM and cocoapods. This PR bumps the version to use that newer version of KSCrash