### PR TITLE
Added the possibility to choose the behavior to capture tap events based on the `UITouch.phase`

### DIFF
--- a/Sources/EmbraceCore/Capture/UX/Tap/TapCaptureService+Options.swift
+++ b/Sources/EmbraceCore/Capture/UX/Tap/TapCaptureService+Options.swift
@@ -4,8 +4,35 @@
 
 #if canImport(UIKit) && !os(watchOS)
 import Foundation
+import UIKit
 
 extension TapCaptureService {
+    /// Defines when a tap event should be recorded.
+    ///
+    /// This allows configuring whether the tap is captured at the beginning (`.onStart`)
+    /// or when the user lifts their finger (`.onEnd`), ensuring more control over what
+    /// is considered a valid tap.
+    @objc(EMBTapCaptureServiceTapPhase)
+    public enum TapPhase: Int {
+        /// Captures the tap when the user first touches the screen.
+        case onStart
+
+        /// Captures the tap only when the user lifts their finger.
+        case onEnd
+
+        /// Converts the `TapPhase` enum into its corresponding `UITouch.Phase` value.
+        ///
+        /// - Returns: the  equivalent`UITouch.Phase`
+        func asUITouchPhase() -> UITouch.Phase {
+            switch self {
+            case .onStart:
+                return .began
+            case .onEnd:
+                return .ended
+            }
+        }
+    }
+
     /// Class used to setup a TapCaptureService.
     @objc(EMBTapCaptureServiceOptions)
     public final class Options: NSObject {
@@ -18,18 +45,27 @@ extension TapCaptureService {
         /// Delegate used to decide if each individual tap should be recorded or not.
         @objc public let delegate: TapCaptureServiceDelegate?
 
+        /// Specifies when a tap should be recorded.
+        @objc public let tapPhase: TapPhase
+
         @objc public init(
             ignoredViewTypes: [AnyClass] = [],
             captureTapCoordinates: Bool = true,
+            tapPhase: TapPhase = .onStart,
             delegate: TapCaptureServiceDelegate? = nil
         ) {
             self.ignoredViewTypes = ignoredViewTypes
             self.captureTapCoordinates = captureTapCoordinates
             self.delegate = delegate
+            self.tapPhase = tapPhase
         }
 
         @objc public convenience override init() {
-            self.init(ignoredViewTypes: [], captureTapCoordinates: true, delegate: nil)
+            self.init(
+                ignoredViewTypes: [],
+                captureTapCoordinates: true,
+                delegate: nil
+            )
         }
     }
 }

--- a/Sources/EmbraceCore/Capture/UX/Tap/TapCaptureService+Options.swift
+++ b/Sources/EmbraceCore/Capture/UX/Tap/TapCaptureService+Options.swift
@@ -22,7 +22,7 @@ extension TapCaptureService {
 
         /// Converts the `TapPhase` enum into its corresponding `UITouch.Phase` value.
         ///
-        /// - Returns: the  equivalent`UITouch.Phase`
+        /// - Returns: the equivalent `UITouch.Phase`
         func asUITouchPhase() -> UITouch.Phase {
             switch self {
             case .onStart:

--- a/Sources/EmbraceCore/Capture/UX/Tap/TapCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/UX/Tap/TapCaptureService.swift
@@ -59,9 +59,17 @@ public final class TapCaptureService: CaptureService {
         guard event.type == .touches,
               let allTouches = event.allTouches,
               let touch = allTouches.first,
-              touch.phase == .began,
+              touch.phase == options.tapPhase.asUITouchPhase(),
               let target = touch.view else {
             return
+        }
+
+        // If we are handling `.ended`, verify that the touch ended inside the original target
+        if touch.phase == .ended {
+            let touchLocation = touch.location(in: target)
+            guard target.bounds.contains(touchLocation) else {
+                return
+            }
         }
 
         // check if the view type should be ignored


### PR DESCRIPTION
# Overview
This PR introduces a configurable tap capture phase in `TapCaptureService`, allowing users to choose whether taps are recorded at the start (`.onStart`, when the user touches the screen) or at the end (`.onEnd`, when the user lifts their finger).

# Details
- Added `TapCaptureSerivce.TapPhase` enum to determine when a tap should be recorded.
- Updated `TapCaptureService.Options` to include a new `tapPhase` property (default is `.onStart` as it's been until today).
- Modified `TapCaptureService` to respect the configured `tapPhase`:
   - If `.onStart`, taps are recorded when the user touches the screen.
   - If `.onEnd`, taps are recorded only if the user lifts their finger within the same control.
