### PR TITLE
Fixed a bug preventing crashes from having session properties

### DIFF
--- a/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/DefaultInternalLogger.swift
@@ -126,7 +126,6 @@ class DefaultInternalLogger: InternalLogger {
 
         let attributes = attributesBuilder
             .addLogType(.internal)
-            .addApplicationProperties()
             .addApplicationState()
             .addSessionIdentifier()
             .build()

--- a/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
+++ b/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
@@ -28,8 +28,10 @@ class EmbraceLogAttributesBuilder {
 
     init(session: SessionRecord?,
          crashReport: CrashReport? = nil,
+         storage: EmbraceStorageMetadataFetcher? = nil,
          initialAttributes: [String: String]) {
         self.session = session
+        self.storage = storage
         self.crashReport = crashReport
         self.attributes = initialAttributes
     }

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -107,6 +107,7 @@ class UnsentDataHandler {
         // send otel log
         let attributes = createLogCrashAttributes(
             otel: otel,
+            storage: storage,
             report: report,
             session: session,
             timestamp: timestamp
@@ -149,6 +150,7 @@ class UnsentDataHandler {
 
     static private func createLogCrashAttributes(
         otel: EmbraceOpenTelemetry?,
+        storage: EmbraceStorage?,
         report: CrashReport,
         session: SessionRecord?,
         timestamp: Date
@@ -157,6 +159,7 @@ class UnsentDataHandler {
         let attributesBuilder = EmbraceLogAttributesBuilder(
             session: session,
             crashReport: report,
+            storage: storage,
             initialAttributes: [:]
         )
 


### PR DESCRIPTION
# Overview
Crash Reports should have the associated custom properties to the session span. However due tu a misconfiguration of the object that creates the attributes on the crash log, this was not happening.
This PR addresses that issue.