### PR TITLE
OTel Logs with file attachments

### DIFF
--- a/Sources/EmbraceCommonInternal/Protocols/DispatchableQueue.swift
+++ b/Sources/EmbraceCommonInternal/Protocols/DispatchableQueue.swift
@@ -23,7 +23,7 @@ public class DefaultDispatchableQueue: DispatchableQueue {
     public func sync(execute block: () -> Void) {
         queue.sync(execute: block)
     }
-    
+
     public static func with(label: String) -> DispatchableQueue {
         DefaultDispatchableQueue(queue: .init(label: label))
     }

--- a/Sources/EmbraceCore/Capture/UX/View/Protocols/CaptureServices+UIViewController.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/Protocols/CaptureServices+UIViewController.swift
@@ -64,7 +64,7 @@ extension CaptureServices {
         }
 
         guard let builder = viewCaptureService.otel?.buildSpan(
-            name: name, 
+            name: name,
             type: type,
             attributes: attributes,
             autoTerminationCode: nil

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -40,12 +40,17 @@ extension Embrace {
 
         let baseUrl = EMBDevice.isDebuggerAttached ? endpoints.developmentBaseURL : endpoints.baseURL
         guard let spansURL = URL.spansEndpoint(basePath: baseUrl),
-              let logsURL = URL.logsEndpoint(basePath: baseUrl) else {
+              let logsURL = URL.logsEndpoint(basePath: baseUrl),
+              let attachmentsURL = URL.attachmentsEndpoit(basePath: baseUrl) else {
             Embrace.logger.error("Failed to initialize endpoints!")
             return nil
         }
 
-        let uploadEndpoints = EmbraceUpload.EndpointOptions(spansURL: spansURL, logsURL: logsURL)
+        let uploadEndpoints = EmbraceUpload.EndpointOptions(
+            spansURL: spansURL,
+            logsURL: logsURL,
+            attachmentsURL: attachmentsURL
+        )
 
         // cache
         guard let cacheUrl = EmbraceFileSystem.uploadsDirectoryPath(

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -41,7 +41,7 @@ extension Embrace {
         let baseUrl = EMBDevice.isDebuggerAttached ? endpoints.developmentBaseURL : endpoints.baseURL
         guard let spansURL = URL.spansEndpoint(basePath: baseUrl),
               let logsURL = URL.logsEndpoint(basePath: baseUrl),
-              let attachmentsURL = URL.attachmentsEndpoit(basePath: baseUrl) else {
+              let attachmentsURL = URL.attachmentsEndpoint(basePath: baseUrl) else {
             Embrace.logger.error("Failed to initialize endpoints!")
             return nil
         }

--- a/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
+++ b/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
@@ -18,7 +18,7 @@ class EmbraceLogAttributesBuilder {
         session ?? sessionControllable?.currentSession
     }
 
-    init(storage: EmbraceStorageMetadataFetcher,
+    init(storage: EmbraceStorageMetadataFetcher?,
          sessionControllable: SessionControllable,
          initialAttributes: [String: String]) {
         self.storage = storage

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -31,14 +31,14 @@ class LogController: LogControllable {
     private weak var upload: EmbraceLogUploader?
     private weak var config: EmbraceConfig?
 
+    var otel: EmbraceOTelBridge = EmbraceOTel() // var so we can inject a mock for testing
+
     /// This will probably be injected eventually.
     /// For consistency, I created a constant
     static let maxLogsPerBatch: Int = 20
 
     static let attachmentLimit: Int = 5
     static let attachmentSizeLimit: Int = 1048576 // 1 MiB
-
-    var otel: EmbraceOTel { EmbraceOTel() }
 
     private var isSDKEnabled: Bool {
         guard let config = config else {
@@ -142,7 +142,7 @@ class LogController: LogControllable {
                         finalAttributes[LogSemantics.keyAttachmentErrorCode] = LogSemantics.attachmentFailedUpload
                     }
 
-                    self?.otel.log(message, severity: severity, attributes: finalAttributes)
+                    self?.otel.log(message, severity: severity, timestamp: timestamp, attributes: finalAttributes)
                 })
             }
         }
@@ -156,7 +156,7 @@ class LogController: LogControllable {
         }
 
         if send {
-            otel.log(message, severity: severity, attributes: finalAttributes)
+            otel.log(message, severity: severity, timestamp: timestamp, attributes: finalAttributes)
         }
     }
 }

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -20,6 +20,7 @@ protocol LogControllable: LogBatcherDelegate {
         attachment: Data?,
         attachmentId: String?,
         attachmentUrl: URL?,
+        attachmentSize: Int?,
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior
     )
@@ -80,6 +81,7 @@ class LogController: LogControllable {
         attachment: Data? = nil,
         attachmentId: String? = nil,
         attachmentUrl: URL? = nil,
+        attachmentSize: Int? = nil,
         attributes: [String: String] = [:],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
@@ -153,6 +155,10 @@ class LogController: LogControllable {
 
             finalAttributes[LogSemantics.keyAttachmentId] = attachmentId
             finalAttributes[LogSemantics.keyAttachmentUrl] = attachmentUrl.absoluteString
+
+            if let attachmentSize = attachmentSize {
+                finalAttributes[LogSemantics.keyAttachmentSize] = String(attachmentSize)
+            }
         }
 
         if send {

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -112,10 +112,10 @@ class LogController: LogControllable {
             .addSessionIdentifier()
             .build()
 
-        var send = true
-
         // handle attachment data
         if let attachment = attachment {
+
+            sessionController.increaseAttachmentCount()
 
             let id = UUID().withoutHyphen
             finalAttributes[LogSemantics.keyAttachmentId] = id
@@ -134,18 +134,7 @@ class LogController: LogControllable {
 
             // upload attachment
             else {
-                send = false
-
-                upload?.uploadAttachment(id: id, data: attachment, completion: { [weak self] result in
-                    switch result {
-                    case .success:
-                        self?.sessionController?.increaseAttachmentCount()
-                    case .failure:
-                        finalAttributes[LogSemantics.keyAttachmentErrorCode] = LogSemantics.attachmentFailedUpload
-                    }
-
-                    self?.otel.log(message, severity: severity, timestamp: timestamp, attributes: finalAttributes)
-                })
+                upload?.uploadAttachment(id: id, data: attachment, completion: nil)
             }
         }
 
@@ -161,9 +150,7 @@ class LogController: LogControllable {
             }
         }
 
-        if send {
-            otel.log(message, severity: severity, timestamp: timestamp, attributes: finalAttributes)
-        }
+        otel.log(message, severity: severity, timestamp: timestamp, attributes: finalAttributes)
     }
 }
 

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -140,7 +140,7 @@ class LogController: LogControllable {
                     switch result {
                     case .success:
                         self?.sessionController?.increaseAttachmentCount()
-                    case .failure(_):
+                    case .failure:
                         finalAttributes[LogSemantics.keyAttachmentErrorCode] = LogSemantics.attachmentFailedUpload
                     }
 

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -8,9 +8,21 @@ import EmbraceUploadInternal
 import EmbraceCommonInternal
 import EmbraceSemantics
 import EmbraceConfigInternal
+import EmbraceOTelInternal
 
 protocol LogControllable: LogBatcherDelegate {
     func uploadAllPersistedLogs()
+    func createLog(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType,
+        timestamp: Date,
+        attachment: Data?,
+        attachmentId: String?,
+        attachmentUrl: URL?,
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior
+    )
 }
 
 class LogController: LogControllable {
@@ -18,9 +30,15 @@ class LogController: LogControllable {
     private weak var storage: Storage?
     private weak var upload: EmbraceLogUploader?
     private weak var config: EmbraceConfig?
+
     /// This will probably be injected eventually.
     /// For consistency, I created a constant
     static let maxLogsPerBatch: Int = 20
+
+    static let attachmentLimit: Int = 5
+    static let attachmentSizeLimit: Int = 1048576 // 1 MiB
+
+    var otel: EmbraceOTel { EmbraceOTel() }
 
     private var isSDKEnabled: Bool {
         guard let config = config else {
@@ -51,6 +69,94 @@ class LogController: LogControllable {
         } catch let exception {
             Error.couldntAccessBatches(reason: exception.localizedDescription).log()
             try? storage.removeAllLogs()
+        }
+    }
+
+    public func createLog(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType = .message,
+        timestamp: Date = Date(),
+        attachment: Data? = nil,
+        attachmentId: String? = nil,
+        attachmentUrl: URL? = nil,
+        attributes: [String: String] = [:],
+        stackTraceBehavior: StackTraceBehavior = .default
+    ) {
+        guard let sessionController = sessionController else {
+            return
+        }
+
+        // generate attributes
+        let attributesBuilder = EmbraceLogAttributesBuilder(
+            storage: storage,
+            sessionControllable: sessionController,
+            initialAttributes: attributes
+        )
+
+        /*
+         If we want to keep this method cleaner, we could move this log to `EmbraceLogAttributesBuilder`
+         However that would cause to always add a frame to the stacktrace.
+         */
+        if stackTraceBehavior == .default && (severity == .warn || severity == .error) {
+            let stackTrace: [String] = Thread.callStackSymbols
+            attributesBuilder.addStackTrace(stackTrace)
+        }
+
+        var finalAttributes = attributesBuilder
+            .addLogType(type)
+            .addApplicationState()
+            .addApplicationProperties()
+            .addSessionIdentifier()
+            .build()
+
+        var send = true
+
+        // handle attachment data
+        if let attachment = attachment {
+
+            let id = UUID().withoutHyphen
+            finalAttributes[LogSemantics.keyAttachmentId] = id
+
+            let size = attachment.count
+            finalAttributes[LogSemantics.keyAttachmentSize] = String(size)
+
+            // check attachment count limit
+            if sessionController.attachmentCount >= Self.attachmentLimit {
+                finalAttributes[LogSemantics.keyAttachmentErrorCode] = LogSemantics.attachmentLimitReached
+
+            // check attachment size limit
+            } else if size > Self.attachmentSizeLimit {
+                finalAttributes[LogSemantics.keyAttachmentErrorCode] = LogSemantics.attachmentTooLarge
+            }
+
+            // upload attachment
+            else {
+                send = false
+
+                upload?.uploadAttachment(id: id, data: attachment, completion: { [weak self] result in
+                    switch result {
+                    case .success:
+                        self?.sessionController?.increaseAttachmentCount()
+                    case .failure(_):
+                        finalAttributes[LogSemantics.keyAttachmentErrorCode] = LogSemantics.attachmentFailedUpload
+                    }
+
+                    self?.otel.log(message, severity: severity, attributes: finalAttributes)
+                })
+            }
+        }
+
+        // handle pre-uploaded attachment
+        else if let attachmentId = attachmentId,
+                let attachmentUrl = attachmentUrl {
+
+            finalAttributes[LogSemantics.keyAttachmentId] = attachmentId
+            finalAttributes[LogSemantics.keyAttachmentUrl] = attachmentUrl.absoluteString
+        }
+
+        if send {
+            otel.log(message, severity: severity, attributes: finalAttributes)
         }
     }
 }

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -159,6 +159,7 @@ extension Embrace: EmbraceOpenTelemetry {
             attachment: nil,
             attachmentId: nil,
             attachmentUrl: nil,
+            attachmentSize: nil,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior
         )
@@ -190,6 +191,7 @@ extension Embrace: EmbraceOpenTelemetry {
             attachment: attachment,
             attachmentId: nil,
             attachmentUrl: nil,
+            attachmentSize: nil,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior
         )
@@ -203,6 +205,7 @@ extension Embrace: EmbraceOpenTelemetry {
     ///   - timestamp: Timestamp for the log.
     ///   - attachmentId: Identifier of the attachment
     ///   - attachmentUrl: URL to dowload the attachment data
+    ///   - attachmentSize: Size of the attachment (optional)
     ///   - attributes: Attributes for the log.
     ///   - stackTraceBehavior: Defines if the stack trace information should be added to the log
     public func log(
@@ -212,6 +215,7 @@ extension Embrace: EmbraceOpenTelemetry {
         timestamp: Date = Date(),
         attachmentId: String,
         attachmentUrl: URL,
+        attachmentSize: Int? = nil,
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
@@ -223,6 +227,7 @@ extension Embrace: EmbraceOpenTelemetry {
             attachment: nil,
             attachmentId: attachmentId,
             attachmentUrl: attachmentUrl,
+            attachmentSize: attachmentSize,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior
         )

--- a/Sources/EmbraceCore/Session/SessionControllable.swift
+++ b/Sources/EmbraceCore/Session/SessionControllable.swift
@@ -20,4 +20,7 @@ protocol SessionControllable: AnyObject {
 
     func update(state: SessionState)
     func update(appTerminated: Bool)
+
+    var attachmentCount: Int { get }
+    func increaseAttachmentCount()
 }

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -261,7 +261,7 @@ extension SessionController {
         currentSession = nil
         currentSessionSpan = nil
     }
-    
+
     private var isSDKEnabled: Bool {
         guard let config = config else {
             return true

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -31,6 +31,9 @@ class SessionController: SessionControllable {
     @ThreadSafe
     private(set) var currentSessionSpan: Span?
 
+    @ThreadSafe
+    private(set) var attachmentCount: Int = 0
+
     // Lock used for session boundaries. Will be shared at both start/end of session
     private let lock = UnfairLock()
 
@@ -138,6 +141,7 @@ class SessionController: SessionControllable {
             NotificationCenter.default.post(name: .embraceSessionDidStart, object: session)
 
             firstSession = false
+            attachmentCount = 0
 
             return session
         }
@@ -221,6 +225,10 @@ class SessionController: SessionControllable {
         queue.async {
             UnsentDataHandler.sendSession(session, storage: storage, upload: upload)
         }
+    }
+
+    func increaseAttachmentCount() {
+        attachmentCount += 1
     }
 }
 

--- a/Sources/EmbraceCore/Utils/URL+Embrace.swift
+++ b/Sources/EmbraceCore/Utils/URL+Embrace.swift
@@ -18,4 +18,8 @@ extension URL {
     static func logsEndpoint(basePath: String) -> URL? {
         return endpoint(basePath: basePath, apiPath: "/v2/logs")
     }
+
+    static func attachmentsEndpoit(basePath: String) -> URL? {
+        return endpoint(basePath: basePath, apiPath: "/v2/attachments")
+    }
 }

--- a/Sources/EmbraceCore/Utils/URL+Embrace.swift
+++ b/Sources/EmbraceCore/Utils/URL+Embrace.swift
@@ -19,7 +19,7 @@ extension URL {
         return endpoint(basePath: basePath, apiPath: "/v2/logs")
     }
 
-    static func attachmentsEndpoit(basePath: String) -> URL? {
+    static func attachmentsEndpoint(basePath: String) -> URL? {
         return endpoint(basePath: basePath, apiPath: "/v2/attachments")
     }
 }

--- a/Sources/EmbraceOTelInternal/EmbraceOTel.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOTel.swift
@@ -54,22 +54,9 @@ public final class EmbraceOTel: NSObject {
             instrumentationVersion: instrumentationVersion
         )
     }
+}
 
-    // MARK: - Tracing
-
-    public func recordSpan<T>(
-        name: String,
-        type: SpanType,
-        attributes: [String: String] = [:],
-        spanOperation: () -> T
-    ) -> T {
-        let span = buildSpan(name: name, type: type, attributes: attributes)
-                        .startSpan()
-        let result = spanOperation()
-        span.end()
-
-        return result
-    }
+extension EmbraceOTel: EmbraceOTelBridge {
 
     public func buildSpan(
         name: String,
@@ -90,16 +77,6 @@ public final class EmbraceOTel: NSObject {
         return builder
     }
 
-    // MARK: - Logging
-
-    public func log(
-        _ message: String,
-        severity: LogSeverity,
-        attributes: [String: String]
-    ) {
-        log(message, severity: severity, timestamp: Date(), attributes: attributes)
-    }
-
     public func log(
         _ message: String,
         severity: LogSeverity,
@@ -117,4 +94,19 @@ public final class EmbraceOTel: NSObject {
             .setSeverity(Severity.fromLogSeverity(severity) ?? .info)
             .emit()
     }
+}
+
+public protocol EmbraceOTelBridge: AnyObject {
+    func buildSpan(
+        name: String,
+        type: SpanType,
+        attributes: [String: String]
+    ) -> SpanBuilder
+
+    func log(
+        _ message: String,
+        severity: LogSeverity,
+        timestamp: Date,
+        attributes: [String: String]
+    )
 }

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -63,6 +63,7 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         timestamp: Date,
         attachmentId: String,
         attachmentUrl: URL,
+        attachmentSize: Int?,
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior
     )

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -45,4 +45,25 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior
     )
+
+    func log(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType,
+        timestamp: Date,
+        attachment: Data,
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior
+    )
+
+    func log(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType,
+        timestamp: Date,
+        attachmentId: String,
+        attachmentUrl: URL,
+        attributes: [String: String],
+        stackTraceBehavior: StackTraceBehavior
+    )
 }

--- a/Sources/EmbraceOTelInternal/Trace/Tracer/Span/Processor/SingleSpanProcessor.swift
+++ b/Sources/EmbraceOTelInternal/Trace/Tracer/Span/Processor/SingleSpanProcessor.swift
@@ -50,7 +50,7 @@ public class SingleSpanProcessor: SpanProcessor {
             autoTerminationSpans[data.spanId] = SpanAutoTerminationData(
                 span: span,
                 spanData: data,
-                code: code, 
+                code: code,
                 parentId: data.parentSpanId
             )
         }

--- a/Sources/EmbraceSemantics/Logs/LogSemantics.swift
+++ b/Sources/EmbraceSemantics/Logs/LogSemantics.swift
@@ -19,6 +19,5 @@ public struct LogSemantics {
     public static let keyAttachmentErrorCode = "emb.attachment_error_code"
 
     public static let attachmentTooLarge = "ATTACHMENT_TOO_LARGE"
-    public static let attachmentFailedUpload = "UNSUCCESSFUL_UPLOAD"
     public static let attachmentLimitReached = "OVER_MAX_ATTACHMENTS"
 }

--- a/Sources/EmbraceSemantics/Logs/LogSemantics.swift
+++ b/Sources/EmbraceSemantics/Logs/LogSemantics.swift
@@ -12,4 +12,13 @@ public struct LogSemantics {
     public static let keySessionId = "session.id"
     public static let keyStackTrace = "emb.stacktrace.ios"
     public static let keyPropertiesPrefix = "emb.properties.%@"
+
+    public static let keyAttachmentId = "emb.attachment_id"
+    public static let keyAttachmentSize = "emb.attachment_size"
+    public static let keyAttachmentUrl = "emb.attachment_url"
+    public static let keyAttachmentErrorCode = "emb.attachment_error_code"
+
+    public static let attachmentTooLarge = "ATTACHMENT_TOO_LARGE"
+    public static let attachmentFailedUpload = "UNSUCCESSFUL_UPLOAD"
+    public static let attachmentLimitReached = "OVER_MAX_ATTACHMENTS"
 }

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -7,6 +7,7 @@ import EmbraceCommonInternal
 
 public protocol EmbraceLogUploader: AnyObject {
     func uploadLog(id: String, data: Data, completion: ((Result<(), Error>) -> Void)?)
+    func uploadAttachment(id: String, data: Data, completion: ((Result<(), Error>) -> Void)?)
 }
 
 /// Class in charge of uploading all the data collected by the Embrace SDK.
@@ -139,15 +140,30 @@ public class EmbraceUpload: EmbraceLogUploader {
         }
     }
 
+    /// Uploads the given attachment data
+    /// - Parameters:
+    ///   - id: Identifier of the attachment
+    ///   - data: The attachment's data
+    ///   - completion: Completion block called when the data is successfully cached, or when an `Error` occurs
+    public func uploadAttachment(id: String, data: Data, completion: ((Result<(), Error>) -> Void)?) {
+        queue.async { [weak self] in
+            self?.uploadData(
+                id: id,
+                data: data,
+                type: .attachment,
+                completion: completion
+            )
+        }
+    }
+
     // MARK: - Internal
     private func uploadData(
         id: String,
         data: Data,
         type: EmbraceUploadType,
         attemptCount: Int = 0,
-        retryCount: Int? = nil,
-        completion: ((Result<(), Error>) -> Void)?) {
-
+        completion: ((Result<(), Error>) -> Void)?) 
+    {
         // validate identifier
         guard id.isEmpty == false else {
             completion?(.failure(EmbraceUploadError.internalError(.invalidMetadata)))
@@ -161,42 +177,59 @@ public class EmbraceUpload: EmbraceLogUploader {
         }
 
         // cache operation
-        let cacheOperation = BlockOperation { [weak self] in
-            do {
-                try self?.cache.saveUploadData(id: id, type: type, data: data)
+        var cacheOperation: BlockOperation?
+
+        if type != .attachment {
+            cacheOperation = BlockOperation { [weak self] in
+                do {
+                    try self?.cache.saveUploadData(id: id, type: type, data: data)
                     completion?(.success(()))
-            } catch {
-                self?.logger.debug("Error caching upload data: \(error.localizedDescription)")
-                completion?(.failure(error))
+                } catch {
+                    self?.logger.debug("Error caching upload data: \(error.localizedDescription)")
+                    completion?(.failure(error))
+                }
             }
         }
 
         // upload operation
-        let uploadOperation = EmbraceUploadOperation(
-            urlSession: urlSession,
-            queue: queue,
-            metadataOptions: options.metadata,
-            endpoint: endpoint(for: type),
-            identifier: id,
+        let retryCount = type != .attachment ?
+            options.redundancy.automaticRetryCount :
+            options.redundancy.attachmentRetryCount
+
+        let uploadOperation = createUploadOperation(
+            id: id,
+            type: type,
+            urlSession: urlSession, 
             data: data,
-            retryCount: retryCount ?? options.redundancy.automaticRetryCount,
-            exponentialBackoffBehavior: options.redundancy.exponentialBackoffBehavior,
-            attemptCount: attemptCount,
-            logger: logger) { [weak self] (result, attemptCount) in
-                self?.queue.async { [weak self] in
+            retryCount: retryCount,
+            attemptCount: attemptCount) { [weak self] (result, attemptCount) in
+
+            self?.queue.async { [weak self] in
+
+                if type == .attachment {
+                    switch result {
+                    case .success: completion?(.success(()))
+                    case .failure(_): completion?(.failure(EmbraceUploadError.internalError(.attachmentUploadFailed)))
+                    }
+                } else {
                     self?.handleOperationFinished(
                         id: id,
                         type: type,
                         result: result,
                         attemptCount: attemptCount
                     )
+
                     self?.clearCacheFromStaleData()
                 }
             }
+        }
 
         // queue operations
-        uploadOperation.addDependency(cacheOperation)
-        operationQueue.addOperation(cacheOperation)
+        if let cacheOperation = cacheOperation {
+            uploadOperation.addDependency(cacheOperation)
+            operationQueue.addOperation(cacheOperation)
+        }
+
         operationQueue.addOperation(uploadOperation)
     }
 
@@ -230,6 +263,47 @@ public class EmbraceUpload: EmbraceLogUploader {
                 }
             }
         operationQueue.addOperation(uploadOperation)
+    }
+
+    private func createUploadOperation(
+        id: String,
+        type: EmbraceUploadType,
+        urlSession: URLSession,
+        data: Data,
+        retryCount: Int,
+        attemptCount: Int,
+        completion: @escaping EmbraceUploadOperationCompletion
+    ) -> EmbraceUploadOperation {
+
+        if type == .attachment {
+            return EmbraceAttachmentUploadOperation(
+                urlSession: urlSession,
+                queue: queue,
+                metadataOptions: options.metadata,
+                endpoint: endpoint(for: type),
+                identifier: id,
+                data: data,
+                retryCount: retryCount,
+                exponentialBackoffBehavior: options.redundancy.exponentialBackoffBehavior,
+                attemptCount: attemptCount,
+                logger: logger,
+                completion: completion
+            )
+        }
+
+        return EmbraceUploadOperation(
+            urlSession: urlSession,
+            queue: queue,
+            metadataOptions: options.metadata,
+            endpoint: endpoint(for: type),
+            identifier: id,
+            data: data,
+            retryCount: retryCount,
+            exponentialBackoffBehavior: options.redundancy.exponentialBackoffBehavior,
+            attemptCount: attemptCount,
+            logger: logger,
+            completion: completion
+        )
     }
 
     private func handleOperationFinished(
@@ -282,6 +356,7 @@ public class EmbraceUpload: EmbraceLogUploader {
         switch type {
         case .spans: return options.endpoints.spansURL
         case .log: return options.endpoints.logsURL
+        case .attachment: return options.endpoints.attachmentsURL
         }
     }
 }

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -80,7 +80,7 @@ public class EmbraceUpload: EmbraceLogUploader {
 
                 // clear data from cache that shouldn't be retried as it's stale
                 self.clearCacheFromStaleData()
-                
+
                 // get all the data cached first, is the only thing that could throw
                 let cachedObjects = try self.cache.fetchAllUploadData()
 
@@ -162,8 +162,7 @@ public class EmbraceUpload: EmbraceLogUploader {
         data: Data,
         type: EmbraceUploadType,
         attemptCount: Int = 0,
-        completion: ((Result<(), Error>) -> Void)?) 
-    {
+        completion: ((Result<(), Error>) -> Void)?) {
         // validate identifier
         guard id.isEmpty == false else {
             completion?(.failure(EmbraceUploadError.internalError(.invalidMetadata)))
@@ -199,7 +198,7 @@ public class EmbraceUpload: EmbraceLogUploader {
         let uploadOperation = createUploadOperation(
             id: id,
             type: type,
-            urlSession: urlSession, 
+            urlSession: urlSession,
             data: data,
             retryCount: retryCount,
             attemptCount: attemptCount) { [weak self] (result, attemptCount) in
@@ -209,7 +208,7 @@ public class EmbraceUpload: EmbraceLogUploader {
                 if type == .attachment {
                     switch result {
                     case .success: completion?(.success(()))
-                    case .failure(_): completion?(.failure(EmbraceUploadError.internalError(.attachmentUploadFailed)))
+                    case .failure: completion?(.failure(EmbraceUploadError.internalError(.attachmentUploadFailed)))
                     }
                 } else {
                     self?.handleOperationFinished(

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -144,7 +144,7 @@ public class EmbraceUpload: EmbraceLogUploader {
     /// - Parameters:
     ///   - id: Identifier of the attachment
     ///   - data: The attachment's data
-    ///   - completion: Completion block called when the data is successfully cached, or when an `Error` occurs
+    ///   - completion: Completion block called when the data is successfully uploaded, or when an `Error` occurs
     public func uploadAttachment(id: String, data: Data, completion: ((Result<(), Error>) -> Void)?) {
         queue.async { [weak self] in
             self?.uploadData(

--- a/Sources/EmbraceUploadInternal/EmbraceUploadType.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUploadType.swift
@@ -5,4 +5,5 @@
 enum EmbraceUploadType: Int {
     case spans = 0
     case log
+    case attachment
 }

--- a/Sources/EmbraceUploadInternal/ErrorManagement/EmbraceUploadError.swift
+++ b/Sources/EmbraceUploadInternal/ErrorManagement/EmbraceUploadError.swift
@@ -9,7 +9,6 @@ public enum EmbraceUploadErrorCode: Int {
     case invalidMetadata = 1000
     case invalidData = 1001
     case operationCancelled = 1002
-    case attachmentUploadFailed = 1003
 }
 
 public enum EmbraceUploadError: Error, Equatable {

--- a/Sources/EmbraceUploadInternal/ErrorManagement/EmbraceUploadError.swift
+++ b/Sources/EmbraceUploadInternal/ErrorManagement/EmbraceUploadError.swift
@@ -9,6 +9,7 @@ public enum EmbraceUploadErrorCode: Int {
     case invalidMetadata = 1000
     case invalidData = 1001
     case operationCancelled = 1002
+    case attachmentUploadFailed = 1003
 }
 
 public enum EmbraceUploadError: Error, Equatable {

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceAttachmentUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceAttachmentUploadOperation.swift
@@ -1,0 +1,67 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+class EmbraceAttachmentUploadOperation: EmbraceUploadOperation {
+
+    override func createRequest(
+        endpoint: URL,
+        data: Data,
+        identifier: String,
+        metadataOptions: EmbraceUpload.MetadataOptions
+    ) -> URLRequest {
+
+        let boundary = UUID().uuidString
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+
+        request.setValue(metadataOptions.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(metadataOptions.apiKey, forHTTPHeaderField: "X-EM-AID")
+        request.setValue(metadataOptions.deviceId, forHTTPHeaderField: "X-EM-DID")
+
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var multiPartData = Data()
+
+        // app_id
+        multiPartData.appendString("--\(boundary)\r\n")
+        multiPartData.appendString("Content-Disposition: form-data; name=\"app_id\"\r\n")
+        multiPartData.appendString("Content-Type: text/plain\r\n")
+        multiPartData.appendString("\r\n")
+        multiPartData.appendString(metadataOptions.apiKey)
+        multiPartData.appendString("\r\n")
+
+        // attachment_id
+        multiPartData.appendString("--\(boundary)\r\n")
+        multiPartData.appendString("Content-Disposition: form-data; name=\"attachment_id\"\r\n")
+        multiPartData.appendString("Content-Type: text/plain\r\n")
+        multiPartData.appendString("\r\n")
+        multiPartData.appendString(identifier)
+        multiPartData.appendString("\r\n")
+
+        // data
+        multiPartData.appendString("--\(boundary)\r\n")
+        multiPartData.appendString("Content-Disposition: form-data; name=\"file\"; filename=\"\(identifier)\"\r\n")
+        multiPartData.appendString("\r\n")
+        multiPartData.append(data)
+        multiPartData.appendString("\r\n")
+
+        multiPartData.appendString("--\(boundary)--")
+
+        request.httpBody = multiPartData
+
+        return request
+    }
+}
+
+extension Data {
+    mutating func appendString(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            self.append(data)
+        }
+    }
+}

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -81,7 +81,7 @@ class EmbraceUploadOperation: AsyncOperation {
         // update request's attempt count header
         request = updateRequest(request, attemptCount: attemptCount)
 
-        task = urlSession.dataTask(with: request, completionHandler: { [weak self] data, response, error in
+        task = urlSession.dataTask(with: request, completionHandler: { [weak self] _, response, error in
             guard let strongSelf = self else {
                 return
             }
@@ -162,7 +162,7 @@ class EmbraceUploadOperation: AsyncOperation {
         // retry for all other non-handled cases with errors
         return error != nil
     }
-    
+
     /// Extracts the suggested delay from `Retry-After` header from the `URLResponse` if present.
     /// - Parameter response: the URLResponse recevied when executing a request.
     /// - Returns:the time in seconds (as `Int`) extracted from the `Retry-After` header.

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -62,7 +62,12 @@ class EmbraceUploadOperation: AsyncOperation {
     }
 
     override func execute() {
-        let request = createRequest()
+        let request = createRequest(
+            endpoint: endpoint,
+            data: data,
+            identifier: identifier,
+            metadataOptions: metadataOptions
+        )
 
         sendRequest(request, retryCount: retryCount)
     }
@@ -76,7 +81,7 @@ class EmbraceUploadOperation: AsyncOperation {
         // update request's attempt count header
         request = updateRequest(request, attemptCount: attemptCount)
 
-        task = urlSession.dataTask(with: request, completionHandler: { [weak self] _, response, error in
+        task = urlSession.dataTask(with: request, completionHandler: { [weak self] data, response, error in
             guard let strongSelf = self else {
                 return
             }
@@ -171,7 +176,13 @@ class EmbraceUploadOperation: AsyncOperation {
         return retryAfterDelay
     }
 
-    private func createRequest() -> URLRequest {
+    func createRequest(
+        endpoint: URL,
+        data: Data,
+        identifier: String,
+        metadataOptions: EmbraceUpload.MetadataOptions
+    ) -> URLRequest {
+
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.httpBody = data

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
@@ -15,10 +15,10 @@ public extension EmbraceUpload {
         let storageMechanism: StorageMechanism
 
         /// Determines the maximum amount of cached requests that will be cached. Use 0 to disable.
-        public var cacheLimit: UInt
+        public let cacheLimit: UInt
 
         /// Determines the maximum amount of days a request will be cached. Use 0 to disable.
-        public var cacheDaysLimit: UInt
+        public let cacheDaysLimit: UInt
 
         public init?(
             cacheBaseUrl: URL,

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+EndpointOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+EndpointOptions.swift
@@ -12,9 +12,13 @@ public extension EmbraceUpload {
         /// URL for the logs upload endpoint
         public let logsURL: URL
 
-        public init(spansURL: URL, logsURL: URL) {
+        /// URL for the attachments upload endpoint
+        public let attachmentsURL: URL
+
+        public init(spansURL: URL, logsURL: URL, attachmentsURL: URL) {
             self.spansURL = spansURL
             self.logsURL = logsURL
+            self.attachmentsURL = attachmentsURL
         }
     }
 }

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+MetadataOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+MetadataOptions.swift
@@ -7,9 +7,9 @@ import Foundation
 public extension EmbraceUpload {
     /// Used to construct the http request headers
     class MetadataOptions {
-        public var apiKey: String
-        public var userAgent: String
-        public var deviceId: String
+        public let apiKey: String
+        public let userAgent: String
+        public let deviceId: String
 
         public init(apiKey: String, userAgent: String, deviceId: String) {
             self.apiKey = apiKey

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+RedundancyOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+RedundancyOptions.swift
@@ -15,9 +15,6 @@ public extension EmbraceUpload {
         /// Enable to automatically try to send any unsent cached data when the phone regains internet connection.
         public let retryOnInternetConnected: Bool
 
-        /// The amount of times an attachment upload can be retried
-        public let attachmentRetryCount: Int
-
         /// Defines the behavior to use when retrying requests
         public let exponentialBackoffBehavior: ExponentialBackoff
 
@@ -25,13 +22,11 @@ public extension EmbraceUpload {
             automaticRetryCount: Int = 3,
             maximumAmountOfRetries: Int = 20,
             retryOnInternetConnected: Bool = true,
-            attachmentRetryCount: Int = 3,
             exponentialBackoffBehavior: ExponentialBackoff = .init()
         ) {
             self.automaticRetryCount = automaticRetryCount
             self.maximumAmountOfRetries = maximumAmountOfRetries
             self.retryOnInternetConnected = retryOnInternetConnected
-            self.attachmentRetryCount = attachmentRetryCount
             self.exponentialBackoffBehavior = exponentialBackoffBehavior
         }
     }

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+RedundancyOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+RedundancyOptions.swift
@@ -7,26 +7,31 @@ import Foundation
 public extension EmbraceUpload {
     class RedundancyOptions {
         /// Total amount of times a request will be immediately retried in case of error. Use 0 to disable.
-        public var automaticRetryCount: Int
+        public let automaticRetryCount: Int
 
         /// Total amount of times a request could be retried.
-        public var maximumAmountOfRetries: Int
+        public let maximumAmountOfRetries: Int
 
         /// Enable to automatically try to send any unsent cached data when the phone regains internet connection.
-        public var retryOnInternetConnected: Bool
+        public let retryOnInternetConnected: Bool
+
+        /// The amount of times an attachment upload can be retried
+        public let attachmentRetryCount: Int
 
         /// Defines the behavior to use when retrying requests
-        public var exponentialBackoffBehavior: ExponentialBackoff
+        public let exponentialBackoffBehavior: ExponentialBackoff
 
         public init(
             automaticRetryCount: Int = 3,
             maximumAmountOfRetries: Int = 20,
             retryOnInternetConnected: Bool = true,
+            attachmentRetryCount: Int = 3,
             exponentialBackoffBehavior: ExponentialBackoff = .init()
         ) {
             self.automaticRetryCount = automaticRetryCount
             self.maximumAmountOfRetries = maximumAmountOfRetries
             self.retryOnInternetConnected = retryOnInternetConnected
+            self.attachmentRetryCount = attachmentRetryCount
             self.exponentialBackoffBehavior = exponentialBackoffBehavior
         }
     }

--- a/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLoggerSharedStateTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLoggerSharedStateTests.swift
@@ -7,14 +7,10 @@ import XCTest
 @testable import EmbraceOTelInternal
 @testable import EmbraceStorageInternal
 import OpenTelemetrySdk
+import TestSupport
 
 class DummyEmbraceResourceProvider: EmbraceResourceProvider {
     func getResource() -> Resource { Resource() }
-}
-
-class DummyLogControllable: LogControllable {
-    func uploadAllPersistedLogs() {}
-    func batchFinished(withLogs logs: [LogRecord]) {}
 }
 
 class EmbraceLoggerSharedStateTests: XCTestCase {

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -222,12 +222,12 @@ private extension LogControllerTests {
 
     func givenEmbraceLogUploader() {
         upload = .init()
-        upload.stubbedCompletion = .success(())
+        upload.stubbedLogCompletion = .success(())
     }
 
     func givenFailingLogUploader() {
         upload = .init()
-        upload.stubbedCompletion = .failure(RandomError())
+        upload.stubbedLogCompletion = .failure(RandomError())
     }
 
     func givenConfig(sdkEnabled: Bool = true) {

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -9,6 +9,7 @@ import EmbraceStorageInternal
 import EmbraceUploadInternal
 import EmbraceCommonInternal
 import EmbraceConfigInternal
+import TestSupport
 
 class LogControllerTests: XCTestCase {
     private var sut: LogController!
@@ -16,8 +17,10 @@ class LogControllerTests: XCTestCase {
     private var sessionController: MockSessionController!
     private var upload: SpyEmbraceLogUploader!
     private var config: EmbraceConfig!
+    private var otelBridge: MockEmbraceOTelBridge!
 
     override func setUp() {
+        givenOTelBridge()
         givenEmbraceLogUploader()
         givenConfig()
         givenSessionControllerWithSession()
@@ -199,6 +202,48 @@ class LogControllerTests: XCTestCase {
             XCTAssertTrue(convertedError.userInfo.isEmpty)
         }
     }
+
+    // MARK: - createLog
+    func test_createLog() throws {
+        givenLogController()
+        whenCreatingLog()
+        thenLogIsCreatedCorrectly()
+    }
+
+    func test_createLogWithAttachment_success() throws {
+        givenEmbraceLogUploader()
+        givenLogController()
+        whenCreatingLogWithAttachment()
+        thenLogWithSuccessfulAttachmentIsCreatedCorrectly()
+    }
+
+    func test_createLogWithAttachment_tooLarge() throws {
+        givenEmbraceLogUploader()
+        givenLogController()
+        whenCreatingLogWithBigAttachment()
+        thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: "ATTACHMENT_TOO_LARGE")
+    }
+
+    func test_createLogWithAttachment_limitReached() throws {
+        givenEmbraceLogUploader()
+        givenLogController()
+        whenAttachmentLimitIsReached()
+        whenCreatingLogWithAttachment()
+        thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: "OVER_MAX_ATTACHMENTS")
+    }
+
+    func test_createLogWithAttachment_serverError() throws {
+        givenFailingLogUploader()
+        givenLogController()
+        whenCreatingLogWithAttachment()
+        thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: "UNSUCCESSFUL_UPLOAD")
+    }
+
+    func test_createLogWithPreuploadedAttachment() throws {
+        givenLogController()
+        whenCreatingLogWithPreUploadedAttachment()
+        thenLogWithPreuploadedAttachmentIsCreatedCorrectly()
+    }
 }
 
 private extension LogControllerTests {
@@ -209,6 +254,8 @@ private extension LogControllerTests {
             controller: sessionController,
             config: config
         )
+
+        sut.otel = otelBridge
     }
 
     func givenLogController() {
@@ -218,20 +265,28 @@ private extension LogControllerTests {
             controller: sessionController,
             config: config
         )
+
+        sut.otel = otelBridge
     }
 
     func givenEmbraceLogUploader() {
         upload = .init()
         upload.stubbedLogCompletion = .success(())
+        upload.stubbedAttachmentCompletion = .success(())
     }
 
     func givenFailingLogUploader() {
         upload = .init()
         upload.stubbedLogCompletion = .failure(RandomError())
+        upload.stubbedAttachmentCompletion = .failure(RandomError())
     }
 
     func givenConfig(sdkEnabled: Bool = true) {
         config = EmbraceConfigMock.default(sdkEnabled: sdkEnabled)
+    }
+
+    func givenOTelBridge() {
+        otelBridge = MockEmbraceOTelBridge()
     }
 
     func givenSessionControllerWithoutSession() {
@@ -265,6 +320,35 @@ private extension LogControllerTests {
 
     func whenInvokingBatchFinished(withLogs logs: [LogRecord]) {
         sut.batchFinished(withLogs: logs)
+    }
+
+    func whenAttachmentLimitIsReached() {
+        sut.sessionController?.increaseAttachmentCount()
+        sut.sessionController?.increaseAttachmentCount()
+        sut.sessionController?.increaseAttachmentCount()
+        sut.sessionController?.increaseAttachmentCount()
+        sut.sessionController?.increaseAttachmentCount()
+    }
+
+    func whenCreatingLog() {
+        sut.createLog("test", severity: .info)
+    }
+
+    func whenCreatingLogWithAttachment() {
+        sut.createLog("test", severity: .info, attachment: TestConstants.data)
+    }
+
+    func whenCreatingLogWithBigAttachment() {
+        var str = ""
+        for _ in 1...1048600 {
+            str += "."
+        }
+        sut.createLog("test", severity: .info, attachment: str.data(using: .utf8)!)
+    }
+
+    func whenCreatingLogWithPreUploadedAttachment() {
+        let url = URL(string: "http//embrace.test.com/attachment/123", testName: testName)!
+        sut.createLog("test", severity: .info, attachmentId: UUID().withoutHyphen, attachmentUrl: url, attachmentSize: 12345)
     }
 
     func thenDoesntTryToUploadAnything() {
@@ -326,6 +410,49 @@ private extension LogControllerTests {
         let unwrappedStorage = try XCTUnwrap(storage)
         XCTAssertTrue(unwrappedStorage.didCallFetchPersonaTagsForProcessId)
         XCTAssertEqual(unwrappedStorage.fetchPersonaTagsForProcessIdReceivedParameter, processId)
+    }
+
+    func thenLogIsCreatedCorrectly() {
+        let log = otelBridge.otel.logs.first
+        XCTAssertNotNil(log)
+        XCTAssertEqual(log!.body!.description, "test")
+        XCTAssertEqual(log!.severity, .info)
+        XCTAssertEqual(log!.attributes["emb.type"]!.description, "sys.log")
+    }
+
+    func thenLogWithSuccessfulAttachmentIsCreatedCorrectly() {
+        wait {
+            let log = self.otelBridge.otel.logs.first
+
+            let attachmentIdFound = log!.attributes["emb.attachment_id"] != nil
+            let attachmentSizeFound = log!.attributes["emb.attachment_size"] != nil
+
+            return attachmentIdFound && attachmentSizeFound
+        }
+    }
+
+    func thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: String) {
+        wait {
+            let log = self.otelBridge.otel.logs.first
+
+            let attachmentIdFound = log!.attributes["emb.attachment_id"] != nil
+            let attachmentSizeFound = log!.attributes["emb.attachment_size"] != nil
+            let attachmentErrorFound = log!.attributes["emb.attachment_error_code"]!.description == errorCode
+
+            return attachmentIdFound && attachmentSizeFound && attachmentErrorFound
+        }
+    }
+
+    func thenLogWithPreuploadedAttachmentIsCreatedCorrectly() {
+        wait {
+            let log = self.otelBridge.otel.logs.first
+
+            let attachmentIdFound = log!.attributes["emb.attachment_id"] != nil
+            let attachmentUrlFound = log!.attributes["emb.attachment_url"] != nil
+            let attachmentSizeFound = log!.attributes["emb.attachment_size"] != nil
+
+            return attachmentIdFound && attachmentUrlFound && attachmentSizeFound
+        }
     }
 
     func randomLogRecord(sessionId: SessionIdentifier? = nil) -> LogRecord {

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -236,7 +236,7 @@ class LogControllerTests: XCTestCase {
         givenFailingLogUploader()
         givenLogController()
         whenCreatingLogWithAttachment()
-        thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: "UNSUCCESSFUL_UPLOAD")
+        thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: nil)
     }
 
     func test_createLogWithPreuploadedAttachment() throws {
@@ -431,13 +431,13 @@ private extension LogControllerTests {
         }
     }
 
-    func thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: String) {
+    func thenLogWithUnsuccessfulAttachmentIsCreatedCorrectly(errorCode: String?) {
         wait {
             let log = self.otelBridge.otel.logs.first
 
             let attachmentIdFound = log!.attributes["emb.attachment_id"] != nil
             let attachmentSizeFound = log!.attributes["emb.attachment_size"] != nil
-            let attachmentErrorFound = log!.attributes["emb.attachment_error_code"]!.description == errorCode
+            let attachmentErrorFound = errorCode == nil || log!.attributes["emb.attachment_error_code"]!.description == errorCode
 
             return attachmentIdFound && attachmentSizeFound && attachmentErrorFound
         }

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -400,7 +400,8 @@ private extension SessionControllerTests {
     func testEndpointOptions(testName: String) -> EmbraceUpload.EndpointOptions {
         .init(
             spansURL: testSessionsUrl(testName: testName),
-            logsURL: testLogsUrl(testName: testName)
+            logsURL: testLogsUrl(testName: testName),
+            attachmentsURL: testAttachmentsUrl(testName: testName)
         )
     }
 
@@ -410,6 +411,10 @@ private extension SessionControllerTests {
 
     func testLogsUrl(testName: String = #function) -> URL {
         URL(string: "https://embrace.\(testName).com/session_controller/logs")!
+    }
+
+    func testAttachmentsUrl(testName: String = #function) -> URL {
+        URL(string: "https://embrace.\(testName).com/session_controller/attachments")!
     }
 
     private var configBaseUrl: String {

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -765,7 +765,8 @@ private extension UnsentDataHandlerTests {
     func testEndpointOptions(forTest testName: String) -> EmbraceUpload.EndpointOptions {
         .init(
             spansURL: testSpansUrl(forTest: testName),
-            logsURL: testLogsUrl(forTest: testName)
+            logsURL: testLogsUrl(forTest: testName),
+            attachmentsURL: testAttachmentsUrl(forTest: testName)
         )
     }
 
@@ -777,6 +778,12 @@ private extension UnsentDataHandlerTests {
 
     func testLogsUrl(forTest testName: String = #function) -> URL {
         var url = URL(string: "https://embrace.test.com/logs")!
+        url.testName = testName
+        return url
+    }
+
+    func testAttachmentsUrl(forTest testName: String = #function) -> URL {
+        var url = URL(string: "https://embrace.test.com/attachments")!
         url.testName = testName
         return url
     }

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockSessionController.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockSessionController.swift
@@ -69,4 +69,10 @@ class MockSessionController: SessionControllable {
     func onUpdateSession(_ callback: @escaping ((SessionRecord?, SessionState?, Bool?) -> Void)) {
         updateSessionCallback = callback
     }
+
+    var attachmentCount: Int = 0
+
+    func increaseAttachmentCount() {
+        attachmentCount += 1
+    }
 }

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/SpyEmbraceLogUploader.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/SpyEmbraceLogUploader.swift
@@ -8,12 +8,24 @@ import EmbraceUploadInternal
 class SpyEmbraceLogUploader: EmbraceLogUploader {
     var didCallUploadLog = false
     var didCallUploadLogCount = 0
-    var stubbedCompletion: (Result<(), Error>)?
+    var stubbedLogCompletion: (Result<(), Error>)?
     func uploadLog(id: String, data: Data, completion: ((Result<(), Error>) -> Void)?) {
         didCallUploadLogCount += 1
         didCallUploadLog = true
-        if let result = stubbedCompletion {
+        if let result = stubbedLogCompletion {
             completion?(result)
         }
     }
+
+    var didCallUploadAttachment = false
+    var didCallUploadAttachmentCount = 0
+    var stubbedAttachmentCompletion: (Result<(), Error>)?
+    func uploadAttachment(id: String, data: Data, completion: ((Result<(), any Error>) -> Void)?) {
+        didCallUploadAttachmentCount += 1
+        didCallUploadAttachment = true
+        if let result = stubbedAttachmentCompletion {
+            completion?(result)
+        }
+    }
+
 }

--- a/Tests/EmbraceOTelInternalTests/EmbraceOTelTests.swift
+++ b/Tests/EmbraceOTelInternalTests/EmbraceOTelTests.swift
@@ -2,18 +2,13 @@ import XCTest
 
 @testable import EmbraceOTelInternal
 @testable import EmbraceCore
-
+import EmbraceCommonInternal
 import OpenTelemetryApi
 import OpenTelemetrySdk
 import EmbraceStorageInternal
 import TestSupport
 
 final class EmbraceOTelTests: XCTestCase {
-
-    class DummyLogControllable: LogControllable {
-        func uploadAllPersistedLogs() {}
-        func batchFinished(withLogs logs: [LogRecord]) {}
-    }
 
     var logExporter = InMemoryLogRecordExporter()
 
@@ -90,40 +85,6 @@ final class EmbraceOTelTests: XCTestCase {
         XCTAssertTrue(first === second)
     }
 
-// MARK: recordSpan with block
-
-    func test_recordSpan_returnsGenericResult_whenInt() throws {
-        let otel = EmbraceOTel()
-
-        let spanResult = otel.recordSpan(name: "math_test", type: .performance) {
-            var result = 0
-            for i in 0...10 {
-                // 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100
-                result += i * i
-            }
-
-            XCTAssertEqual(result, 385)
-            return result
-        }
-
-        XCTAssertEqual(spanResult, 385)
-    }
-
-    func test_recordSpan_returnsGenericResult_whenString() throws {
-        let otel = EmbraceOTel()
-
-        let spanResult = otel.recordSpan(name: "math_test", type: .performance) {
-            for i in 0...10 {
-                // 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100
-                _ = i * i
-            }
-
-            return "example_result"
-        }
-
-        XCTAssertEqual(spanResult, "example_result")
-    }
-
     // MARK: buildSpan
 
     // Test failing consistently in CI
@@ -160,7 +121,7 @@ final class EmbraceOTelTests: XCTestCase {
     func test_log_emitsLogToExporter() throws {
         let otel = EmbraceOTel()
 
-        otel.log("example message", severity: .info, attributes: [:])
+        otel.log("example message", severity: .info, timestamp: Date(), attributes: [:])
         let record = logExporter.finishedLogRecords.first { $0.body == .string("example message") }
 
         XCTAssertNotNil(record)

--- a/Tests/EmbraceOTelInternalTests/Logs/GenericLogExporterTests.swift
+++ b/Tests/EmbraceOTelInternalTests/Logs/GenericLogExporterTests.swift
@@ -11,10 +11,6 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 
 final class GenericLogExporterTests: XCTestCase {
-    class DummyLogControllable: LogControllable {
-        func uploadAllPersistedLogs() {}
-        func batchFinished(withLogs logs: [LogRecord]) {}
-    }
 
     func test_genericExporter_isCalled_whenConfiguredInSharedState() throws {
         let exporter = InMemoryLogRecordExporter()

--- a/Tests/EmbraceUploadInternalTests/EmbraceAttachmentOperationTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceAttachmentOperationTests.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+import XCTest
+import TestSupport
+@testable import EmbraceUploadInternal
+
+
+class EmbraceAttachmentUploadOperationTests: XCTestCase {
+
+    let testMetadataOptions = EmbraceUpload.MetadataOptions(
+        apiKey: "apiKey",
+        userAgent: "userAgent",
+        deviceId: "12345678"
+    )
+
+    var urlSession: URLSession!
+    var queue: DispatchQueue!
+
+    override func setUpWithError() throws {
+        let urlSessionconfig = URLSessionConfiguration.ephemeral
+        urlSessionconfig.httpMaximumConnectionsPerHost = .max
+        urlSessionconfig.protocolClasses = [EmbraceHTTPMock.self]
+
+        self.urlSession = URLSession(configuration: urlSessionconfig)
+        self.queue = .main
+    }
+    
+    func test_createRequest() {
+
+        let data = "12345".data(using: .utf8)!
+        let attachmentId = "987654321"
+
+        let operation = EmbraceAttachmentUploadOperation(
+            urlSession: urlSession,
+            queue: queue,
+            metadataOptions: testMetadataOptions,
+            endpoint: TestConstants.url,
+            identifier: attachmentId,
+            data: data,
+            retryCount: 0,
+            exponentialBackoffBehavior: .init(),
+            attemptCount: 0
+        )
+
+        let request = operation.createRequest(
+            endpoint: TestConstants.url,
+            data: data,
+            identifier: attachmentId,
+            metadataOptions: testMetadataOptions
+        )
+
+        XCTAssert(request.allHTTPHeaderFields!["Content-Type"]!.contains("multipart/form-data;"))
+
+        let body = String(data: request.httpBody!, encoding: .utf8)
+
+        // app id
+        XCTAssert(body!.contains("Content-Disposition: form-data; name=\"app_id\""))
+        XCTAssert(body!.contains(testMetadataOptions.apiKey))
+
+        // attachment id
+        XCTAssert(body!.contains("Content-Disposition: form-data; name=\"attachment_id\""))
+        XCTAssert(body!.contains(attachmentId))
+
+        // attachment data
+        XCTAssert(body!.contains("Content-Disposition: form-data; name=\"file\"; filename=\"987654321\""))
+        XCTAssert(body!.contains("12345"))
+    }
+}

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -201,6 +201,7 @@ class EmbraceUploadTests: XCTestCase {
         // then requests are made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 1)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testAttachmentsUrl()).count, 0)
     }
 
     func test_retryCachedData_emptyCache() throws {
@@ -214,6 +215,7 @@ class EmbraceUploadTests: XCTestCase {
         // then no requests are made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testAttachmentsUrl()).count, 0)
     }
 
     func test_spansEndpoint() throws {
@@ -225,6 +227,7 @@ class EmbraceUploadTests: XCTestCase {
         // then a request to the right endpoint is made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testAttachmentsUrl()).count, 0)
     }
 
     func test_logsEndpoint() throws {
@@ -236,6 +239,19 @@ class EmbraceUploadTests: XCTestCase {
         // then a request to the right endpoint is made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 1)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testAttachmentsUrl()).count, 0)
+    }
+
+    func test_attachmentsEndpoint() throws {
+        // when uploading attachment data
+        module.uploadLog(id: "id", data: TestConstants.data, completion: nil)
+
+        wait(delay: .defaultTimeout)
+
+        // then a request to the right endpoint is made
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testAttachmentsUrl()).count, 1)
     }
 }
 

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -248,10 +248,15 @@ private extension EmbraceUploadTests {
         URL(string: "https://embrace.\(testName).com/upload/logs")!
     }
 
+    func testAttachmentsUrl(testName: String = #function) -> URL {
+        URL(string: "https://embrace.\(testName).com/upload/attachments")!
+    }
+
     func testEndpointOptions(testName: String) -> EmbraceUpload.EndpointOptions {
         .init(
             spansURL: testSpansUrl(testName: testName),
-            logsURL: testLogsUrl(testName: testName)
+            logsURL: testLogsUrl(testName: testName),
+            attachmentsURL: testAttachmentsUrl(testName: testName)
         )
     }
 }

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -244,7 +244,7 @@ class EmbraceUploadTests: XCTestCase {
 
     func test_attachmentsEndpoint() throws {
         // when uploading attachment data
-        module.uploadLog(id: "id", data: TestConstants.data, completion: nil)
+        module.uploadAttachment(id: "id", data: TestConstants.data, completion: nil)
 
         wait(delay: .defaultTimeout)
 

--- a/Tests/TestSupport/Mocks/DummyLogControllable.swift
+++ b/Tests/TestSupport/Mocks/DummyLogControllable.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import EmbraceCore
+import EmbraceCommonInternal
+import EmbraceStorageInternal
+
+public class DummyLogControllable: LogControllable {
+
+    public init() {}
+    
+    public func uploadAllPersistedLogs() {}
+
+    public func createLog(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType,
+        timestamp: Date,
+        attachment: Data?,
+        attachmentId: String?,
+        attachmentUrl: URL?,
+        attributes: [String : String],
+        stackTraceBehavior: StackTraceBehavior
+    ) { }
+
+    public func batchFinished(withLogs logs: [LogRecord]) {}
+}

--- a/Tests/TestSupport/Mocks/DummyLogControllable.swift
+++ b/Tests/TestSupport/Mocks/DummyLogControllable.swift
@@ -21,6 +21,7 @@ public class DummyLogControllable: LogControllable {
         attachment: Data?,
         attachmentId: String?,
         attachmentUrl: URL?,
+        attachmentSize: Int?,
         attributes: [String : String],
         stackTraceBehavior: StackTraceBehavior
     ) { }

--- a/Tests/TestSupport/Mocks/MockEmbraceOTelBridge.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOTelBridge.swift
@@ -13,6 +13,8 @@ public class MockEmbraceOTelBridge: EmbraceOTelBridge {
     public let otel = MockEmbraceOpenTelemetry()
     public var logs: [ReadableLogRecord] = []
 
+    public init() {}
+
     public func buildSpan(name: String, type: SpanType, attributes: [String : String]) -> any SpanBuilder {
         return otel.buildSpan(name: name, type: type, attributes: attributes)
     }

--- a/Tests/TestSupport/Mocks/MockEmbraceOTelBridge.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOTelBridge.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import EmbraceOTelInternal
+import EmbraceCommonInternal
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+public class MockEmbraceOTelBridge: EmbraceOTelBridge {
+
+    public let otel = MockEmbraceOpenTelemetry()
+    public var logs: [ReadableLogRecord] = []
+
+    public func buildSpan(name: String, type: SpanType, attributes: [String : String]) -> any SpanBuilder {
+        return otel.buildSpan(name: name, type: type, attributes: attributes)
+    }
+    
+    public func log(_ message: String, severity: LogSeverity, timestamp: Date, attributes: [String : String]) {
+        otel.log(message, severity: severity, timestamp: timestamp, attributes: attributes)
+    }
+}

--- a/Tests/TestSupport/Mocks/MockEmbraceOTelBridge.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOTelBridge.swift
@@ -11,7 +11,6 @@ import OpenTelemetrySdk
 public class MockEmbraceOTelBridge: EmbraceOTelBridge {
 
     public let otel = MockEmbraceOpenTelemetry()
-    public var logs: [ReadableLogRecord] = []
 
     public init() {}
 

--- a/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
@@ -120,6 +120,7 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
         timestamp: Date = Date(),
         attachmentId: String,
         attachmentUrl: URL,
+        attachmentSize: Int?,
         attributes: [String : String] = [:],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {

--- a/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
@@ -10,7 +10,7 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import EmbraceSemantics
 
-public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
+public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {   
     private(set) public var spanProcessor = MockSpanProcessor()
     private(set) public var events: [SpanEvent] = []
     private(set) public var logs: [ReadableLogRecord] = []
@@ -99,5 +99,30 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
         )
 
         logs.append(log)
+    }
+
+    public func log(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType = .performance,
+        timestamp: Date = Date(),
+        attachment: Data,
+        attributes: [String : String] = [:],
+        stackTraceBehavior: StackTraceBehavior = .default
+    ) {
+
+    }
+
+    public func log(
+        _ message: String,
+        severity: LogSeverity,
+        type: LogType = .performance,
+        timestamp: Date = Date(),
+        attachmentId: String,
+        attachmentUrl: URL,
+        attributes: [String : String] = [:],
+        stackTraceBehavior: StackTraceBehavior = .default
+    ) {
+
     }
 }


### PR DESCRIPTION
* Added new public APIs to create logs with attachments (`Embrace+OTel.swift`).
* Moved log creating logic inside of `LogController` (so we can test the logic without needing to initialize the Embrace client).
* Added new type of data to the `EmbraceUpload` module:
  - Uploaded attachments are retried a few times but never cached
  - If the upload fails, the data is discarded and the log is sent with the appropriate attachment error