### PR TITLE
Delete extra EmbraceObjCUtilsInternal module.modulemap file

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/module.modulemap
+++ b/Sources/EmbraceObjCUtilsInternal/module.modulemap
@@ -1,4 +1,0 @@
-module EmbraceObjCUtilsInternal {
-    umbrella "./include"
-    export *
-}


### PR DESCRIPTION
## Checklist

Remove extra modulemap file.

Swift Package Manager only searches for modulemap files for library targets inside the `include/` folder.

This file is not being used anywhere and fails to build when using auxiliary tools like `rules_swift_package_manager` that translates SPM target description into Bazel BUILD files

- [x] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
