### PR TITLE
Ensure thread safe access to `UIViewController` associated properties

### DIFF
--- a/Sources/EmbraceCore/Internal/SpanStorageExporter/Validation/Validators/LengthOfNameValidator.swift
+++ b/Sources/EmbraceCore/Internal/SpanStorageExporter/Validation/Validators/LengthOfNameValidator.swift
@@ -10,7 +10,7 @@ import EmbraceCommonInternal
 /// Validates the length of ``SpanData.name``.
 /// This compares the length of the String in characters, not bytes.
 class LengthOfNameValidator: SpanDataValidator {
-    private static let whitelist: [SpanType] = [.networkRequest, .view, .viewLoad]
+    private static let allowList: [SpanType] = [.networkRequest, .view, .viewLoad]
     let allowedCharacterCount: ClosedRange<Int>
 
     init(allowedCharacterCount: ClosedRange<Int> = 1...50) {
@@ -25,6 +25,6 @@ class LengthOfNameValidator: SpanDataValidator {
     }
 
     private func shouldValidate(data: SpanData) -> Bool {
-        return !LengthOfNameValidator.whitelist.contains(data.embType)
+        return !LengthOfNameValidator.allowList.contains(data.embType)
     }
 }

--- a/Sources/EmbraceCore/Internal/SpanStorageExporter/Validation/Validators/LengthOfNameValidator.swift
+++ b/Sources/EmbraceCore/Internal/SpanStorageExporter/Validation/Validators/LengthOfNameValidator.swift
@@ -5,11 +5,12 @@
 import EmbraceOTelInternal
 import EmbraceSemantics
 import OpenTelemetrySdk
+import EmbraceCommonInternal
 
-/// Validates the length of ``SpanData.name``. 
+/// Validates the length of ``SpanData.name``.
 /// This compares the length of the String in characters, not bytes.
 class LengthOfNameValidator: SpanDataValidator {
-
+    private static let whitelist: [SpanType] = [.networkRequest, .view, .viewLoad]
     let allowedCharacterCount: ClosedRange<Int>
 
     init(allowedCharacterCount: ClosedRange<Int> = 1...50) {
@@ -24,6 +25,6 @@ class LengthOfNameValidator: SpanDataValidator {
     }
 
     private func shouldValidate(data: SpanData) -> Bool {
-        return data.embType != .networkRequest
+        return !LengthOfNameValidator.whitelist.contains(data.embType)
     }
 }


### PR DESCRIPTION
# Overview
This PR addresses a potential crash caused by threading issues when accessing or modifying `UIViewController` properties using Objective-C runtime associations (`objc_setAssociatedObject` and `objc_getAssociatedObject`) on a background thread.

An example: when a `UIViewController` with a very short lifespan (like we observe on, for example `SwiftUI.UIKitNavigationController`) is being deallocated, we could be adding associated objects at the same time, leading to unsafe interactions with the Objective-C runtime. 

To prevent this, the code has been updated to ensure all accesses to `vc.emb_identifier` (a property backed by `objc_setAssociatedObject`) are performed on the main thread, ensuring the `UIViewController` is in the rendering process and not being deallocated.

## Extra
Found out that `LengthOfNameValidator` was preventing to push some `.viewLoad`/`.view` spans due to name length. We've added a whitelist to prevent this from happening.

