### PR TITLE
Fix push notification bug

### DIFF
--- a/Sources/EmbraceCore/Capture/PushNotifications/UNUserNotificationCenterDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/PushNotifications/UNUserNotificationCenterDelegateProxy.swift
@@ -14,9 +14,13 @@ class UNUserNotificationCenterDelegateProxy: NSObject {
     }
 
     override func responds(to aSelector: Selector!) -> Bool {
-        if super.responds(to: aSelector) {
-            return true
-        } else if let originalDelegate = originalDelegate, originalDelegate.responds(to: aSelector) {
+        // We will only respond to the given selectors if and only if the `originalDelegate` we are proxying also implements them.
+        // If this condition is not met, we risk stealing the notification from the app, which is undesirable.
+        // Additionally, if the user doesn't implement any of these methods, we ensure that the push notification is still captured by
+        // swizzling `UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
+        if super.responds(to: aSelector),
+           let originalDelegate = originalDelegate,
+           originalDelegate.responds(to: aSelector) {
             return true
         }
         return false

--- a/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
+++ b/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
@@ -51,6 +51,7 @@ import EmbraceCaptureService
         return LowPowerModeCaptureService()
     }
 
+#if os(iOS)
     /// Adds a `PushNotificationCaptureService` with the given `PushNotificationCaptureService.Options`.
     /// - Parameter options: `PushNotificationCaptureService.Options` used to configure the service.
     static func pushNotification(
@@ -58,4 +59,5 @@ import EmbraceCaptureService
     ) -> PushNotificationCaptureService {
         return PushNotificationCaptureService(options: options)
     }
+#endif
 }


### PR DESCRIPTION
# Overview
This PR fixes [#113](https://github.com/embrace-io/embrace-apple-sdk/issues/113), where push notifications were sometimes not reaching the app when users did not implement `UNUserNotificationCenterDelegate` methods.

## Description

We’ve introduced conditional logic for proxying `UNUserNotificationCenterDelegate` methods:
- The SDK now only responds to a selector if the original delegate also implements it.
- This prevents scenarios where the SDK intercepts notifications without forwarding them, ensuring they always reach the app’s implementation when it exists (or the user).

To account for cases where users don't implement `UNUserNotificationCenterDelegate` methods, we have added a fallback swizzling of `UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`. This ensures that notifications are still captured by the SDK, even when no delegate is explicitly handling them.

> [!WARNING]
> This does not handle cases where an app receives push notifications but does not implement any handling logic (e.g., neither `UNUserNotificationCenterDelegate` methods nor `UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:))`. In such scenarios, push notifications will still be received by iOS but we'll not be able to capture them.