### PR TITLE
Attempt to fix `WKNavigationDelegateProxy` crash

### DIFF
--- a/Sources/EmbraceCore/Capture/PushNotifications/UNUserNotificationCenterDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/PushNotifications/UNUserNotificationCenterDelegateProxy.swift
@@ -6,7 +6,7 @@ import UserNotifications
 import EmbraceOTelInternal
 
 class UNUserNotificationCenterDelegateProxy: NSObject {
-    weak var originalDelegate: UNUserNotificationCenterDelegate?
+    var originalDelegate: UNUserNotificationCenterDelegate?
     let captureData: Bool
 
     init(captureData: Bool) {

--- a/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
@@ -7,7 +7,7 @@ import WebKit
 import EmbraceOTelInternal
 
 class WKNavigationDelegateProxy: NSObject {
-    weak var originalDelegate: WKNavigationDelegate?
+    var originalDelegate: WKNavigationDelegate?
 
     // callback triggered the webview loads an url or errors
     var callback: ((URL?, Int?) -> Void)?

--- a/Sources/EmbraceIO/Capture/CaptureServiceBuilder.swift
+++ b/Sources/EmbraceIO/Capture/CaptureServiceBuilder.swift
@@ -57,13 +57,6 @@ public class CaptureServiceBuilder: NSObject {
         }
 #endif
 
-#if canImport(WebKit)
-        // web view
-        if !services.contains(where: { $0 is WebViewCaptureService }) {
-            add(.webView())
-        }
-#endif
-
         // low memory
         if !services.contains(where: { $0 is LowMemoryWarningCaptureService }) {
             add(.lowMemoryWarning())

--- a/Tests/EmbraceCoreTests/Capture/UX/View/UIViewControllerHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/View/UIViewControllerHandlerTests.swift
@@ -172,7 +172,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         validateViewDidAppearSpans(vc: vc, parentName: parentName)
 
         // then all the spans are created and ended at the right times
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             return parent != nil && self.cacheIsEmpty()
         }
@@ -190,7 +190,7 @@ class UIViewControllerHandlerTests: XCTestCase {
 
         handler.onViewDidDisappear(vc)
 
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             return parent != nil && parent!.status.isError == true && self.cacheIsEmpty()
         }
@@ -208,7 +208,7 @@ class UIViewControllerHandlerTests: XCTestCase {
 
         handler.appDidEnterBackground()
 
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             return parent != nil && parent!.status.isError == true && self.cacheIsEmpty()
         }
@@ -238,7 +238,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewBecameInteractive(vc)
 
         // then the spans are ended
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             let uiReady = self.otel.spanProcessor.endedSpans.first(where: { $0.name == "ui-ready"})
 
@@ -260,7 +260,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         validateViewDidAppearSpans(vc: vc, parentName: parentName)
 
         // then the spans are ended
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             let uiReady = self.otel.spanProcessor.endedSpans.first(where: { $0.name == "ui-ready"})
 
@@ -280,7 +280,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewDidDisappear(vc)
 
         // then the spans are ended
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             return parent != nil && parent!.status.isError == true && self.cacheIsEmpty()
         }
@@ -299,7 +299,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.appDidEnterBackground()
 
         // then the spans are ended
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.endedSpans.first(where: { $0.name.contains(parentName) })
             return parent != nil && parent!.status.isError == true && self.cacheIsEmpty()
         }
@@ -310,7 +310,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewDidLoadStart(vc)
 
         // then spans are created
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.startedSpans.first(where: { $0.name.contains(parentName) })
             let child = self.otel.spanProcessor.startedSpans.first(where: { $0.name == "emb-view-did-load"})
 
@@ -321,7 +321,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewDidLoadEnd(vc)
 
         // then the view did load span is ended
-        wait {
+        wait(timeout: .longTimeout) {
             let span = self.otel.spanProcessor.startedSpans.first(where: { $0.name == "emb-view-did-load"})
             return span != nil && self.handler.viewDidLoadSpans.isEmpty
         }
@@ -332,7 +332,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewWillAppearStart(vc)
 
         // then a child span is created
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.startedSpans.first(where: { $0.name.contains(parentName) })
             let child = self.otel.spanProcessor.startedSpans.first(where: { $0.name == "emb-view-will-appear"})
 
@@ -343,7 +343,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewWillAppearEnd(vc)
 
         // then the view will appear span is ended
-        wait {
+        wait(timeout: .longTimeout) {
             let span = self.otel.spanProcessor.endedSpans.first(where: { $0.name == "emb-view-will-appear"})
             return span != nil && self.handler.viewWillAppearSpans.isEmpty
         }
@@ -354,7 +354,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewDidAppearStart(vc)
 
         // then a child span is created
-        wait {
+        wait(timeout: .longTimeout) {
             let parent = self.otel.spanProcessor.startedSpans.first(where: { $0.name.contains(parentName) })
             let child = self.otel.spanProcessor.startedSpans.first(where: { $0.name == "emb-view-did-appear"})
 
@@ -365,7 +365,7 @@ class UIViewControllerHandlerTests: XCTestCase {
         handler.onViewDidAppearEnd(vc)
 
         // then the view did appear span is ended
-        wait {
+        wait(timeout: .longTimeout) {
             let span = self.otel.spanProcessor.endedSpans.first(where: { $0.name == "emb-view-did-appear"})
             return span != nil && self.handler.viewDidAppearSpans.isEmpty
         }

--- a/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
@@ -29,10 +29,6 @@ class CaptureServiceBuilderTests: XCTestCase {
         XCTAssertNotNil(list.first(where: { $0 is TapCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is ViewCaptureService }))
 #endif
-#if canImport(WebKit)
-        count += 1
-        XCTAssertNotNil(list.first(where: { $0 is WebViewCaptureService }))
-#endif
 
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
@@ -61,10 +57,6 @@ class CaptureServiceBuilderTests: XCTestCase {
         count += 2
         XCTAssertNotNil(list.first(where: { $0 is TapCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is ViewCaptureService }))
-#endif
-#if canImport(WebKit)
-        count += 1
-        XCTAssertNotNil(list.first(where: { $0 is WebViewCaptureService }))
 #endif
 
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
@@ -97,16 +89,10 @@ class CaptureServiceBuilderTests: XCTestCase {
         // then the list contains the correct services
         let list = builder.build()
 
-        var count = 2
-
-#if canImport(WebKit)
-        count += 1
-        XCTAssertNotNil(list.first(where: { $0 is WebViewCaptureService }))
-#endif
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
 
-        XCTAssertEqual(list.count, count)
+        XCTAssertEqual(list.count, 2)
     }
 
     func test_replace() {


### PR DESCRIPTION
My suspicion is that the original delegate is being deallocated in between the `respondsTo` and `forwardingTarget` calls; which could result in the selector being called directly to the proxy causing an unrecognized selector crash.

This PR changes the `originalDelegate` property so it's retained by the proxy. 
I also updated the `UNUserNotificationCenterDelegateProxy` since it will probably run into the same issues.
Note that we were already doing this in the `URLSessionDelegateProxy` class.

Note: Also attempting to fix some flaky tests.