### PR TITLE
Embr 6517 thena t0q1bf4ua 5769 repeated crashes in ios embrace sdk 6 x with thread sanitizer warning

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
@@ -111,6 +111,11 @@ struct URLSessionInitWithDelegateSwizzler: URLSessionSwizzler {
                     return originalImplementation(urlSession, Self.selector, configuration, delegate, queue)
                 }
 
+                // Add protection against re-proxying our own proxy
+                guard !(proxiedDelegate is URLSessionDelegateProxy) else {
+                    return originalImplementation(urlSession, Self.selector, configuration, delegate, queue)
+                }
+
                 let newDelegate = URLSessionDelegateProxy(originalDelegate: proxiedDelegate, handler: handler)
                 let session = originalImplementation(urlSession, Self.selector, configuration, newDelegate, queue)
 


### PR DESCRIPTION
some teams are experiencing a hang/crash noticed in URLSessionDelegateProxy

added checks using !(originalDelegate is URLSessionDelegateProxy) to prevent self-delegation
added similar check for the session delegate: !(sessionDelegate is URLSessionDelegateProxy)
