### PR TITLE
[EMBR-5543] Span auto termination

### DIFF
--- a/Sources/EmbraceCaptureService/CaptureService.swift
+++ b/Sources/EmbraceCaptureService/CaptureService.swift
@@ -96,7 +96,7 @@ extension CaptureService {
             return nil
         }
 
-        return otel?.buildSpan(name: name, type: type, attributes: attributes)
+        return otel?.buildSpan(name: name, type: type, attributes: attributes, autoTerminationCode: nil)
     }
 
     /// Adds the given event to the session.

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -103,7 +103,8 @@ final class DefaultURLSessionTaskHandler: URLSessionTaskHandler {
             let networkSpan = otel.buildSpan(
                 name: name,
                 type: .networkRequest,
-                attributes: attributes
+                attributes: attributes,
+                autoTerminationCode: nil
             )
 
             // This should be modified if we start doing this for streaming tasks.

--- a/Sources/EmbraceCore/Capture/UX/View/Protocols/CaptureServices+UIViewController.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/Protocols/CaptureServices+UIViewController.swift
@@ -63,7 +63,12 @@ extension CaptureServices {
             throw parentSpanNotFoundError
         }
 
-        guard let builder = viewCaptureService.otel?.buildSpan(name: name, type: type, attributes: attributes) else {
+        guard let builder = viewCaptureService.otel?.buildSpan(
+            name: name, 
+            type: type,
+            attributes: attributes,
+            autoTerminationCode: nil
+        ) else {
             return nil
         }
 
@@ -88,7 +93,12 @@ extension CaptureServices {
             throw parentSpanNotFoundError
         }
 
-        guard let builder = viewCaptureService.otel?.buildSpan(name: name, type: type, attributes: attributes) else {
+        guard let builder = viewCaptureService.otel?.buildSpan(
+            name: name,
+            type: type,
+            attributes: attributes,
+            autoTerminationCode: nil
+        ) else {
             return
         }
 

--- a/Sources/EmbraceCore/Capture/UX/View/UIViewControllerHandler.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/UIViewControllerHandler.swift
@@ -322,7 +322,9 @@ class UIViewControllerHandler {
             attributes: [
                 SpanSemantics.View.keyViewTitle: vc.emb_viewName,
                 SpanSemantics.View.keyViewName: vc.className
-            ])
+            ],
+            autoTerminationCode: nil
+        )
 
         if let parent = parent {
             builder.setParent(parent)

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -162,6 +162,9 @@ class SessionController: SessionControllable {
             }
             // -
 
+            // auto terminate spans
+            EmbraceOTel.processor?.autoTerminateSpans()
+
             // post notification
             notificationCenter.post(name: .embraceSessionWillEnd, object: currentSession)
 

--- a/Sources/EmbraceOTelInternal/EmbraceOTel.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOTel.swift
@@ -14,6 +14,8 @@ public final class EmbraceOTel: NSObject {
     let instrumentationName = "EmbraceOpenTelemetry"
     let instrumentationVersion = "semver:\(EmbraceMeta.sdkVersion)"
 
+    public private(set) static var processor: SingleSpanProcessor?
+
     /// Setup the OpenTelemetryApi
     /// - Parameter: spanProcessor The processor in which to run during the lifetime of each Span
     public static func setup(spanProcessors: [SpanProcessor]) {
@@ -24,6 +26,8 @@ public final class EmbraceOTel: NSObject {
                 spanProcessors: spanProcessors
             )
         )
+
+        processor = spanProcessors.first(where: { $0 is SingleSpanProcessor }) as? SingleSpanProcessor
     }
 
     public static func setup(logSharedState: EmbraceLogSharedState) {

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -5,11 +5,14 @@
 import Foundation
 import OpenTelemetryApi
 import EmbraceCommonInternal
+import EmbraceSemantics
 
 public protocol EmbraceOpenTelemetry: AnyObject {
     func buildSpan(name: String,
                    type: SpanType,
-                   attributes: [String: String]) -> SpanBuilder
+                   attributes: [String: String],
+                   autoTerminationCode: SpanErrorCode?
+    ) -> SpanBuilder
 
     func recordCompletedSpan(
         name: String,
@@ -19,7 +22,7 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         endTime: Date,
         attributes: [String: String],
         events: [RecordingSpanEvent],
-        errorCode: ErrorCode?
+        errorCode: SpanErrorCode?
     )
 
     func add(events: [SpanEvent])

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/Span+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/Span+Embrace.swift
@@ -21,11 +21,11 @@ extension Span {
         setAttribute(key: SpanSemantics.keyIsPrivateSpan, value: "true")
     }
 
-    public func end(errorCode: ErrorCode? = nil, time: Date = Date()) {
+    public func end(errorCode: SpanErrorCode? = nil, time: Date = Date()) {
         end(error: nil, errorCode: errorCode, time: time)
     }
 
-    public func end(error: Error?, errorCode: ErrorCode? = nil, time: Date = Date()) {
+    public func end(error: Error?, errorCode: SpanErrorCode? = nil, time: Date = Date()) {
         var errorCode = errorCode
 
         // get attributes from error

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/SpanData+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/Span/SpanData+Embrace.swift
@@ -20,11 +20,11 @@ extension SpanData {
         return .performance
     }
 
-    var errorCode: ErrorCode? {
+    var errorCode: SpanErrorCode? {
         guard let value = attributes[SpanSemantics.keyErrorCode] else {
             return nil
         }
-        return ErrorCode(rawValue: value.description)
+        return SpanErrorCode(rawValue: value.description)
     }
 
     public func toJSON() throws -> Data {

--- a/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/SpanBuilder/SpanBuilder+Embrace.swift
+++ b/Sources/EmbraceOTelInternal/Trace/EmbraceSemantics/SpanBuilder/SpanBuilder+Embrace.swift
@@ -22,7 +22,7 @@ extension SpanBuilder {
         return self
     }
 
-    @discardableResult public func error(errorCode: ErrorCode) -> Self {
+    @discardableResult public func error(errorCode: SpanErrorCode) -> Self {
         setAttribute(key: SpanSemantics.keyErrorCode, value: errorCode.rawValue)
     }
 

--- a/Sources/EmbraceOTelInternal/Trace/Tracer/Span/Processor/SingleSpanProcessor.swift
+++ b/Sources/EmbraceOTelInternal/Trace/Tracer/Span/Processor/SingleSpanProcessor.swift
@@ -5,19 +5,38 @@
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
+import EmbraceSemantics
+import EmbraceCommonInternal
 
 /// A really simple implementation of the SpanProcessor that converts the ExportableSpan to SpanData
 /// and passes it to the configured exporter in both `onStart` and `onEnd`
-public struct SingleSpanProcessor: SpanProcessor {
+public class SingleSpanProcessor: SpanProcessor {
 
     let spanExporter: SpanExporter
     private let processorQueue = DispatchQueue(label: "io.embrace.spanprocessor", qos: .utility)
+
+    @ThreadSafe var autoTerminationSpans: [String: ReadableSpan] = [:]
 
     /// Returns a new SingleSpanProcessor that converts spans to SpanData and forwards them to
     /// the given spanExporter.
     /// - Parameter spanExporter: the SpanExporter to where the Spans are pushed.
     public init(spanExporter: SpanExporter) {
         self.spanExporter = spanExporter
+    }
+
+    public func autoTerminateSpans() {
+        for span in autoTerminationSpans.values {
+            let data = span.toSpanData()
+            guard let errorCode = data.attributes[SpanSemantics.keyAutoTerminationCode]?.description else {
+                continue
+            }
+
+            span.setAttribute(key: SpanSemantics.keyErrorCode, value: errorCode)
+            span.status = .error(description: errorCode)
+            span.end()
+        }
+
+        autoTerminationSpans.removeAll()
     }
 
     public let isStartRequired: Bool = true
@@ -29,14 +48,17 @@ public struct SingleSpanProcessor: SpanProcessor {
 
         let data = span.toSpanData()
 
+        // cache if flagged for auto termination
+        if data.attributes[SpanSemantics.keyAutoTerminationCode] != nil {
+            autoTerminationSpans[span.autoTerminationKey] = span
+        }
+
         processorQueue.async {
             _ = exporter.export(spans: [data])
         }
     }
 
     public func onEnd(span: OpenTelemetrySdk.ReadableSpan) {
-        let exporter = self.spanExporter
-
         var data = span.toSpanData()
         if data.hasEnded && data.status == .unset {
             if let errorCode = data.errorCode {
@@ -47,7 +69,20 @@ public struct SingleSpanProcessor: SpanProcessor {
         }
 
         processorQueue.async {
-            _ = exporter.export(spans: [data])
+            _ = self.spanExporter.export(spans: [data])
+        }
+    }
+
+    public func flush(span: OpenTelemetrySdk.ReadableSpan) {
+        let data = span.toSpanData()
+
+        // update cache if needed
+        if data.attributes[SpanSemantics.keyAutoTerminationCode] != nil {
+            autoTerminationSpans[span.autoTerminationKey] = span
+        }
+
+        processorQueue.sync {
+            _ = self.spanExporter.export(spans: [data])
         }
     }
 
@@ -59,5 +94,11 @@ public struct SingleSpanProcessor: SpanProcessor {
         processorQueue.sync {
             spanExporter.shutdown()
         }
+    }
+}
+
+extension Span {
+    var autoTerminationKey: String {
+        context.traceId.hexString + "_" + context.spanId.hexString
     }
 }

--- a/Sources/EmbraceSemantics/Span/SpanErrorCode.swift
+++ b/Sources/EmbraceSemantics/Span/SpanErrorCode.swift
@@ -3,7 +3,7 @@
 //
 
 /// Embrace specific error status for spans
-public enum ErrorCode: String {
+public enum SpanErrorCode: String {
     /// Span ended in an expected, but less than optimal state
     case failure
 

--- a/Sources/EmbraceSemantics/Span/SpanSemantics.swift
+++ b/Sources/EmbraceSemantics/Span/SpanSemantics.swift
@@ -10,4 +10,6 @@ public struct SpanSemantics {
 
     public static let keyNSErrorMessage = "error.message"
     public static let keyNSErrorCode = "error.code"
+
+    public static let keyAutoTerminationCode = "emb.auto_termination.code"
 }

--- a/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
@@ -28,8 +28,9 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
     public func buildSpan(
         name: String,
         type: SpanType,
-        attributes: [String: String]) -> SpanBuilder {
-
+        attributes: [String: String] = [:],
+        autoTerminationCode: SpanErrorCode? = nil
+    ) -> SpanBuilder {
         return EmbraceOTel()
             .buildSpan(name: name, type: type, attributes: attributes)
     }
@@ -42,7 +43,7 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
         endTime: Date,
         attributes: [String: String],
         events: [RecordingSpanEvent],
-        errorCode: ErrorCode? ) {
+        errorCode: SpanErrorCode? ) {
 
     }
 


### PR DESCRIPTION
This PR adds a new parameter `autoTerminationCode` to the `buildSpan` public API.
This allows the user to preemptively define the `SpanErrorCode` that the span should be ended with if the span is still open when the current Embrace session ends.
If the parent of a span has an auto termination code, the child span will also be auto terminated.

Note: `ErrorCode` was renamed to `SpanErrorCode` and moved to `EmbraceSemantics`.