### PR TITLE
Fixed crash in DefaultURLSessionTaskHandler.addData

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
@@ -153,4 +153,8 @@ class NetworkPayloadCaptureHandler {
             rulesTriggeredMap[rule.id] = true
         }
     }
+
+    func isEnabled() -> Bool {
+        active && rules.count > 0
+    }
 }

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTask+Extension.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTask+Extension.swift
@@ -30,6 +30,12 @@ extension URLSessionTask {
         }
     }
 
+    /// Stores the accumulated response body data for a `URLSessionTask`.
+    ///
+    /// This is primarily used when network body capture is enabled.
+    ///
+    /// - Warning: Access to this property must be synchronized externally (e.g., using `DispatchQueue` or `UnfairLock`)
+    /// to ensure thread safety, since `URLSessionTask` is shared across threads.
     var embraceData: Data? {
         get {
             return objc_getAssociatedObject(self,

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTask+Extension.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTask+Extension.swift
@@ -39,7 +39,7 @@ extension URLSessionTask {
             objc_setAssociatedObject(self,
                                      &AssociatedKeys.embraceData,
                                      newValue,
-                                     .OBJC_ASSOCIATION_RETAIN)
+                                     .OBJC_ASSOCIATION_COPY)
         }
     }
 

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -26,12 +26,15 @@ protocol URLSessionTaskHandlerDataSource: AnyObject {
 final class DefaultURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
     private var spans: [URLSessionTask: Span] = [:]
     private let queue: DispatchableQueue
+    private let capturedDataQueue: DispatchableQueue
     private let payloadCaptureHandler: NetworkPayloadCaptureHandler
     weak var dataSource: URLSessionTaskHandlerDataSource?
 
     init(processingQueue: DispatchableQueue = DefaultURLSessionTaskHandler.queue(),
+         capturedDataQueue: DispatchableQueue = DefaultURLSessionTaskHandler.capturedDataQueue(),
          dataSource: URLSessionTaskHandlerDataSource?) {
         self.queue = processingQueue
+        self.capturedDataQueue = capturedDataQueue
         self.dataSource = dataSource
         self.payloadCaptureHandler = NetworkPayloadCaptureHandler(otel: dataSource?.otel)
     }
@@ -159,11 +162,13 @@ final class DefaultURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
             }
 
             if let data = data {
-                let totalData = task.embraceData ?? data
-                span.setAttribute(
-                    key: SpanSemantics.NetworkRequest.keyResponseSize,
-                    value: totalData.count
-                )
+                self.capturedDataQueue.sync {
+                    let totalData = task.embraceData ?? data
+                    span.setAttribute(
+                        key: SpanSemantics.NetworkRequest.keyResponseSize,
+                        value: totalData.count
+                    )
+                }
             }
 
             if let error = error ?? task.error {
@@ -192,11 +197,13 @@ final class DefaultURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
 
     func addData(_ data: Data, dataTask: URLSessionDataTask) {
         if payloadCaptureHandler.isEnabled() {
-            if var previousData = dataTask.embraceData {
-                previousData.append(data)
-                dataTask.embraceData = previousData
-            } else {
-                dataTask.embraceData = data
+            capturedDataQueue.sync {
+                if var previousData = dataTask.embraceData {
+                    previousData.append(data)
+                    dataTask.embraceData = previousData
+                } else {
+                    dataTask.embraceData = data
+                }
             }
         }
     }
@@ -245,5 +252,9 @@ final class DefaultURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
 private extension DefaultURLSessionTaskHandler {
     static func queue() -> DispatchableQueue {
         .with(label: "com.embrace.URLSessionTaskHandler", qos: .utility)
+    }
+
+    static func capturedDataQueue() -> DispatchableQueue {
+        .with(label: "com.embrace.URLSessionTask.embraceData", qos: .utility)
     }
 }

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -191,11 +191,13 @@ final class DefaultURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
     }
 
     func addData(_ data: Data, dataTask: URLSessionDataTask) {
-        if var previousData = dataTask.embraceData {
-            previousData.append(data)
-            dataTask.embraceData = previousData
-        } else {
-            dataTask.embraceData = data
+        if payloadCaptureHandler.isEnabled() {
+            if var previousData = dataTask.embraceData {
+                previousData.append(data)
+                dataTask.embraceData = previousData
+            } else {
+                dataTask.embraceData = data
+            }
         }
     }
 


### PR DESCRIPTION
# Overview
A crash was occurring when attempting to append data to a URLSessionTask’s associated `embraceData` because the associated_object was not done in a way that would ensure thread safety.

# Details
- Switched from `OBJC_ASSOCIATION_RETAIN` to `OBJC_ASSOCIATION_COPY` when associating `embraceData` to `URLSessionTask` to ensure data consistency and avoid thread/memory issues.
- Added a guard around the `addData` method to ensure it only performs operations if network body capture feature is enabled (which, by default, is off).

Fixes #217 