### PR TITLE
Bump opentelemetry-swift to use 1.12.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift",
       "state" : {
-        "revision" : "0dd37c4a14a6aeeb131eea40a13cb3832c7c6a97",
-        "version" : "1.10.1"
+        "revision" : "f2315d8646432c02338960e85b5fe20417ad6d8d",
+        "version" : "1.12.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",
-            exact: "1.10.1"
+            exact: "1.12.1"
         ),
         .package(
             url: "https://github.com/groue/GRDB.swift",


### PR DESCRIPTION
# Overview
This https://github.com/embrace-io/embrace-apple-sdk/issues/116#issue-2630331627 led to the creation of a https://github.com/open-telemetry/opentelemetry-swift/pull/632 in `OpenTelemetrySdk`. 
This PR bumps the version to the latest one (1.12.1) which has that fix.

Fixes https://github.com/embrace-io/embrace-apple-sdk/issues/116