### PR TITLE
[EMBR-6503] Add Metadata Tests on Functional Test App

### DIFF
--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Enums/TestResult.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Enums/TestResult.swift
@@ -10,12 +10,14 @@ enum TestResult {
     case unknown
     case testing
     case success
+    case warning
     case fail
 
     var resultColor: Color {
         switch self {
         case .unknown, .testing: .gray
         case .success: .green
+        case .warning: .yellow
         case .fail: .red
         }
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Protocols/PayloadTestProtocol.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Protocols/PayloadTestProtocol.swift
@@ -17,6 +17,7 @@ protocol PayloadTest {
     func test(spans: [OpenTelemetrySdk.SpanData], logs: [ReadableLogRecord]) -> TestReport
     func evaluate(_ target: String, expecting: String, on: [String: AttributeValue]) -> TestReportItem
     func evaluate(_ target: String, contains: String, on: [String: AttributeValue]) -> TestReportItem
+    func evaluate(_ target: String, expectedToExist: Bool, on: [String: AttributeValue]) -> TestReportItem
     func evaluateSpanExistence(identifiedBy id: String, underAttributeKey key: String, on spans: [SpanData]) -> (TestReportItem, SpanData?)
     func evaluateLogExistence(withMessage: String, on logs: [ReadableLogRecord]) -> (TestReportItem, ReadableLogRecord?)
     func runTestPreparations()
@@ -57,6 +58,15 @@ extension PayloadTest {
         let result: TestResult = recorded.contains(substring) ? .success : .fail
 
         return .init(target: target, expected: "contains \(substring)", recorded: result == .success ? "found" : "missing", result: result)
+    }
+
+    func evaluate(_ target: String, expectedToExist: Bool = true, on attributes: [String: AttributeValue]) -> TestReportItem {
+        let value = attributes[target]
+        
+        let expected = expectedToExist ? "exists" : "missing"
+        let recorded = value != nil ? "exists" : "missing"
+
+        return .init(target: target, expected: expected, recorded: recorded)
     }
 
     func test(spans: [OpenTelemetrySdk.SpanData]) -> TestReport { .init(items: []) }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Views/TestComponentViewResult.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Views/TestComponentViewResult.swift
@@ -14,6 +14,8 @@ struct TextComponentViewResult: View {
             "xmark.circle.fill"
         case .unknown, .testing:
             "questionmark.circle.fill"
+        case .warning:
+            "exclamationmark.circle.fill"
         case .success:
             "checkmark.circle.fill"
         }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Screens/TestReportCard/Views/TestReportCardItemView.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Screens/TestReportCard/Views/TestReportCardItemView.swift
@@ -21,11 +21,24 @@ struct TestReportCardItemView: View {
                     .font(.embraceFont(size: 11))
                     .frame(width: 100, alignment: .leading)
                 Spacer()
-                Image(systemName: item.passed ? "checkmark" : "xmark")
-                    .foregroundStyle(item.passed ? .green : .red)
+                Image(systemName: iconName(for: item.result))
+                    .foregroundStyle(item.result.resultColor)
                     .frame(width: 20, alignment: .trailing)
                     .padding(.trailing, 5)
             }
+        }
+    }
+
+    private func iconName(for result: TestResult) -> String {
+        switch result {
+        case .fail:
+            "xmark"
+        case .success:
+            "checkmark"
+        case .warning:
+            "exclamationmark"
+        default:
+            "questionmark"
         }
     }
 }
@@ -33,7 +46,10 @@ struct TestReportCardItemView: View {
 #Preview {
     @Previewable var passedItem: TestReportItem = .init(target: "viewDidLoad", expected: "viewDidLoad", recorded: "found", result: .success)
     @Previewable var failItem: TestReportItem = .init(target: "viewDidLoad", expected: "viewDidLoad", recorded: "not found", result: .fail)
+    @Previewable var warningItem: TestReportItem = .init(target: "viewDidLoad", expected: "viewDidLoad", recorded: "not found", result: .warning)
     TestReportCardItemView(item: passedItem)
         .padding(.bottom, 40)
     TestReportCardItemView(item: failItem)
+        .padding(.bottom, 40)
+    TestReportCardItemView(item: warningItem)
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/Tests/LoggingErrorMessageTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/Tests/LoggingErrorMessageTest.swift
@@ -45,6 +45,8 @@ class LoggingErrorMessageTest: PayloadTest {
             testItems.append(evaluate(property.key, expecting: property.value, on: log.attributes))
         }
 
+        MetadataResourceTest.testMetadataInclussion(on: log.resource, testItems: &testItems)
+
         return .init(items: testItems)
     }
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/MetadataTestsDataModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/MetadataTestsDataModel.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum MetadataTestsDataModel: Int, TestScreenDataModel, CaseIterable {
     case setup = 0
     case start
+    case resourceMetadata
 
     var title: String {
         switch self {
@@ -16,6 +17,8 @@ enum MetadataTestsDataModel: Int, TestScreenDataModel, CaseIterable {
             "Setup Payload"
         case .start:
             "Start Payload"
+        case .resourceMetadata:
+            "Payload Resource Attributes"
         }
     }
 
@@ -25,15 +28,19 @@ enum MetadataTestsDataModel: Int, TestScreenDataModel, CaseIterable {
             "setupPayloadTestButton"
         case .start:
             "startPayloadTestButton"
+        case .resourceMetadata:
+            "payloadResourceAttributesTestButton"
         }
     }
 
     @ViewBuilder var uiComponent: some View {
         switch self {
         case .setup:
-            TestSpanScreenButtonView(viewModel: .init(dataModel: self, payloadTestObject: MetadataSetupTest()))
+            TestSpanScreenButtonView(viewModel: .init(dataModel: self, payloadTestObject: MetadataSetupPayloadTest()))
         case .start:
-            TestSpanScreenButtonView(viewModel: .init(dataModel: self, payloadTestObject: MetadataStartTest()))
+            TestSpanScreenButtonView(viewModel: .init(dataModel: self, payloadTestObject: MetadataStartupPayloadTest()))
+        case .resourceMetadata:
+            TestSpanScreenButtonView(viewModel: .init(dataModel: self, payloadTestObject: MetadataResourceTest()))
         }
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataResourceTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataResourceTest.swift
@@ -1,0 +1,90 @@
+//
+//  MetadataResourceTest.swift
+//  EmbraceIOTestApp
+//
+//
+
+import OpenTelemetrySdk
+import OpenTelemetryApi
+
+class MetadataResourceTest: PayloadTest {
+    var testRelevantPayloadNames: [String] { ["emb-sdk-start"] }
+    var requiresCleanup: Bool { false }
+    var runImmediatelyIfSpansFound: Bool { true }
+    var testType: TestType { .Spans }
+    private var testRelevantSpanName: String {
+        testRelevantPayloadNames[0]
+    }
+
+    private static var expectedKeys: [String] {
+        ["emb.sdk.version",
+         "emb.process_pre_warm",
+         "emb.app.build_id",
+         "emb.os.build_id",
+         "emb.app.bundle_version",
+         "emb.app.version",
+         "service.name",
+         "emb.app.environment_detailed",
+         "os.type",
+         "emb.process_identifier",
+         "device.model.identifier",
+         "os.version",
+         "emb.device.architecture",
+         "emb.device.is_jailbroken",
+         "emb.device_id",
+         "emb.device.timezone",
+         "emb.os.variant",
+         "emb.device.locale",
+         "emb.process_start_time",
+         "emb.app.framework",
+         "emb.session.upload_index",
+         "emb.app.environment",
+         "emb.device.disk_size",
+         "os.name",
+         "telemetry.sdk.language"]
+    }
+
+    private static func missingResourceMetadataKeys(on attributes: [String: AttributeValue]) -> [String] {
+        return expectedKeys.filter { attributes[$0] == nil }
+    }
+
+    private static func unknownResourceMetadataKeys(on attributes: [String: AttributeValue]) -> [String] {
+        return attributes.keys.filter { !expectedKeys.contains($0) }
+    }
+
+    func test(spans: [OpenTelemetrySdk.SpanData]) -> TestReport {
+        var testItems = [TestReportItem]()
+
+        guard let startSpan = spans.first, startSpan.name == testRelevantSpanName else {
+            return .init(items: [.init(target: "\(testRelevantSpanName) span", expected: "exists", recorded: "missing", result: .fail)])
+        }
+
+        MetadataResourceTest.unknownResourceMetadataKeys(on: startSpan.resource.attributes).forEach{ unknownKey in
+            testItems.append(.init(target: unknownKey, expected: "unexpected", recorded: "unexpected key found", result: .warning))
+        }
+
+        MetadataResourceTest.expectedKeys.forEach { key in
+            testItems.append(evaluate(key, on: startSpan.resource.attributes))
+        }
+
+        return .init(items: testItems)
+    }
+
+    static func testMetadataInclussion(on resource: Resource, testItems: inout [TestReportItem]) {
+        let missingMetadataKeys = missingResourceMetadataKeys(on: resource.attributes)
+        testItems.append(.init(target: "Missing Metadata Keys", expected: 0, recorded: missingMetadataKeys.count))
+
+        missingMetadataKeys.forEach { missingKey in
+            testItems.append(.init(target: "Metadata Key \(missingKey)", expected: "exists", recorded: "missing"))
+        }
+
+        let unknownMetadataKeys = MetadataResourceTest.unknownResourceMetadataKeys(on: resource.attributes)
+        if (unknownMetadataKeys.count > 0) {
+            testItems.append(.init(target: "Unknown Metadata Keys", expected: "0", recorded: "\(missingMetadataKeys.count)", result: .warning))
+
+            unknownMetadataKeys.forEach { unknownKey in
+                testItems.append(.init(target: "Metadata Key \(unknownKey)", expected: "unexpected", recorded: "unexpected key found", result: .warning))
+            }
+        }
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataSetupPayloadTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataSetupPayloadTest.swift
@@ -1,34 +1,12 @@
 //
-//  MetadataTest.swift
+//  MetadataSetupPayloadTest.swift
 //  EmbraceIOTestApp
 //
 //
 
 import OpenTelemetrySdk
 
-class MetadataStartTest: PayloadTest {
-    var testRelevantPayloadNames: [String] { ["emb-sdk-start"] }
-    var requiresCleanup: Bool { false }
-    var runImmediatelyIfSpansFound: Bool { true }
-    var testType: TestType { .Spans }
-    private var testRelevantSpanName: String {
-        testRelevantPayloadNames[0]
-    }
-
-    func test(spans: [OpenTelemetrySdk.SpanData]) -> TestReport {
-        var testItems = [TestReportItem]()
-
-        guard let startSpan = spans.first, startSpan.name == testRelevantSpanName else {
-            return .init(items: [.init(target: "\(testRelevantSpanName) span", expected: "exists", recorded: "missing", result: .fail)])
-        }
-
-        testItems.append(evaluate("emb.type", expecting: "perf", on: startSpan.attributes))
-
-        return .init(items: testItems)
-    }
-}
-
-class MetadataSetupTest: PayloadTest {
+class MetadataSetupPayloadTest: PayloadTest {
     var testRelevantPayloadNames: [String] { ["emb-setup"] }
     var requiresCleanup: Bool { false }
     var runImmediatelyIfSpansFound: Bool { true }
@@ -46,6 +24,8 @@ class MetadataSetupTest: PayloadTest {
 
         testItems.append(evaluate("emb.type", expecting: "perf", on: setupSpan.attributes))
         testItems.append(evaluate("emb.private", expecting: "true", on: setupSpan.attributes))
+
+        MetadataResourceTest.testMetadataInclussion(on: setupSpan.resource, testItems: &testItems)
 
         return .init(items: testItems)
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataStartupPayloadTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataStartupPayloadTest.swift
@@ -1,0 +1,31 @@
+//
+//  MetadataStartupPayloadTest.swift
+//  EmbraceIOTestApp
+//
+//
+
+import OpenTelemetrySdk
+
+class MetadataStartupPayloadTest: PayloadTest {
+    var testRelevantPayloadNames: [String] { ["emb-sdk-start"] }
+    var requiresCleanup: Bool { false }
+    var runImmediatelyIfSpansFound: Bool { true }
+    var testType: TestType { .Spans }
+    private var testRelevantSpanName: String {
+        testRelevantPayloadNames[0]
+    }
+
+    func test(spans: [OpenTelemetrySdk.SpanData]) -> TestReport {
+        var testItems = [TestReportItem]()
+
+        guard let startSpan = spans.first, startSpan.name == testRelevantSpanName else {
+            return .init(items: [.init(target: "\(testRelevantSpanName) span", expected: "exists", recorded: "missing", result: .fail)])
+        }
+
+        testItems.append(evaluate("emb.type", expecting: "perf", on: startSpan.attributes))
+
+        MetadataResourceTest.testMetadataInclussion(on: startSpan.resource, testItems: &testItems)
+
+        return .init(items: testItems)
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Netowrking/Tests/NetworkingTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Netowrking/Tests/NetworkingTest.swift
@@ -55,6 +55,8 @@ class NetworkingTest: PayloadTest {
             testItems.append(.init(target: "http.request.body.size", expected: "Bigger than 0", recorded: "\(bodySize)", result: bodySize > 0 ? .success : .fail))
         }
 
+        MetadataResourceTest.testMetadataInclussion(on: networkCallSpan.resource, testItems: &testItems)
+
         return .init(items: testItems)
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/ViewControllers/Tests/ViewControllerViewDidAppearTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/ViewControllers/Tests/ViewControllerViewDidAppearTest.swift
@@ -58,6 +58,8 @@ class ViewControllerViewDidAppearTest: PayloadTest {
 
         testItems.append(.init(target: "Span Trigger Order", expected: "didLoad, willAppear, isAppearing, didAppear", recorded: spanOrderString(order)))
 
+        MetadataResourceTest.testMetadataInclussion(on: viewDidLoadSpan.resource, testItems: &testItems)
+
         return .init(items: testItems)
     }
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/ViewControllers/Tests/ViewControllerViewDidLoadTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/ViewControllers/Tests/ViewControllerViewDidLoadTest.swift
@@ -30,6 +30,8 @@ class ViewControllerViewDidLoadTest: PayloadTest {
         testItems.append(evaluate("view.title", expecting: "TestViewController", on: viewDidLoadSpan.attributes))
         testItems.append(evaluate("view.name", expecting: "TestViewController", on: viewDidLoadSpan.attributes))
 
+        MetadataResourceTest.testMetadataInclussion(on: viewDidLoadSpan.resource, testItems: &testItems)
+
         return .init(items: testItems)
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
@@ -1,0 +1,133 @@
+//
+//  EmbraceIOTestNetworkingUITests.swift
+//  EmbraceIOTestApp
+//
+//
+
+import XCTest
+@testable import EmbraceIOTestApp
+
+final class EmbraceIOTestNetworkingUITests: XCTestCase {
+    var app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        app.launch()
+
+        let initButton = app.buttons["EmbraceInitButton"]
+        initButton.tap()
+
+        XCTAssertTrue(initButton.wait(for: \.label, toEqual: "EmbraceIO has started!", timeout: 5.0))
+
+        let sideMenuButton = app.buttons["SideMenuButton"]
+        sideMenuButton.tap()
+
+        app.staticTexts["networking"].tap()
+
+        continueAfterFailure = true
+    }
+
+    override func tearDownWithError() throws {
+
+    }
+
+    private var embraceURL: String { "https://embrace.io" }
+    private var reqresURL: String { "https://reqres.in" }
+    private var reqresUsersAPI: String { "/api/users" }
+
+    private func enterURL(_ url: String) {
+        let urlTextField = app.textFields["networkingTests_URLTextField"]
+        urlTextField.tap()
+
+        _ = waitUntilElementHasFocus(element: urlTextField)
+
+        urlTextField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: (urlTextField.value as? String ?? "").count))
+
+        urlTextField.typeText(url)
+        urlTextField.typeText(XCUIKeyboardKey.return.rawValue)
+    }
+
+    private func enterAPI(_ api: String) {
+        let apiTextField = app.textFields["networkingTests_APITextField"]
+        apiTextField.tap()
+
+        _ = waitUntilElementHasFocus(element: apiTextField)
+
+        apiTextField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: (apiTextField.value as? String ?? "").count))
+
+        apiTextField.typeText(api)
+        apiTextField.typeText(XCUIKeyboardKey.return.rawValue)
+    }
+
+    private func selectRequestMethod(_ method: URLRequestMethod) {
+        let identifier = method.identifier
+        app.buttons[identifier].tap()
+    }
+
+    private func enterCustomBodyProperty(key: String, value: String) {
+        let bodyKeyTextField = app.textFields["NetworkingTestBody_Key"]
+        bodyKeyTextField.tap()
+
+        _ = waitUntilElementHasFocus(element: bodyKeyTextField)
+
+        bodyKeyTextField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyKeyTextField.value as? String ?? "").count))
+
+        bodyKeyTextField.typeText(key)
+        bodyKeyTextField.typeText(XCUIKeyboardKey.return.rawValue)
+
+        let bodyValueTextField = app.textFields["NetworkingTestBody_Value"]
+        bodyValueTextField.tap()
+
+        _ = waitUntilElementHasFocus(element: bodyValueTextField)
+
+        bodyValueTextField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyValueTextField.value as? String ?? "").count))
+
+        bodyValueTextField.typeText(value)
+        bodyValueTextField.typeText(XCUIKeyboardKey.return.rawValue)
+
+        app.buttons["NetworkingTestBody_Insert_Button"].tap()
+    }
+
+    private func runNetworkTest() {
+        app.buttons["networkCallTestButton"].tap()
+
+        sleep(5)
+
+        XCTAssertTrue(app.staticTexts["PASS"].exists)
+        XCTAssertFalse(app.staticTexts["FAIL"].exists)
+    }
+
+    func testGetRequest() {
+        enterURL(embraceURL)
+        selectRequestMethod(.get)
+
+        runNetworkTest()
+    }
+
+    func testPostRequest() {
+        enterURL(reqresURL)
+        enterAPI(reqresUsersAPI)
+        selectRequestMethod(.post)
+        enterCustomBodyProperty(key: "name", value: "Charles")
+        enterCustomBodyProperty(key: "job", value: "Whatever")
+
+        runNetworkTest()
+    }
+
+    func testPutRequest() {
+        enterURL(reqresURL)
+        enterAPI("\(reqresUsersAPI)/1234")
+        selectRequestMethod(.put)
+        enterCustomBodyProperty(key: "name", value: "Charles")
+        enterCustomBodyProperty(key: "job", value: "Whatever")
+
+        runNetworkTest()
+    }
+
+    func testDeleteRequest() {
+        enterURL(reqresURL)
+        enterAPI("\(reqresUsersAPI)/1234")
+        selectRequestMethod(.delete)
+
+        runNetworkTest()
+    }
+}


### PR DESCRIPTION
Added metadata tests on all payloads, and a dedicated metadata test listing all the keys and checking they exist.

None of the changes on this PR affects the actual SDK, they're all for the Functional Test App.