### PR TITLE
Disabling memory termination feature from KSCrash

### DIFF
--- a/Examples/BombApp/BombApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/BombApp/BombApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "0468c294af9d271301bf8ad1942dc4aa3cf6ab08",
-        "version" : "2.0.6"
+        "revision" : "6ce425727d3895c14cd7ff839f788ccb2bcf4081",
+        "version" : "2.0.7"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift",
       "state" : {
-        "revision" : "0dd37c4a14a6aeeb131eea40a13cb3832c7c6a97",
-        "version" : "1.10.1"
+        "revision" : "f2315d8646432c02338960e85b5fe20417ad6d8d",
+        "version" : "1.12.1"
       }
     },
     {

--- a/Examples/DemoObjectiveC/DemoObjectiveC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/DemoObjectiveC/DemoObjectiveC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "0468c294af9d271301bf8ad1942dc4aa3cf6ab08",
-        "version" : "2.0.6"
+        "revision" : "6ce425727d3895c14cd7ff839f788ccb2bcf4081",
+        "version" : "2.0.7"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/open-telemetry/opentelemetry-swift",
       "state" : {
-        "revision" : "0dd37c4a14a6aeeb131eea40a13cb3832c7c6a97",
-        "version" : "1.10.1"
+        "revision" : "f2315d8646432c02338960e85b5fe20417ad6d8d",
+        "version" : "1.12.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/KSCrash.git",
       "state" : {
-        "revision" : "0468c294af9d271301bf8ad1942dc4aa3cf6ab08",
-        "version" : "2.0.6"
+        "revision" : "6ce425727d3895c14cd7ff839f788ccb2bcf4081",
+        "version" : "2.0.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     dependencies: [
         .package(
              url: "https://github.com/embrace-io/KSCrash.git",
-             exact: "2.0.6"
+             exact: "2.0.7"
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift",

--- a/Sources/EmbraceCrash/EmbraceCrashReporter.swift
+++ b/Sources/EmbraceCrash/EmbraceCrashReporter.swift
@@ -102,6 +102,7 @@ public final class EmbraceCrashReporter: NSObject, CrashReporter {
 
         let bundleName = context.appId ?? "default"
         ksCrash = KSCrash.sharedInstance(withBasePath: basePath, andBundleName: bundleName)
+        ksCrash?.reportsMemoryTerminations = false // this feature seems to have many issues, disabling it for now
 
         updateKSCrashInfo()
         ksCrash?.install()


### PR DESCRIPTION
Also bumped KSCrash to v2.0.7 which adds sanity checks for the reports timestamps