### PR TITLE
Update patch updates on GRDB

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/groue/GRDB.swift",
-            exact: "6.29.1"
+            .upToNextMinor(from: "6.29.1")
         )
     ],
     targets: [


### PR DESCRIPTION
# Overview
We are updating the dependency requirement for `GRDB` from a fixed version to `.upToNextMinor`, specifically allowing any patch within the `6.29.x` range. This adjustment ensures greater flexibility and compatibility for our SDK when integrated into environments where other applications or SDKs might be using different patch versions of `GRDB`. By allowing patch updates, we allow users to adopt the latest bug fixes and performance improvements while minimizing dependency conflicts.