### PR TITLE
WKNavigationDelegate crash fix

### DIFF
--- a/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
@@ -78,5 +78,15 @@ extension WKNavigationDelegateProxy: WKNavigationDelegate {
         // call original
         originalDelegate?.webView?(webView, didFail: navigation, withError: error)
     }
+
+    func webView(_ webView: WKWebView,
+        didFinish navigation: WKNavigation!
+    ) {
+        // Capture navigation event
+        callback?(webView.url, nil)
+
+        // Call original delegate's implementation if available
+        originalDelegate?.webView?(webView, didFinish: navigation)
+    }
 }
 #endif

--- a/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
@@ -17,15 +17,22 @@ class WKNavigationDelegateProxy: NSObject {
         self.callback = callback
     }
 
-    override func responds(to aSelector: Selector!) -> Bool {
-        if super.responds(to: aSelector) {
-            return true
-        } else if let originalDelegate = originalDelegate, originalDelegate.responds(to: aSelector) {
-            return true
-        }
-        return false
-    }
+    // 1. remove this first then have the client test
+    // Test this first on a test app!
+//    override func responds(to aSelector: Selector!) -> Bool {
+//        if super.responds(to: aSelector) {
+//            return true
+//        } else if let originalDelegate = originalDelegate, originalDelegate.responds(to: aSelector) {
+//            return true
+//        }
+//        return false
+//    }
 
+    // webview with delegate method that implements this methods
+    // webview capture service
+    // are they using third party web view libraries
+    
+    
     override func forwardingTarget(for aSelector: Selector!) -> Any? {
         if super.responds(to: aSelector) {
             return self

--- a/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WKNavigationDelegateProxy.swift
@@ -16,22 +16,6 @@ class WKNavigationDelegateProxy: NSObject {
         self.originalDelegate = originalDelegate
         self.callback = callback
     }
-
-    // 1. remove this first then have the client test
-    // Test this first on a test app!
-//    override func responds(to aSelector: Selector!) -> Bool {
-//        if super.responds(to: aSelector) {
-//            return true
-//        } else if let originalDelegate = originalDelegate, originalDelegate.responds(to: aSelector) {
-//            return true
-//        }
-//        return false
-//    }
-
-    // webview with delegate method that implements this methods
-    // webview capture service
-    // are they using third party web view libraries
-    
     
     override func forwardingTarget(for aSelector: Selector!) -> Any? {
         if super.responds(to: aSelector) {
@@ -84,16 +68,6 @@ extension WKNavigationDelegateProxy: WKNavigationDelegate {
 
         // call original
         originalDelegate?.webView?(webView, didFail: navigation, withError: error)
-    }
-
-    func webView(_ webView: WKWebView,
-        didFinish navigation: WKNavigation!
-    ) {
-        // Capture navigation event
-        callback?(webView.url, nil)
-
-        // Call original delegate's implementation if available
-        originalDelegate?.webView?(webView, didFinish: navigation)
     }
 }
 #endif


### PR DESCRIPTION
**Description:**

Crash reported:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[EmbraceCore.WKNavigationDelegateProxy webView:didFinishNavigation:]: unrecognized selector sent to instance 0x6000082a3cc0'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001804b757c __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x000000018008eda8 objc_exception_throw + 72
	2   CoreFoundation                      0x00000001804cd064 +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
	3   CoreFoundation                      0x00000001804bb658 ___forwarding___ + 720
	4   CoreFoundation                      0x00000001804bdf9c _CF_forwarding_prep_0 + 92
	5   WebKit                              0x000000018c37a79c _ZN6WebKit15NavigationState16NavigationClient19didFinishNavigationERNS_12WebPageProxyEPN3API10NavigationEPNS4_6ObjectE + 172
	6   WebKit                              0x000000018c4f7e44 _ZN6WebKit12WebPageProxy21didFinishLoadForFrameERN3IPC10ConnectionEN7WebCore16ProcessQualifiedIN3WTF23ObjectIdentifierGenericINS4_19FrameIdentifierTypeENS6_38ObjectIdentifierMainThreadAccessTrait	7   WebKit                              0x000000018c9bbaf8 _ZN3IPC13handleMessageIN8Messages12WebPageProxy21DidFinishLoadForFrameEN6WebKit12WebPageProxyES5_FvRNS_10ConnectionEN7WebCore16ProcessQualifiedIN3WTF23ObjectIdentifierGenericINS8_19FrameIdentifie	8   WebKit                              0x000000018c9b8128 _ZN6WebKit12WebPageProxy17didReceiveMessageERN3IPC10ConnectionERNS1_7DecoderE + 956
	9   WebKit                              0x000000018cac7018 _ZN3IPC18MessageReceiverMap15dispatchMessageERNS_10ConnectionERNS_7DecoderE + 260
	10  WebKit                              0x000000018c569f38 _ZN6WebKit15WebProcessProxy17didReceiveMessageERN3IPC10ConnectionERNS1_7DecoderE + 40
	11  WebKit                              0x000000018cac3598 _ZN3IPC10Connection15dispatchMessageEN3WTF9UniqueRefINS_7DecoderEEE + 712
	12  WebKit                              0x000000018cac391c _ZN3IPC10Connection24dispatchIncomingMessagesEv + 512
	13  JavaScriptCore                      0x0000000197271b34 _ZN3WTF7RunLoop11performWorkEv + 176
	14  JavaScriptCore                      0x0000000197272888 _ZN3WTF7RunLoop11performWorkEPv + 32
	15  CoreFoundation                      0x000000018041b7c4 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
	16  CoreFoundation                      0x000000018041b70c __CFRunLoopDoSource0 + 172
	17  CoreFoundation                      0x000000018041ae70 __CFRunLoopDoSources0 + 232
	18  CoreFoundation                      0x00000001804153b4 __CFRunLoopRun + 788
	19  CoreFoundation                      0x0000000180414c24 CFRunLoopRunSpecific + 552
	20  GraphicsServices                    0x000000019020ab10 GSEventRunModal + 160
	21  UIKitCore                           0x0000000185ad82fc -[UIApplication _run] + 796
	22  UIKitCore                           0x0000000185adc4f4 UIApplicationMain + 124
	23  SwiftUI                             0x00000001d290b41c $s7SwiftUI17KitRendererCommon33_ACC2C5639A7D76F611E170E831FCA491LLys5NeverOyXlXpFAESpySpys4Int8VGSgGXEfU_ + 164
	24  SwiftUI                             0x00000001d290b144 $s7SwiftUI6runAppys5NeverOxAA0D0RzlF + 84
	25  SwiftUI                             0x00000001d266bef4 $s7SwiftUI3AppPAAE4mainyyFZ + 148
	26  Work.debug.dylib                    0x0000000300006b28 $s4Work0A3AppV5$mainyyFZ + 40
	27  Work.debug.dylib                    0x00000003003fe52c __debug_main_executable_dylib_entry_point + 12
	28  dyld                                0x0000000100b11410 start_sim + 20
	29  ???                                 0x0000000100c06274 0x0 + 4307575412
)
libc++abi: terminating due to uncaught exception of type NSException
```

**Solution:**
The crash is due to webView:didFinishNavigation: not being implemented in WKNavigationDelegateProxy. The WebKit framework expects this method to exist because the proxy is set as the WKNavigationDelegate, but when WebKit tries to call it, it doesn’t find it.

so I added the didFinishNavigation method.