### PR TITLE
Fix flakyness in tests

### DIFF
--- a/Sources/EmbraceCommonInternal/Protocols/DispatchableQueue.swift
+++ b/Sources/EmbraceCommonInternal/Protocols/DispatchableQueue.swift
@@ -1,0 +1,16 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+public protocol DispatchableQueue: AnyObject {
+    func async(_ block: @escaping () -> Void)
+    func sync(execute block: () -> Void)
+}
+
+extension DispatchQueue: DispatchableQueue {
+    public func async(_ block: @escaping () -> Void) {
+        async(group: nil, execute: block)
+    }
+}

--- a/Sources/EmbraceConfigInternal/EmbraceConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfig.swift
@@ -20,19 +20,20 @@ public class EmbraceConfig {
 
     let configurable: EmbraceConfigurable
 
-    let queue: DispatchQueue
+    let queue: DispatchableQueue
 
     public init(
         configurable: EmbraceConfigurable,
         options: Options,
         notificationCenter: NotificationCenter,
-        logger: InternalLogger
+        logger: InternalLogger,
+        queue: DispatchableQueue = DispatchQueue(label: "com.embrace.config", attributes: .concurrent)
     ) {
         self.options = options
         self.notificationCenter = notificationCenter
         self.logger = logger
         self.configurable = configurable
-        self.queue = DispatchQueue(label: "com.embrace.config", attributes: .concurrent)
+        self.queue = queue
 
         update()
 

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -31,11 +31,11 @@ protocol URLSessionTaskHandlerDataSource: AnyObject {
 final class DefaultURLSessionTaskHandler: URLSessionTaskHandler {
 
     private var spans: [URLSessionTask: Span] = [:]
-    private let queue: DispatchQueue
+    private let queue: DispatchableQueue
     private let payloadCaptureHandler: NetworkPayloadCaptureHandler
     weak var dataSource: URLSessionTaskHandlerDataSource?
 
-    init(processingQueue: DispatchQueue = DefaultURLSessionTaskHandler.queue(),
+    init(processingQueue: DispatchableQueue = DefaultURLSessionTaskHandler.queue(),
          dataSource: URLSessionTaskHandlerDataSource?) {
         self.queue = processingQueue
         self.dataSource = dataSource
@@ -213,7 +213,7 @@ final class DefaultURLSessionTaskHandler: URLSessionTaskHandler {
 }
 
 private extension DefaultURLSessionTaskHandler {
-    static func queue() -> DispatchQueue {
-        .init(label: "com.embrace.URLSessionTaskHandler", qos: .utility)
+    static func queue() -> DispatchableQueue {
+        DispatchQueue(label: "com.embrace.URLSessionTaskHandler", qos: .utility)
     }
 }

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigTests.swift
@@ -19,7 +19,8 @@ final class EmbraceConfigTests: XCTestCase {
             configurable: configurable,
             options: options,
             notificationCenter: .default,
-            logger: MockLogger()
+            logger: MockLogger(),
+            queue: MockQueue()
         )
     }
 

--- a/Tests/EmbraceCoreTests/Capture/Network/DefaultURLSessionTaskHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DefaultURLSessionTaskHandlerTests.swift
@@ -207,7 +207,7 @@ class DefaultURLSessionTaskHandlerTests: XCTestCase {
 private extension DefaultURLSessionTaskHandlerTests {
     func givenTaskHandler() {
         dataSource.state = .active
-        sut = DefaultURLSessionTaskHandler(dataSource: dataSource)
+        sut = DefaultURLSessionTaskHandler(processingQueue: MockQueue(), dataSource: dataSource)
     }
 
     func givenStateChanged(toState: CaptureServiceState) {

--- a/Tests/TestSupport/Mocks/MockQueue.swift
+++ b/Tests/TestSupport/Mocks/MockQueue.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceCommonInternal
+
+public class MockQueue: DispatchableQueue {
+    public func async(_ block: @escaping () -> Void) {
+        block()
+    }
+
+    public func sync(execute block: () -> Void) {
+        block()
+    }
+
+    public init() {}
+}


### PR DESCRIPTION
# Overview
Added `DispatchableQueue` protocol to abstract `DispatchQueue` and make it easy to mock. In that way, everything runs sync and doesn't depends on the actual behavior of `DispatchQueue`s.
