### PR TITLE
Fixing `LogLevel` visibility

### DIFF
--- a/Sources/EmbraceCommonInternal/InternalLogger.swift
+++ b/Sources/EmbraceCommonInternal/InternalLogger.swift
@@ -4,36 +4,7 @@
 
 import Foundation
 
-/// Levels ordered by severity
-@objc public enum LogLevel: Int {
-    case none
-    case trace
-    case debug
-    case info
-    case warning
-    case error
-
-    #if DEBUG
-    public static let `default`: LogLevel = .debug
-    #else
-    public static let `default`: LogLevel = .error
-    #endif
-
-    public var severity: LogSeverity {
-        switch self {
-        case .trace: return LogSeverity.trace
-        case .debug: return LogSeverity.debug
-        case .info: return LogSeverity.info
-        case .warning: return LogSeverity.warn
-        default: return LogSeverity.error
-        }
-    }
-}
-
 @objc public protocol InternalLogger: AnyObject {
-    @discardableResult @objc func log(level: LogLevel, message: String, attributes: [String: String]) -> Bool
-    @discardableResult @objc func log(level: LogLevel, message: String) -> Bool
-
     @discardableResult @objc func trace(_ message: String, attributes: [String: String]) -> Bool
     @discardableResult @objc func trace(_ message: String) -> Bool
 

--- a/Sources/EmbraceCore/Public/LogLevel.swift
+++ b/Sources/EmbraceCore/Public/LogLevel.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import EmbraceCommonInternal
+
+/// Levels ordered by severity
+@objc public enum LogLevel: Int {
+    case none
+    case trace
+    case debug
+    case info
+    case warning
+    case error
+
+    #if DEBUG
+    public static let `default`: LogLevel = .debug
+    #else
+    public static let `default`: LogLevel = .error
+    #endif
+
+    var severity: LogSeverity {
+        switch self {
+        case .trace: return LogSeverity.trace
+        case .debug: return LogSeverity.debug
+        case .info: return LogSeverity.info
+        case .warning: return LogSeverity.warn
+        default: return LogSeverity.error
+        }
+    }
+}

--- a/Tests/TestSupport/Mocks/MockLogger.swift
+++ b/Tests/TestSupport/Mocks/MockLogger.swift
@@ -2,6 +2,7 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceCore
 import EmbraceCommonInternal
 
 public class MockLogger: InternalLogger {


### PR DESCRIPTION
So users don't have to import `EmbraceCommonInternal` to use it.