### PR TITLE
Change sdk enabled logic to mimic android and backend

### DIFF
--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -89,9 +89,6 @@ extension RemoteConfig: EmbraceConfigurable {
 
 extension RemoteConfig {
     func isEnabled(threshold: Float) -> Bool {
-        if (threshold <= 0 || threshold > 100) {
-            return false
-        }
         return Self.isEnabled(hexValue: deviceIdHexValue, digits: Self.deviceIdUsedDigits, threshold: threshold)
     }
 
@@ -108,6 +105,10 @@ extension RemoteConfig {
     ///  - digits: The number of digits used to calculate the total space. Must match the number of digits used to determine the hexValue
     ///  - threshold: The percentage threshold to test against. Values between 0.0 and 100.0
     static func isEnabled(hexValue: UInt64, digits: UInt, threshold: Float) -> Bool {
+        if threshold <= 0 || threshold > 100 {
+            return false
+        }
+
         let space = powf(16, Float(digits)) - 1
         let result = (Float(hexValue) / space) * 100
 

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -97,17 +97,17 @@ extension RemoteConfig {
     /// Determine the max value for the probability `space` by using the number of `digits` (16 ^ `n`)
     /// If the `hexValue` is within the `threshold`
     /// ```
-    /// space = 16^numDigits
-    /// result = (hexValue / space) * 100.0 < threshold
+    /// space = 16^numDigits - 1
+    /// result = (hexValue / space) * 100.0 <= threshold
     /// ```
     /// - Parameters:
     ///  - hexValue: The value to test
     ///  - digits: The number of digits used to calculate the total space. Must match the number of digits used to determine the hexValue
     ///  - threshold: The percentage threshold to test against. Values between 0.0 and 100.0
     static func isEnabled(hexValue: UInt64, digits: UInt, threshold: Float) -> Bool {
-        let space = powf(16, Float(digits))
+        let space = powf(16, Float(digits)) - 1
         let result = (Float(hexValue) / space) * 100
 
-        return result < threshold
+        return result <= threshold
     }
 }

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -89,6 +89,9 @@ extension RemoteConfig: EmbraceConfigurable {
 
 extension RemoteConfig {
     func isEnabled(threshold: Float) -> Bool {
+        if (threshold <= 0 || threshold > 100) {
+            return false
+        }
         return Self.isEnabled(hexValue: deviceIdHexValue, digits: Self.deviceIdUsedDigits, threshold: threshold)
     }
 


### PR DESCRIPTION
## Checklist

We want to have the exact same logic (than android and backend) to decide if the SDK is enabled or not.
The `- 1` is because otherwise you can never get a value of 100.

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
