### PR TITLE
[EMBR-5747] Adding url ignore list to `URLSessionCaptureService`

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService+Options.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService+Options.swift
@@ -15,13 +15,18 @@ extension URLSessionCaptureService {
         /// before the Embrace SDK captures their data.
         @objc public let requestsDataSource: URLSessionRequestsDataSource?
 
-        @objc public init(injectTracingHeader: Bool, requestsDataSource: URLSessionRequestsDataSource?) {
+        /// List of urls to be ignored by this service.
+        /// Any request's url that contains any of these strings will not be captured.
+        @objc public let ignoredURLs: [String]
+
+        @objc public init(injectTracingHeader: Bool, requestsDataSource: URLSessionRequestsDataSource?, ignoredURLs: [String]) {
             self.injectTracingHeader = injectTracingHeader
             self.requestsDataSource = requestsDataSource
+            self.ignoredURLs = ignoredURLs
         }
 
         @objc public convenience override init() {
-            self.init(injectTracingHeader: true, requestsDataSource: nil)
+            self.init(injectTracingHeader: true, requestsDataSource: nil, ignoredURLs: [])
         }
     }
 }

--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
@@ -80,6 +80,10 @@ public final class URLSessionCaptureService: CaptureService, URLSessionTaskHandl
     var requestsDataSource: URLSessionRequestsDataSource? {
         return options.requestsDataSource
     }
+
+    var ignoredURLs: [String] {
+        return options.ignoredURLs
+    }
 }
 
 // swiftlint:disable line_length

--- a/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
@@ -46,7 +46,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         let builder = CaptureServiceBuilder()
 
         // when adding a URLSessionCaptureService with custom options
-        let options = URLSessionCaptureService.Options(injectTracingHeader: false, requestsDataSource: nil)
+        let options = URLSessionCaptureService.Options(injectTracingHeader: false, requestsDataSource: nil, ignoredURLs: [])
         builder.add(.urlSession(options: options))
 
         // when adding the defaults
@@ -117,7 +117,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         builder.add(.urlSession())
 
         // and then adding it again
-        let options = URLSessionCaptureService.Options(injectTracingHeader: false, requestsDataSource: nil)
+        let options = URLSessionCaptureService.Options(injectTracingHeader: false, requestsDataSource: nil, ignoredURLs: [])
         builder.add(.urlSession(options: options))
 
         // then the list contains the correct services
@@ -134,7 +134,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         let builder = CaptureServiceBuilder()
 
         // when adding a URLSessionCaptureService
-        let options = URLSessionCaptureService.Options(injectTracingHeader: false, requestsDataSource: nil)
+        let options = URLSessionCaptureService.Options(injectTracingHeader: false, requestsDataSource: nil, ignoredURLs: [])
         builder.add(.urlSession(options: options))
 
         // then the list contains the capture service


### PR DESCRIPTION
Can be configured through the string array `URLSessionCaptureService.Options.ignoredURLs`.
Any request pointing to an URL that contains any of the strings in that array will be ignored by the service.