### PR TITLE
Bump OpenTelemetry to new version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift",
       "state" : {
-        "revision" : "0dd37c4a14a6aeeb131eea40a13cb3832c7c6a97",
-        "version" : "1.10.1"
+        "revision" : "0cd4a4c041baead7f845325b86b57f3d1355e86b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",
-            exact: "1.10.1"
+            revision: "0cd4a4c041baead7f845325b86b57f3d1355e86b"
         ),
         .package(
             url: "https://github.com/groue/GRDB.swift",


### PR DESCRIPTION
# Overview
This [issue](https://github.com/embrace-io/embrace-apple-sdk/issues/116#issue-2630331627) led to the creation of a [fix](https://github.com/open-telemetry/opentelemetry-swift/pull/632) in `OpenTelemetrySdk`. This PR uses that specific commit/revision as a dependency until a new version of OTel is released.

Additionally, we modified the `build_dependencies` script to support building dependencies from revisions, branches, and versions extracted from `Package.resolved`.

Fixes #116 