### PR TITLE
Added default `completionHandler` on `didReceiveResponse` in `EMBURLSessionDelegateProxy`

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/source/EMBURLSessionDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/EMBURLSessionDelegateProxy.m
@@ -135,6 +135,8 @@ didReceiveResponse:(NSURLResponse *)response
 
     if (target) {
         [(id<NSURLSessionDataDelegate>)target URLSession:session dataTask:dataTask didReceiveResponse:response completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionResponseAllow);
     }
 }
 


### PR DESCRIPTION
# Overview
When the swizzled delegate by `EMBURLSessionDelegateProxy` doesn't implement the `didReceiveResponse`, we need to provide a default `NSURLSessionResponseDisposition` value.
This prevents the next error from happening:
> API MISUSE: `dataTask:didReceiveResponse:completionHandler:` completion handler not called