### PR TITLE
Autoinstrumentation feature flag was changed due to problems in the o…

### DIFF
--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -34,7 +34,7 @@ public struct RemoteConfigPayload: Decodable, Equatable {
             case threshold = "pct_enabled"
         }
 
-        case uiLoadInstrumentationEnabled = "ui_load_instrumentation_enabled"
+        case uiLoadInstrumentationEnabled = "ui_load_instrumentation_enabled_v2"
 
         case internalLogLimits = "internal_log_limits"
         enum InternalLogLimitsCodingKeys: String, CodingKey {

--- a/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
+++ b/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
@@ -6,7 +6,7 @@
     "network_span_forwarding": {
         "pct_enabled": 25
     },
-    "ui_load_instrumentation_enabled": false,
+    "ui_load_instrumentation_enabled_v2": false,
     "internal_log_limits": {
         "trace": 10,
         "debug": 20,


### PR DESCRIPTION
# Overview
Old flag is broken for some iOS versions. To prevent any kind of error from happening, we changed the autoinstrumentation flag to be `ui_load_instrumentation_enabled_v2`.