### PR TITLE
Fixed `SessionControllerTests`

### DIFF
--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -47,22 +47,23 @@ class SessionController: SessionControllable {
     }
 
     let heartbeat: SessionHeartbeat
-    let queue: DispatchQueue
+    let queue: DispatchableQueue
     var firstSession = true
 
     init(
         storage: EmbraceStorage,
         upload: EmbraceUpload?,
         config: EmbraceConfig?,
-        heartbeatInterval: TimeInterval = SessionHeartbeat.defaultInterval
+        heartbeatInterval: TimeInterval = SessionHeartbeat.defaultInterval,
+        queue: DispatchableQueue = .with(label: "com.embrace.session_controller_upload"),
+        heartbeatQueue: DispatchQueue = DispatchQueue(label: "com.embrace.session_heartbeat")
     ) {
         self.storage = storage
         self.upload = upload
         self.config = config
 
-        let heartbeatQueue = DispatchQueue(label: "com.embrace.session_heartbeat")
         self.heartbeat = SessionHeartbeat(queue: heartbeatQueue, interval: heartbeatInterval)
-        self.queue = DispatchQueue(label: "com.embrace.session_controller_upload")
+        self.queue = queue
 
         self.heartbeat.callback = { [weak self] in
             let heartbeat = Date()

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -45,8 +45,7 @@ final class SessionControllerTests: XCTestCase {
             urlSessionConfiguration: uploadUrlSessionconfig
         )
 
-        self.queue = DispatchQueue(label: "com.test.embrace.upload.queue", attributes: .concurrent)
-        upload = try EmbraceUpload(options: uploadTestOptions, logger: MockLogger(), queue: queue, semaphore: .init(value: .max))
+        upload = try EmbraceUpload(options: uploadTestOptions, logger: MockLogger(), queue: .main, semaphore: .init(value: .max))
         storage = try EmbraceStorage.createInMemoryDb()
 
         sdkStateProvider.isEnabled = true

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/EmbraceConfigMock.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/EmbraceConfigMock.swift
@@ -4,6 +4,7 @@
 
 @testable import EmbraceConfigInternal
 import TestSupport
+import Foundation
 
 class EmbraceConfigMock {
     static func `default`(sdkEnabled: Bool = true) -> EmbraceConfig {
@@ -11,7 +12,8 @@ class EmbraceConfigMock {
             configurable: MockEmbraceConfigurable(isSDKEnabled: sdkEnabled),
             options: .init(minimumUpdateInterval: .infinity),
             notificationCenter: .default,
-            logger: MockLogger()
+            logger: MockLogger(),
+            queue: DispatchQueue.main
         )
     }
 }


### PR DESCRIPTION
# Overview
Following the same approach as the previous [`UIViewControllerHandlerTests` PR](https://github.com/embrace-io/embrace-apple-sdk/pull/205), `SessionControllerTests` are also flaky, and in this PR we attempt to fix that by ensuring the logic runs on the main thread when running in a test environment, preventing timeouts and other inconsistencies.