### PR TITLE
ci: Use macos-14 and XCode 15.4 in all workflows.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           name: Embrace-Universal Build Artifacts
           path: xcframeworks.zip
-      
+
       - name: Tag the release candidate version
         if: env.IS_PRODUCTION_READY == 'false'
         run: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     name: "Run Danger"
     steps:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         run: |
-          sudo xcode-select -s /Applications/Xcode_15.0.app
+          sudo xcode-select -s /Applications/Xcode_15.4.app
           xcodebuild -version
 
       - name: Install Danger Swift
@@ -27,8 +27,8 @@ jobs:
 
             if ! which brew > /dev/null; then
               echo "Brew is not installed; cannot proceed with Danger installation."
-            fi 
-            
+            fi
+
             brew bundle --verbose
 
             echo "Danger was installed successfully"
@@ -42,4 +42,3 @@ jobs:
         run: danger-swift ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,3 @@
-
 name: Run Swift Tests
 
 on:
@@ -15,14 +14,14 @@ on:
 jobs:
   run-tests:
     timeout-minutes: 30
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["15.1"]
+        xcode_version: ["15.4"]
     steps:
       - name: Select Xcode
-        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
         run: |
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
           xcodebuild -version

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -5,6 +5,7 @@ env:
 
 on:
   workflow_dispatch:
+
 # These permissions are needed to interact with GitHub's OIDC Token endpoint
 permissions:
   id-token: write
@@ -14,7 +15,7 @@ permissions:
 jobs:
   build-smoke-tests-app:
     timeout-minutes: 40
-    runs-on: [macos-12]
+    runs-on: [macos-14]
     strategy:
       fail-fast: false
 
@@ -56,7 +57,6 @@ jobs:
     uses: embrace-io/actions/.github/workflows/smoke-test.yml@master
     secrets: inherit
     with:
-      #Host: self-hosted, macos # macos-12
       LaunchCommand: xcrun simctl launch booted
       KillAppCommand: xcrun simctl terminate booted io.embrace.BrandGame
       BundleID: io.embrace.BrandGame


### PR DESCRIPTION
GitHub is deprecating macos-12 in the near future. There is actually macos-15 image now as well, but it only has Xcode 16.0

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
