### PR TITLE
Fix `UIViewControllerHandlerTests`

### DIFF
--- a/Sources/EmbraceCore/Capture/UX/View/UIViewControllerHandler.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/UIViewControllerHandler.swift
@@ -21,7 +21,7 @@ protocol UIViewControllerHandlerDataSource: AnyObject {
 class UIViewControllerHandler {
 
     weak var dataSource: UIViewControllerHandlerDataSource?
-    private let queue: DispatchableQueue = .with(label: "com.embrace.UIViewControllerHandler", qos: .utility)
+    private let queue: DispatchableQueue
 
     @ThreadSafe var parentSpans: [String: Span] = [:]
     @ThreadSafe var viewDidLoadSpans: [String: Span] = [:]
@@ -33,7 +33,8 @@ class UIViewControllerHandler {
     @ThreadSafe var uiReadySpans: [String: Span] = [:]
     @ThreadSafe var alreadyFinishedUiReadyIds: Set<String> = []
 
-    init() {
+    init(queue: DispatchableQueue = .with(label: "com.embrace.UIViewControllerHandler", qos: .utility)) {
+        self.queue = queue
         Embrace.notificationCenter.addObserver(
             self,
             selector: #selector(foregroundSessionDidEnd),

--- a/Tests/EmbraceCoreTests/Capture/UX/View/UIViewControllerHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/View/UIViewControllerHandlerTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import OpenTelemetryApi
 import EmbraceOTelInternal
 import TestSupport
+import EmbraceCommonInternal
 
 class UIViewControllerHandlerTests: XCTestCase {
 
@@ -21,7 +22,7 @@ class UIViewControllerHandlerTests: XCTestCase {
 
     override func setUpWithError() throws {
         dataSource = MockUIViewControllerHandlerDataSource()
-        handler = UIViewControllerHandler()
+        handler = UIViewControllerHandler(queue: DispatchQueue.main)
         handler.dataSource = dataSource
     }
 

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/DispatchQueue+DispatchableQueue.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/DispatchQueue+DispatchableQueue.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+    
+import Foundation
+import EmbraceCommonInternal
+
+// Only add this extension to Test Targets
+extension DispatchQueue: @retroactive DispatchableQueue {
+    public func async(_ block: @escaping () -> Void) {
+        self.async(execute: block)
+    }
+}

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/DispatchQueue+DispatchableQueue.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/DispatchQueue+DispatchableQueue.swift
@@ -6,7 +6,7 @@ import Foundation
 import EmbraceCommonInternal
 
 // Only add this extension to Test Targets
-extension DispatchQueue: @retroactive DispatchableQueue {
+extension DispatchQueue: DispatchableQueue {
     public func async(_ block: @escaping () -> Void) {
         self.async(execute: block)
     }


### PR DESCRIPTION
# Overview
`UIViewControllerHandlerTests` are flaky. This PR attempts to fix that by ensuring the logic runs on the main thread when running in a test environment, preventing timeouts.
