### PR TITLE
Fixes issues on generating a `.swiftinterface` for `EmbraceConfiguration`

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -116,6 +116,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.embraceio.EmbraceConfiguration",
+            deploymentTargets: .iOS("13.0"),
             sources: ["Sources/EmbraceConfiguration/**"],
             dependencies: [],
             settings: .settings(base: [

--- a/Sources/EmbraceConfiguration/NetworkPayloadCaptureRule.swift
+++ b/Sources/EmbraceConfiguration/NetworkPayloadCaptureRule.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 @objc
-public final class NetworkPayloadCaptureRule: NSObject, Decodable  {
+public final class NetworkPayloadCaptureRule: NSObject, Decodable {
     public let id: String
     public let urlRegex: String
     public let statusCodes: [Int]?

--- a/Sources/EmbraceConfiguration/NetworkPayloadCaptureRule.swift
+++ b/Sources/EmbraceConfiguration/NetworkPayloadCaptureRule.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 @objc
-public final class NetworkPayloadCaptureRule: NSObject {
+public final class NetworkPayloadCaptureRule: NSObject, Decodable  {
     public let id: String
     public let urlRegex: String
     public let statusCodes: [Int]?
@@ -34,7 +34,7 @@ public final class NetworkPayloadCaptureRule: NSObject {
     }
 }
 
-extension NetworkPayloadCaptureRule: Decodable {
+extension NetworkPayloadCaptureRule {
     enum CodingKeys: String, CodingKey {
         case id
         case urlRegex = "url"


### PR DESCRIPTION
# Overview
While generating the `.xcframework`s, we're encountering issues with generating the `.swiftinterface` for `EmbraceConfiguration`. Specifically, it appears that the automatic code generation for `Codable` creates the `init` inside an extension, which is not allowed in Swift as can be seen in the attached image:
<img width="1318" alt="Screenshot 2024-10-16 at 2 56 04 PM" src="https://github.com/user-attachments/assets/44b52afa-f601-4ad5-9887-8efee639503e">
This PR fixes that issue.

**Extra:** Added a deployment target to `Project.swift` for `EmbraceConfiguration` to prevent known issues.

