### PR TITLE
Ensure payload data is always included when Network Payload Capture is enabled

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/URLSessionTask+Extension.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTask+Extension.swift
@@ -9,7 +9,6 @@ extension URLSessionTask {
         static var embraceCaptured: UInt8 = 0
         static var embraceData: UInt8 = 1
         static var embraceStartTime: UInt8 = 2
-        static var embraceEndTime: UInt8 = 3
     }
 
     var embraceCaptured: Bool {
@@ -51,19 +50,6 @@ extension URLSessionTask {
         set {
             objc_setAssociatedObject(self,
                                      &AssociatedKeys.embraceStartTime,
-                                     newValue,
-                                     .OBJC_ASSOCIATION_RETAIN)
-        }
-    }
-
-    var embraceEndTime: Date? {
-        get {
-            return objc_getAssociatedObject(self,
-                                            &AssociatedKeys.embraceEndTime) as? Date
-        }
-        set {
-            objc_setAssociatedObject(self,
-                                     &AssociatedKeys.embraceEndTime,
                                      newValue,
                                      .OBJC_ASSOCIATION_RETAIN)
         }

--- a/Sources/EmbraceObjCUtilsInternal/include/EMBURLSessionDelegateProxy.h
+++ b/Sources/EmbraceObjCUtilsInternal/include/EMBURLSessionDelegateProxy.h
@@ -13,6 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)finishWithTask:(NSURLSessionTask *)task
                   data:(nullable NSData *)data
                  error:(nullable NSError *)error NS_SWIFT_NAME(finish(task:data:error:));
+- (void)finishWithTask:(NSURLSessionTask *)task
+              bodySize:(NSInteger )bodySize
+                 error:(nullable NSError *)error NS_SWIFT_NAME(finish(task:bodySize:error:));
 - (void)addData:(NSData *)data dataTask:(NSURLSessionDataTask *)dataTask NS_SWIFT_NAME(addData(_:dataTask:));
 
 @end

--- a/Sources/EmbraceObjCUtilsInternal/source/EMBURLSessionDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/EMBURLSessionDelegateProxy.m
@@ -106,13 +106,18 @@
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics {
-    [self.handler finishWithTask:task data:nil error:nil];
+    NSInteger totalBytes = 0;
+    for (NSURLSessionTaskTransactionMetrics *transaction in metrics.transactionMetrics) {
+        totalBytes += transaction.countOfResponseBodyBytesReceived;
+    }
+
+    [self.handler finishWithTask:task bodySize:totalBytes error:nil];
+
     id target = [self getTargetForSelector:DID_FINISH_COLLECTING_METRICS session:session];
 
     if (target) {
         [(id<NSURLSessionTaskDelegate>)target URLSession:session task:task didFinishCollectingMetrics:metrics];
     }
-
 }
 
 #pragma mark - NSURLSessionDataDelegate Methods


### PR DESCRIPTION
# Overview
This PR introduces the necessary changes to ensure that, whenever the **Network Payload Capture** functionality is enabled, the payload associated with a request is properly captured regardless of whether `async` APIs, block-based (`completionHandler`), or delegation patterns are used.

# Details
- Removed `embraceEndTime` as it's an unnecessary associated object to the `URLSessionTask`. 
- Make some changes to make the `endTime` that the **Network Payload Capture** uses to be more accurate.