### PR TITLE
URLSessionDelegateProxy self recursion crash

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -142,6 +151,15 @@
       "state" : {
         "revision" : "6a9e38e7bd22a3b8ba80bddf395623cf68f57807",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
@@ -111,6 +111,11 @@ struct URLSessionInitWithDelegateSwizzler: URLSessionSwizzler {
                     return originalImplementation(urlSession, Self.selector, configuration, delegate, queue)
                 }
 
+                // Add protection against re-proxying our own proxy
+                guard !(proxiedDelegate is URLSessionDelegateProxy) else {
+                    return originalImplementation(urlSession, Self.selector, configuration, delegate, queue)
+                }
+
                 let newDelegate = URLSessionDelegateProxy(originalDelegate: proxiedDelegate, handler: handler)
                 let session = originalImplementation(urlSession, Self.selector, configuration, newDelegate, queue)
 


### PR DESCRIPTION
Puttshack team experiencing a hang/crash noticed in URLSessionDelegateProxy

added checks using !(originalDelegate is URLSessionDelegateProxy) to prevent self-delegation
added similar check for the session delegate: !(sessionDelegate is URLSessionDelegateProxy)
combined the guard conditions to make the code more robust


