### PR TITLE
Fixing log attachment count bug

### DIFF
--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -107,8 +107,6 @@ class LogController: LogControllable {
         // handle attachment data
         if let attachment = attachment {
 
-            sessionController.increaseAttachmentCount()
-
             let id = UUID().withoutHyphen
             finalAttributes[LogSemantics.keyAttachmentId] = id
 
@@ -128,6 +126,8 @@ class LogController: LogControllable {
             else {
                 upload?.uploadAttachment(id: id, data: attachment, completion: nil)
             }
+
+            sessionController.increaseAttachmentCount()
         }
 
         // handle pre-uploaded attachment

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -20,7 +20,6 @@ protocol LogControllable: LogBatcherDelegate {
         attachment: Data?,
         attachmentId: String?,
         attachmentUrl: URL?,
-        attachmentSize: Int?,
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior
     )
@@ -73,7 +72,6 @@ class LogController: LogControllable {
         attachment: Data? = nil,
         attachmentId: String? = nil,
         attachmentUrl: URL? = nil,
-        attachmentSize: Int? = nil,
         attributes: [String: String] = [:],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
@@ -136,10 +134,6 @@ class LogController: LogControllable {
 
             finalAttributes[LogSemantics.keyAttachmentId] = attachmentId
             finalAttributes[LogSemantics.keyAttachmentUrl] = attachmentUrl.absoluteString
-
-            if let attachmentSize = attachmentSize {
-                finalAttributes[LogSemantics.keyAttachmentSize] = String(attachmentSize)
-            }
         }
 
         otel.log(message, severity: severity, timestamp: timestamp, attributes: finalAttributes)

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -159,7 +159,6 @@ extension Embrace: EmbraceOpenTelemetry {
             attachment: nil,
             attachmentId: nil,
             attachmentUrl: nil,
-            attachmentSize: nil,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior
         )
@@ -191,7 +190,6 @@ extension Embrace: EmbraceOpenTelemetry {
             attachment: attachment,
             attachmentId: nil,
             attachmentUrl: nil,
-            attachmentSize: nil,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior
         )
@@ -205,7 +203,6 @@ extension Embrace: EmbraceOpenTelemetry {
     ///   - timestamp: Timestamp for the log.
     ///   - attachmentId: Identifier of the attachment
     ///   - attachmentUrl: URL to dowload the attachment data
-    ///   - attachmentSize: Size of the attachment (optional)
     ///   - attributes: Attributes for the log.
     ///   - stackTraceBehavior: Defines if the stack trace information should be added to the log
     public func log(
@@ -215,7 +212,6 @@ extension Embrace: EmbraceOpenTelemetry {
         timestamp: Date = Date(),
         attachmentId: String,
         attachmentUrl: URL,
-        attachmentSize: Int? = nil,
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
@@ -227,7 +223,6 @@ extension Embrace: EmbraceOpenTelemetry {
             attachment: nil,
             attachmentId: attachmentId,
             attachmentUrl: attachmentUrl,
-            attachmentSize: attachmentSize,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior
         )

--- a/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
+++ b/Sources/EmbraceOTelInternal/EmbraceOpenTelemetry.swift
@@ -63,7 +63,6 @@ public protocol EmbraceOpenTelemetry: AnyObject {
         timestamp: Date,
         attachmentId: String,
         attachmentUrl: URL,
-        attachmentSize: Int?,
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior
     )

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -348,7 +348,7 @@ private extension LogControllerTests {
 
     func whenCreatingLogWithPreUploadedAttachment() {
         let url = URL(string: "http//embrace.test.com/attachment/123", testName: testName)!
-        sut.createLog("test", severity: .info, attachmentId: UUID().withoutHyphen, attachmentUrl: url, attachmentSize: 12345)
+        sut.createLog("test", severity: .info, attachmentId: UUID().withoutHyphen, attachmentUrl: url)
     }
 
     func thenDoesntTryToUploadAnything() {
@@ -449,9 +449,8 @@ private extension LogControllerTests {
 
             let attachmentIdFound = log!.attributes["emb.attachment_id"] != nil
             let attachmentUrlFound = log!.attributes["emb.attachment_url"] != nil
-            let attachmentSizeFound = log!.attributes["emb.attachment_size"] != nil
 
-            return attachmentIdFound && attachmentUrlFound && attachmentSizeFound
+            return attachmentIdFound && attachmentUrlFound
         }
     }
 

--- a/Tests/TestSupport/Mocks/DummyLogControllable.swift
+++ b/Tests/TestSupport/Mocks/DummyLogControllable.swift
@@ -21,7 +21,6 @@ public class DummyLogControllable: LogControllable {
         attachment: Data?,
         attachmentId: String?,
         attachmentUrl: URL?,
-        attachmentSize: Int?,
         attributes: [String : String],
         stackTraceBehavior: StackTraceBehavior
     ) { }

--- a/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceOpenTelemetry.swift
@@ -120,7 +120,6 @@ public class MockEmbraceOpenTelemetry: NSObject, EmbraceOpenTelemetry {
         timestamp: Date = Date(),
         attachmentId: String,
         attachmentUrl: URL,
-        attachmentSize: Int?,
         attributes: [String : String] = [:],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {


### PR DESCRIPTION
* The actual attachment limit was 4 per session (instead of 5) due to this bug. 
* Also removing the attachment size parameter since it wont be used.
