### PR TITLE
Improvements during startup

### DIFF
--- a/Sources/EmbraceCore/Capture/CaptureServices.swift
+++ b/Sources/EmbraceCore/Capture/CaptureServices.swift
@@ -70,11 +70,16 @@ final class CaptureServices {
         NotificationCenter.default.removeObserver(self)
     }
 
-    func start() {
+    func install() {
         crashReporter?.install(context: context, logger: Embrace.logger)
 
         for service in services {
             service.install(otel: Embrace.client, logger: Embrace.logger)
+        }
+    }
+
+    func start() {
+        for service in services {
             service.start()
         }
     }

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -203,9 +203,12 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
                 started = true
 
                 sessionLifecycle.start()
-                captureServices.start()
+                captureServices.install()
 
                 processingQueue.async { [weak self] in
+
+                    self?.captureServices.start()
+
                     // fetch crash reports and link them to sessions
                     // then upload them
                     UnsentDataHandler.sendUnsentData(

--- a/Tests/TestSupport/Mocks/MockEmbraceConfigurable.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceConfigurable.swift
@@ -92,11 +92,11 @@ public class MockEmbraceConfigurable: EmbraceConfigurable {
         }
     }
 
-    public let updateExpectation = XCTestExpectation(description: "update called")
+    public var updateCallCount = 0
     public var updateCompletionParamDidUpdate: Bool
     public var updateCompletionParamError: Error?
     public func update(completion: @escaping (Bool, (any Error)?) -> Void) {
-        updateExpectation.fulfill()
+        updateCallCount += 1
         completion(updateCompletionParamDidUpdate, updateCompletionParamError)
     }
 }


### PR DESCRIPTION
* Improves `Embrace.setup` by 10ms-20ms
  - `EmbraceConfig` was unintentionally doing some stuff on the main thread. It is now being dispatched async on a different queue.

* Improves `Embrace.start` by 10ms-20ms
  - I split `CaptureServices.start` into 2 methods. Only the `install` needed to be done on the main thread.

* Fixes the remote config being fetched twice on startup.
