### PR TITLE
Fixing network payload rules parsing

### DIFF
--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -42,7 +42,7 @@ public struct RemoteConfigPayload: Decodable, Equatable {
             case error
         }
 
-        case networkPayLoadCapture = "network_payload_capture"
+        case networkPayLoadCapture = "network_capture"
     }
 
     public init(from decoder: Decoder) throws {

--- a/Sources/EmbraceConfiguration/NetworkPayloadCaptureRule.swift
+++ b/Sources/EmbraceConfiguration/NetworkPayloadCaptureRule.swift
@@ -9,26 +9,28 @@ public final class NetworkPayloadCaptureRule: NSObject, Decodable {
     public let id: String
     public let urlRegex: String
     public let statusCodes: [Int]?
-    public let methods: [String]?
+    public let method: String?
     public let expiration: Double
     public let publicKey: String
 
     public var expirationDate: Date {
-        return Date(timeIntervalSince1970: expiration)
+        return creationDate.addingTimeInterval(expiration)
     }
+
+    private let creationDate: Date = Date()
 
     init(
         id: String,
         urlRegex: String,
         statusCodes: [Int]?,
-        methods: [String]?,
+        method: String?,
         expiration: Double,
         publicKey: String
     ) {
         self.id = id
         self.urlRegex = urlRegex
         self.statusCodes = statusCodes
-        self.methods = methods
+        self.method = method
         self.expiration = expiration
         self.publicKey = publicKey
     }
@@ -38,9 +40,9 @@ extension NetworkPayloadCaptureRule {
     enum CodingKeys: String, CodingKey {
         case id
         case urlRegex = "url"
-        case statusCodes = "status_code"
-        case methods = "method"
-        case expiration
+        case statusCodes = "status_codes"
+        case method
+        case expiration = "expires_in"
         case publicKey = "public_key"
     }
 }

--- a/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/URLSessionTaskCaptureRule.swift
+++ b/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/URLSessionTaskCaptureRule.swift
@@ -56,10 +56,8 @@ class URLSessionTaskCaptureRule {
         }
 
         // check that the method matches
-        if let methods = rule.methods {
-            guard methods.contains(method) else {
-                return false
-            }
+        guard let ruleMethod = rule.method, ruleMethod == method else {
+            return false
         }
 
         // check status codes

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfig/RemoteConfigPayloadTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfig/RemoteConfigPayloadTests.swift
@@ -48,14 +48,14 @@ class RemoteConfigPayloadTests: XCTestCase {
         let rule1 = payload.networkPayloadCaptureRules.first { $0.id == "rule1" }
         XCTAssertEqual(rule1!.urlRegex, "www.test.com/user/*")
         XCTAssertEqual(rule1!.statusCodes, [200, 201, 404, -1])
-        XCTAssertEqual(rule1!.methods, ["GET", "POST"])
+        XCTAssertEqual(rule1!.method, "GET")
         XCTAssertEqual(rule1!.expiration, 1723570602)
         XCTAssertEqual(rule1!.publicKey, "key")
 
         let rule2 = payload.networkPayloadCaptureRules.first { $0.id == "rule2" }
         XCTAssertEqual(rule2!.urlRegex, "www.test.com/test")
         XCTAssertNil(rule2!.statusCodes)
-        XCTAssertNil(rule2!.methods)
+        XCTAssertNil(rule2!.method)
         XCTAssertEqual(rule2!.expiration, 1723570602)
         XCTAssertEqual(rule2!.publicKey, "key")
     }

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
@@ -139,7 +139,7 @@ final class RemoteConfigTests: XCTestCase {
             id: "test1",
             urlRegex: "https://example.com/.*",
             statusCodes: [200],
-            methods: ["GET"],
+            method: "GET",
             expiration: 0,
             publicKey: ""
         )
@@ -148,7 +148,7 @@ final class RemoteConfigTests: XCTestCase {
             id: "test2",
             urlRegex: "https://test.com/.*",
             statusCodes: [404],
-            methods: ["GET"],
+            method: "GET",
             expiration: 0,
             publicKey: ""
         )

--- a/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
+++ b/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
@@ -13,27 +13,24 @@
         "warning": 40,
         "error": 50,
     },
-    "network_payload_capture": [
+    "network_capture": [
         {
             "id": "rule1",
             "url": "www.test.com/user/*",
-            "status_code": [
+            "status_codes": [
                 200,
                 201,
                 404,
                 -1
             ],
-            "method": [
-                "GET",
-                "POST"
-            ],
-            "expiration": 1723570602,
+            "method": "GET",
+            "expires_in": 1723570602,
             "public_key": "key"
         },
         {
             "id": "rule2",
             "url": "www.test.com/test",
-            "expiration": 1723570602,
+            "expires_in": 1723570602,
             "public_key": "key"
         },
     ]

--- a/Tests/EmbraceCoreTests/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandlerTests.swift
@@ -16,7 +16,7 @@ class NetworkPayloadCaptureHandlerTests: XCTestCase {
             id: "rule1",
             urlRegex: "www.test.com/user/*",
             statusCodes: [500],
-            methods: ["GET"],
+            method: "GET",
             expiration: 9999999999,
             publicKey: TestConstants.rsaSanitizedPublicKey
         ),
@@ -25,7 +25,7 @@ class NetworkPayloadCaptureHandlerTests: XCTestCase {
             id: "rule2",
             urlRegex: "www.test.com/test/*",
             statusCodes: [-1],
-            methods: ["POST"],
+            method: "POST",
             expiration: 9999999999,
             publicKey: TestConstants.rsaSanitizedPublicKey
         )

--- a/Tests/EmbraceCoreTests/Capture/Network/NetworkPayloadCapture/URLSessionTaskCaptureRuleTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/NetworkPayloadCapture/URLSessionTaskCaptureRuleTests.swift
@@ -15,7 +15,7 @@ class URLSessionTaskCaptureRuleTests: XCTestCase {
         id: "rule1",
         urlRegex: "www.test.com/user/*",
         statusCodes: [500],
-        methods: ["GET"],
+        method: "GET",
         expiration: 9999999999,
         publicKey: TestConstants.rsaSanitizedPublicKey
     )
@@ -24,7 +24,7 @@ class URLSessionTaskCaptureRuleTests: XCTestCase {
         id: "rule2",
         urlRegex: "www.test.com/test",
         statusCodes: [-1],
-        methods: ["POST"],
+        method: "POST",
         expiration: 9999999999,
         publicKey: TestConstants.rsaPublicKey
     )
@@ -33,7 +33,7 @@ class URLSessionTaskCaptureRuleTests: XCTestCase {
         id: "rule3",
         urlRegex: "www.test.com/test",
         statusCodes: [-1],
-        methods: ["POST"],
+        method: "POST",
         expiration: 1,
         publicKey: TestConstants.rsaSanitizedPublicKey
     )


### PR DESCRIPTION
It seems that the remote config API was never updated with the suggested changes for network payload capture.
This resulted in network capture rules not being parsed correctly on this version of the SDK.

This PR contains the necessary changes for us to parse the old payload.