### PR TITLE
Fixed failures on the run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,18 +53,28 @@ jobs:
         timeout-minutes: 2
         continue-on-error: true
 
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+
       - name: Run Tests
-        run: bin/test | xcpretty && exit ${PIPESTATUS[0]}
+        run: bin/test | xcbeautify && exit ${PIPESTATUS[0]}
         timeout-minutes: 30
+
+      - name: Upload xcresult Bundle Manually
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: output_xcresult
+          path: .build/test/output.xcresult
 
       - uses: kishikawakatsumi/xcresulttool@v1
         if: always()
         with:
-          path: .build/test/output.xcresult
+          path: .build/test/output
           title: "Test Results"
           show-passed-tests: true
           show-code-coverage: true
-          upload-bundles: true
+          upload-bundles: "never" # Uploading the `xcresult` using the xcresultool action seems to fail; 
 
       - name: Convert results for Codecov
         run: |

--- a/bin/test
+++ b/bin/test
@@ -9,7 +9,7 @@ set -e
 
 CLONED_SOURCE_PACKAGES_DIR_PATH=".build"    # This matches spm location `swift run` uses
 DERIVED_DATA_PATH=".build/DerivedData"
-XCRESULT_PATH=".build/test/output.xcresult"
+XCRESULT_PATH=".build/test/output"
 
 if [ -d "$XCRESULT_PATH" ]; then
     rm -rf $XCRESULT_PATH


### PR DESCRIPTION
# Overview
A few weeks ago, we started experiencing several issues with the run-tests workflow, likely due to recent updates to some actions and the underlying changes in how some of those GitHub Actions behave. This PR aims to address all of those issues.

# Details
- Replaced the usage of `xcpretty` to use [`xcbeautify`](https://github.com/cpisciotta/xcbeautify), which is slightly more stable, faster, better supports Xcode’s "new" build system, and handles SPM output formatting.
- The `kishikawakatsumi/xcresulttool` action consistently fails when trying to upload the `.xcresult` bundle. To work around this, we now manually upload the `.xcresult` artifact using the `upload-artifact` action, and configure the `xcresulttool` action to skip the upload step.
> [!IMPORTANT]  
> The `.xcresult` bundle will be uploaded as a `.zip` file. After downloading, be sure to extract its contents and rename the resulting folder by appending the `.xcresult` extension.