### PR TITLE
[EMBR-5972] Removed DispatchQueue Extension (to confrom to DispatchableQueue)

### DIFF
--- a/Sources/EmbraceCommonInternal/Protocols/DispatchableQueue.swift
+++ b/Sources/EmbraceCommonInternal/Protocols/DispatchableQueue.swift
@@ -4,13 +4,37 @@
 
 import Foundation
 
-public protocol DispatchableQueue: AnyObject {
+public protocol DispatchableQueue {
     func async(_ block: @escaping () -> Void)
     func sync(execute block: () -> Void)
 }
 
-extension DispatchQueue: DispatchableQueue {
+public class DefaultDispatchableQueue: DispatchableQueue {
+    private let queue: DispatchQueue
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
     public func async(_ block: @escaping () -> Void) {
-        async(group: nil, execute: block)
+        queue.async(group: nil, execute: block)
+    }
+
+    public func sync(execute block: () -> Void) {
+        queue.sync(execute: block)
+    }
+    
+    public static func with(label: String) -> DispatchableQueue {
+        DefaultDispatchableQueue(queue: .init(label: label))
+    }
+}
+
+public extension DispatchableQueue where Self == DefaultDispatchableQueue {
+    static func with(
+        label: String,
+        qos: DispatchQoS = .unspecified,
+        attributes: DispatchQueue.Attributes = []
+    ) -> DispatchableQueue {
+        DefaultDispatchableQueue(queue: .init(label: label, qos: qos, attributes: attributes))
     }
 }

--- a/Sources/EmbraceConfigInternal/EmbraceConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfig.swift
@@ -27,7 +27,7 @@ public class EmbraceConfig {
         options: Options,
         notificationCenter: NotificationCenter,
         logger: InternalLogger,
-        queue: DispatchableQueue = DispatchQueue(label: "com.embrace.config", attributes: .concurrent)
+        queue: DispatchableQueue = .with(label: "com.embrace.config", attributes: .concurrent)
     ) {
         self.options = options
         self.notificationCenter = notificationCenter

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -235,6 +235,6 @@ final class DefaultURLSessionTaskHandler: URLSessionTaskHandler {
 
 private extension DefaultURLSessionTaskHandler {
     static func queue() -> DispatchableQueue {
-        DispatchQueue(label: "com.embrace.URLSessionTaskHandler", qos: .utility)
+        .with(label: "com.embrace.URLSessionTaskHandler", qos: .utility)
     }
 }

--- a/Sources/EmbraceCore/Capture/UX/View/UIViewControllerHandler.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/UIViewControllerHandler.swift
@@ -21,7 +21,7 @@ protocol UIViewControllerHandlerDataSource: AnyObject {
 class UIViewControllerHandler {
 
     weak var dataSource: UIViewControllerHandlerDataSource?
-    private let queue: DispatchableQueue = DispatchQueue(label: "com.embrace.UIViewControllerHandler", qos: .utility)
+    private let queue: DispatchableQueue = .with(label: "com.embrace.UIViewControllerHandler", qos: .utility)
 
     @ThreadSafe var parentSpans: [String: Span] = [:]
     @ThreadSafe var viewDidLoadSpans: [String: Span] = [:]

--- a/Sources/EmbraceCrash/EmbraceCrashReporter.swift
+++ b/Sources/EmbraceCrash/EmbraceCrashReporter.swift
@@ -56,7 +56,7 @@ public final class EmbraceCrashReporter: NSObject, CrashReporter {
     /// Unused in this KSCrash implementation
     public var onNewReport: ((CrashReport) -> Void)?
 
-    public init(queue: DispatchableQueue = DispatchQueue(label: "com.embrace.crashreporter"),
+    public init(queue: DispatchableQueue = .with(label: "com.embrace.crashreporter"),
                 signalsBlockList: [CrashSignal] = [.SIGTERM]
     ) {
         self.queue = queue


### PR DESCRIPTION
# Overview
When we make `DispatchQueue` conform to the `DispatchableQueue` protocol, it sometimes leads to collisions that the compiler cannot resolve unless the client imports Embrace. This is _undoubtedly not only unnecessary but also unexpected_.

This PR addresses the issue by removing that extension, meaning **`DispatchQueue` no longer conforms to `DispatchableQueue`**.

To maintain the flexibility of `DispatchableQueue`, a wrapper for `DispatchQueue` was created: **`DefaultDispatchableQueue`**, which does conform to `DispatchableQueue`. Additionally, convenience methods were added to simplify the creation of these queues.