### PR TITLE
Fixed hangs on setting new deviceId on keychain using main thread

### DIFF
--- a/Sources/EmbraceCore/Utils/KeychainAccess.swift
+++ b/Sources/EmbraceCore/Utils/KeychainAccess.swift
@@ -31,17 +31,16 @@ class KeychainAccess {
 
         // generate new id
         let newId = UUID()
-        let status = keychain.setValue(
+        keychain.setValue(
             service: kEmbraceKeychainService as CFString,
             account: kEmbraceDeviceId as CFString,
-            value: newId.uuidString
-        )
-
-        if status != errSecSuccess {
-            if let err = SecCopyErrorMessageString(status, nil) {
-                Embrace.logger.error("Write failed: \(err)")
+            value: newId.uuidString) { status in
+                if status != errSecSuccess {
+                    if let err = SecCopyErrorMessageString(status, nil) {
+                        Embrace.logger.error("Write failed: \(err)")
+                    }
+                }
             }
-        }
 
         return newId
     }

--- a/Tests/EmbraceCoreTests/Utils/KeychainAccessTest.swift
+++ b/Tests/EmbraceCoreTests/Utils/KeychainAccessTest.swift
@@ -12,10 +12,10 @@ class AlwaysSuccessfulKeychainInterface: KeychainInterface {
     func valueFor(service: CFString, account: CFString) -> (value: String?, status: OSStatus) {
         return (value, errSecSuccess)
     }
-
-    func setValue(service: CFString, account: CFString, value: String) -> OSStatus {
+    
+    func setValue(service: CFString, account: CFString, value: String, completion: (OSStatus) -> Void) {
         self.value = value
-        return errSecSuccess
+        completion(errSecSuccess)
     }
 
     func deleteValue(service: CFString, account: CFString) -> OSStatus {


### PR DESCRIPTION
# Overview
This PR improves the `DefaultKeychainInterface` implementation by doing async keychain writes to prevent potential App Hangs.

## Details
In particular, the `setValue` method is now asynchronous, moving potentially blocking Keychain write operations (e.g. `SecItemAdd`) off the Main Thread.
This change prevents UI freezes and improves overall app responsiveness when doing `setup` on the EmbraceIO SDK