### PR TITLE
Make `RemoteConfigPayload` mapping more resilient

### DIFF
--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigFetcher.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigFetcher.swift
@@ -62,7 +62,7 @@ class RemoteConfigFetcher {
                 completion(payload)
             } catch {
                 self?.logger.error("Error decoding remote config:\n\(error.localizedDescription)")
-                // If it's a decoding issue, rather than returnin `nil`, we provide the default `RemoteConfigPayload`.
+                // if a decoding issue happens, instead of returning `nil`, we provide a default `RemoteConfigPayload`
                 completion(RemoteConfigPayload())
             }
         }

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigFetcher.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigFetcher.swift
@@ -62,7 +62,8 @@ class RemoteConfigFetcher {
                 completion(payload)
             } catch {
                 self?.logger.error("Error decoding remote config:\n\(error.localizedDescription)")
-                completion(nil)
+                // If it's a decoding issue, rather than returnin `nil`, we provide the default `RemoteConfigPayload`.
+                completion(RemoteConfigPayload())
             }
         }
 

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -124,10 +124,10 @@ public struct RemoteConfigPayload: Decodable, Equatable {
         }
 
         // network payload capture
-        networkPayloadCaptureRules = try rootContainer.decodeIfPresent(
+        networkPayloadCaptureRules = (try? rootContainer.decodeIfPresent(
             [NetworkPayloadCaptureRule].self,
             forKey: .networkPayLoadCapture
-        ) ?? defaultPayload.networkPayloadCaptureRules
+        )) ?? defaultPayload.networkPayloadCaptureRules
     }
 
     // defaults

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfig/RemoteConfigPayloadTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfig/RemoteConfigPayloadTests.swift
@@ -10,13 +10,14 @@ import TestSupport
 
 class RemoteConfigPayloadTests: XCTestCase {
 
-    func test_defaults() {
+    func testOnReceivingEmptyRemoteConfig_RemoteConfigPayload_shouldUseDefaultValues() throws {
         // given an empty remote config
-        let path = Bundle.module.path(forResource: "remote_config_empty", ofType: "json", inDirectory: "Fixtures")!
-        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+        let data = try getRemoteConfigData(forResource: "remote_config_empty")
+
+        // when decoding payload
+        let payload = try XCTUnwrap(try JSONDecoder().decode(RemoteConfigPayload.self, from: data))
 
         // then the default values are used
-        let payload = try! JSONDecoder().decode(RemoteConfigPayload.self, from: data)
         XCTAssertEqual(payload.sdkEnabledThreshold, 100)
         XCTAssertEqual(payload.backgroundSessionThreshold, 0)
         XCTAssertEqual(payload.networkSpansForwardingThreshold, 0)
@@ -28,13 +29,14 @@ class RemoteConfigPayloadTests: XCTestCase {
         XCTAssertEqual(payload.networkPayloadCaptureRules.count, 0)
     }
 
-    func test_values() {
+    func testOnHavingValidRemoteConfig_RemoteConfigPayload_shouldOverridedDefaultValuesWithProvidedOnes() throws {
         // given a valid remote config
-        let path = Bundle.module.path(forResource: "remote_config", ofType: "json", inDirectory: "Fixtures")!
-        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+        let data = try getRemoteConfigData(forResource: "remote_config")
+
+        // when decoding payload
+        let payload = try XCTUnwrap(try JSONDecoder().decode(RemoteConfigPayload.self, from: data))
 
         // then the values are correct
-        let payload = try! JSONDecoder().decode(RemoteConfigPayload.self, from: data)
         XCTAssertEqual(payload.sdkEnabledThreshold, 50)
         XCTAssertEqual(payload.backgroundSessionThreshold, 75)
         XCTAssertEqual(payload.networkSpansForwardingThreshold, 25)
@@ -58,6 +60,30 @@ class RemoteConfigPayloadTests: XCTestCase {
         XCTAssertNil(rule2!.method)
         XCTAssertEqual(rule2!.expiration, 1723570602)
         XCTAssertEqual(rule2!.publicKey, "key")
+    }
+
+    func test_onHavingOldAndInvalidRemoteConfigPayload_RemoteConfigPayload_shouldBeCreatedWithDefaults() throws {
+        // given an invalid remote config
+        let data = try getRemoteConfigData(forResource: "invalid_remote_config")
+
+        // when decoding payload
+        let payload = try XCTUnwrap(try JSONDecoder().decode(RemoteConfigPayload.self, from: data))
+
+        // then the default values are used
+        XCTAssertEqual(payload.sdkEnabledThreshold, 100)
+        XCTAssertEqual(payload.backgroundSessionThreshold, 0)
+        XCTAssertEqual(payload.networkSpansForwardingThreshold, 0)
+        XCTAssertEqual(payload.internalLogsTraceLimit, 0)
+        XCTAssertEqual(payload.internalLogsDebugLimit, 0)
+        XCTAssertEqual(payload.internalLogsInfoLimit, 0)
+        XCTAssertEqual(payload.internalLogsWarningLimit, 0)
+        XCTAssertEqual(payload.internalLogsErrorLimit, 3)
+        XCTAssertEqual(payload.networkPayloadCaptureRules.count, 0)
+    }
+
+    func getRemoteConfigData(forResource resource: String) throws -> Data {
+        let path = try XCTUnwrap(Bundle.module.path(forResource: resource, ofType: "json", inDirectory: "Fixtures"))
+        return try XCTUnwrap(Data(contentsOf: URL(fileURLWithPath: path)))
     }
 }
 

--- a/Tests/EmbraceConfigInternalTests/Fixtures/invalid_remote_config.json
+++ b/Tests/EmbraceConfigInternalTests/Fixtures/invalid_remote_config.json
@@ -1,0 +1,40 @@
+{
+    "background": {
+        "thresholdsdasd": 0,
+        "offset": 0,
+        "mode": "full",
+        "limit": 10,
+        "interval_limit": 1000
+    },
+    "threshHold": 50,
+    "network_span_forwarding": {
+        "extra_key_pct_enabled": 25
+    },
+    "internal_log_limits": {
+        "traece": 10,
+        "debugg": 20,
+        "infiio": 30,
+        "warnifesng": 40,
+        "erroasr": 50,
+    },
+    "network_capture": [
+        {
+            "id": "1cd3e74437604d29954b45ab1d7ce016",
+            "url": "embrace-echo-api.herokuapp.com/.*/task",
+            "method": "GET",
+            "status_codes": [
+                200
+            ],
+            "duration": 2000,
+            "expires_in": 86400,
+            "max_size": 1024,
+            "max_count": 100
+        }
+    ],
+    "session_control": {
+        "enable": true
+    },
+    "console_logs": {
+        "cl": 100
+    }
+}


### PR DESCRIPTION
# Overview
There's a possibility of receiving outdated `NetworkBodyCapture` rules, which would cause the decoding of `RemoteConfigPayload` to fail.
This PR improves the resilience of the decoding process. Additionally, in cases where a decoding issue cannot be avoided/prevent (either now, or in the future), we'll use the default values.