### PR TITLE
Remove responds(to aSelector: Selector!) method in  url session delegate and user notification center delegate proxies

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/Proxy/URLSessionDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/Network/Proxy/URLSessionDelegateProxy.swift
@@ -26,15 +26,6 @@ class URLSessionDelegateProxy: NSObject {
         super.init()
     }
 
-    override func responds(to aSelector: Selector!) -> Bool {
-        if super.responds(to: aSelector) {
-            return true
-        } else if let originalDelegate = originalDelegate, originalDelegate.responds(to: aSelector) {
-            return true
-        }
-        return false
-    }
-
     override func forwardingTarget(for aSelector: Selector!) -> Any? {
         if super.responds(to: aSelector) {
             return self

--- a/Sources/EmbraceCore/Capture/PushNotifications/UNUserNotificationCenterDelegateProxy.swift
+++ b/Sources/EmbraceCore/Capture/PushNotifications/UNUserNotificationCenterDelegateProxy.swift
@@ -13,15 +13,6 @@ class UNUserNotificationCenterDelegateProxy: NSObject {
         self.captureData = captureData
     }
 
-    override func responds(to aSelector: Selector!) -> Bool {
-        if super.responds(to: aSelector) {
-            return true
-        } else if let originalDelegate = originalDelegate, originalDelegate.responds(to: aSelector) {
-            return true
-        }
-        return false
-    }
-
     override func forwardingTarget(for aSelector: Selector!) -> Any? {
         if super.responds(to: aSelector) {
             return self


### PR DESCRIPTION
 url session delegate and user notification center delegate proxies contain a method override func responds(to aSelector: Selector!) -> Bool which we have seen cause certain customers to run into crashes in similar file WKNavigationDelegateProxy.swift. Removing override func responds(to aSelector: Selector!) -> Bool  safe guards against this crash