### PR TITLE
[EMBR-7094] Fixed id for log severity "Fatal".

### DIFF
--- a/Sources/EmbraceCommonInternal/Models/LogSeverity.swift
+++ b/Sources/EmbraceCommonInternal/Models/LogSeverity.swift
@@ -10,7 +10,7 @@ import Foundation
     case info = 9
     case warn = 13
     case error = 17
-    case fatal = 24
+    case fatal = 21
 
     /// The value provided is compliant with what SeverityText is for OTel
     /// More info: https://opentelemetry.io/docs/specs/otel/logs/data-model/

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -443,7 +443,7 @@ class UnsentDataHandlerTests: XCTestCase {
         XCTAssertEqual(otel.logs[0].attributes["emb.type"], .string(LogType.crash.rawValue))
         XCTAssertEqual(otel.logs[0].timestamp, report.timestamp)
         XCTAssertEqual(otel.logs[0].body?.description, "")
-        XCTAssertEqual(otel.logs[0].severity, .fatal4)
+        XCTAssertEqual(otel.logs[0].severity, .fatal)
         XCTAssertEqual(otel.logs[0].attributes["session.id"], .string(TestConstants.sessionId.toString))
         XCTAssertEqual(otel.logs[0].attributes["emb.state"], .string(SessionState.foreground.rawValue))
         XCTAssertEqual(otel.logs[0].attributes["log.record.uid"], .string(report.id.withoutHyphen))


### PR DESCRIPTION
LogSeverity "FATAL" has the wrong id set so it displays "FATAL4" by default instead of just "FATAL". 

