### PR TITLE
Improvements around data cleanup and fetches

### DIFF
--- a/Sources/EmbraceCore/Public/Metadata/MetadataHandler.swift
+++ b/Sources/EmbraceCore/Public/Metadata/MetadataHandler.swift
@@ -247,9 +247,10 @@ extension MetadataHandler {
         }
 
         let request = NSFetchRequest<MetadataRecordTmp>(entityName: MetadataRecordTmp.entityName)
-        let oldRecords = coreData.fetch(withRequest: request)
 
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) { 
+            oldRecords in
+
             for record in oldRecords {
                 guard let type = MetadataRecordType(rawValue: record.type),
                       let lifespan = MetadataRecordLifespan(rawValue: record.lifespan) else {

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -225,6 +225,11 @@ class UnsentDataHandler {
             return
         }
 
+        if performCleanUp {
+            cleanOldSpans(storage: storage)
+            cleanMetadata(storage: storage)
+        }
+
         // upload session spans
         upload.uploadSpans(id: session.idRaw, data: payloadData) { result in
             switch result {
@@ -233,11 +238,6 @@ class UnsentDataHandler {
                 // we can remove this immediately because the upload module will cache it until the upload succeeds
                 if let sessionId = session.id {
                     storage.deleteSession(id: sessionId)
-                }
-
-                if performCleanUp {
-                    cleanOldSpans(storage: storage)
-                    cleanMetadata(storage: storage)
                 }
 
             case .failure(let error):

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Log.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Log.swift
@@ -59,11 +59,11 @@ extension EmbraceStorage {
         request.predicate = NSPredicate(format: "processIdRaw != %@", processIdentifier.hex)
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceLog] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -152,8 +152,7 @@ extension EmbraceStorage {
             request.predicate = processIdPredicate
         }
 
-        let records = coreData.fetch(withRequest: request)
-        coreData.deleteRecords(records)
+        coreData.deleteRecords(withRequest: request)
     }
 
     /// Removes the `MetadataRecord` for the given values.
@@ -190,8 +189,7 @@ extension EmbraceStorage {
 
         request.predicate = NSCompoundPredicate(type: .and, subpredicates: [typePredicate, lifespansPredicate])
 
-        let records = coreData.fetch(withRequest: request)
-        coreData.deleteRecords(records)
+        coreData.deleteRecords(withRequest: request)
     }
 
     /// Removes all `MetadataRecords` for the given keys and timespan.
@@ -214,8 +212,7 @@ extension EmbraceStorage {
 
         request.predicate = NSCompoundPredicate(type: .and, subpredicates: [typePredicate, keyPredicate])
 
-        let records = coreData.fetch(withRequest: request)
-        coreData.deleteRecords(records)
+        coreData.deleteRecords(withRequest: request)
     }
 
     /// Returns the permanent required resource for the given key.
@@ -257,11 +254,11 @@ extension EmbraceStorage {
         )
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceMetadata] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 
@@ -285,11 +282,11 @@ extension EmbraceStorage {
         )
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceMetadata] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 
@@ -309,11 +306,11 @@ extension EmbraceStorage {
         )
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceMetadata] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 
@@ -336,11 +333,11 @@ extension EmbraceStorage {
         )
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceMetadata] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 
@@ -363,11 +360,11 @@ extension EmbraceStorage {
         )
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceMetadata] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 
@@ -387,11 +384,11 @@ extension EmbraceStorage {
         )
 
         // fetch
-        let records = coreData.fetch(withRequest: request)
-
-        // convert to immutable structs
         var result: [EmbraceMetadata] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable structs
             result = records.map { $0.toImmutable() }
         }
 

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
@@ -115,11 +115,11 @@ extension EmbraceStorage {
         // fetch
         let request = fetchSessionRequest(id: id)
         var result: EmbraceSession?
-        coreData.fetchAndPerform(withRequest: request) {
-            records in
+        coreData.fetchFirstAndPerform(withRequest: request) {
+            record in
 
             // convert to immutable struct
-            result = records.first?.toImmutable()
+            result = record?.toImmutable()
         }
 
         return result
@@ -144,11 +144,11 @@ extension EmbraceStorage {
 
         // fetch
         var result: EmbraceSession?
-        coreData.fetchAndPerform(withRequest: request) {
-            records in
+        coreData.fetchFirstAndPerform(withRequest: request) {
+            record in
 
             // convert to immutable struct
-            result = records.first?.toImmutable()
+            result = record?.toImmutable()
         }
 
         return result
@@ -163,11 +163,11 @@ extension EmbraceStorage {
 
         // fetch
         var result: EmbraceSession?
-        coreData.fetchAndPerform(withRequest: request) {
-            records in
+        coreData.fetchFirstAndPerform(withRequest: request) {
+            record in
 
             // convert to immutable struct
-            result = records.first?.toImmutable()
+            result = record?.toImmutable()
         }
 
         return result
@@ -206,8 +206,8 @@ extension EmbraceStorage {
         let request = fetchSessionRequest(id: sessionId)
         var result: EmbraceSession?
 
-        coreData.fetchAndPerform(withRequest: request) { records in
-            guard let session = records.first else {
+        coreData.fetchFirstAndPerform(withRequest: request) { session in
+            guard let session else {
                 return
             }
 

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -197,16 +197,20 @@ class EmbraceUploadCache {
     ) {
 
         let request = fetchUploadDataRequest(id: id, type: type)
-        coreData.fetchAndPerform(withRequest: request) { 
-            [weak self] records in
+        coreData.fetchFirstAndPerform(withRequest: request) {
+            [weak self] record in
 
-            guard let uploadData = records.first else {
+            guard let uploadData = record else {
                 return
             }
 
             uploadData.attemptCount = attemptCount
             
-            try? self?.coreData.context.save()
+            do {
+                try self?.coreData.context.save()
+            } catch {
+                self?.logger.warning("Error upading attempt count:\n\(error.localizedDescription)")
+            }
         }
     }
 

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -32,15 +32,21 @@ class EmbraceUploadCache {
         self.coreData = try CoreDataWrapper(options: coreDataOptions, logger: logger)
     }
 
+    func fetchUploadDataRequest(id: String, type: EmbraceUploadType) -> NSFetchRequest<UploadDataRecord> {
+        let request = NSFetchRequest<UploadDataRecord>(entityName: UploadDataRecord.entityName)
+        request.predicate = NSPredicate(format: "id == %@ AND type == %i", id, type.rawValue)
+        request.fetchLimit = 1
+
+        return request
+    }
+
     /// Fetches the cached upload data for the given identifier.
     /// - Parameters:
     ///   - id: Identifier of the data
     ///   - type: Type of the data
     /// - Returns: The cached `UploadDataRecord`, if any
     public func fetchUploadData(id: String, type: EmbraceUploadType) -> UploadDataRecord? {
-        let request = NSFetchRequest<UploadDataRecord>(entityName: UploadDataRecord.entityName)
-        request.predicate = NSPredicate(format: "id == %@ AND type == %i", id, type.rawValue)
-
+        let request = fetchUploadDataRequest(id: id, type: type)
         return coreData.fetch(withRequest: request).first
     }
 
@@ -48,10 +54,13 @@ class EmbraceUploadCache {
     /// - Returns: An array containing all the cached `UploadDataRecords`
     public func fetchAllUploadData() -> [ImmutableUploadDataRecord] {
         let request = NSFetchRequest<UploadDataRecord>(entityName: UploadDataRecord.entityName)
-        let records = coreData.fetch(withRequest: request)
 
+        // fetch
         var result: [ImmutableUploadDataRecord] = []
-        coreData.context.performAndWait {
+        coreData.fetchAndPerform(withRequest: request) {
+            records in
+
+            // convert to immutable struct
             result = records.map { $0.toImmutable() }
         }
 
@@ -171,11 +180,8 @@ class EmbraceUploadCache {
     ///   - id: Identifier of the data
     ///   - type: Type of the data
     func deleteUploadData(id: String, type: EmbraceUploadType) {
-        guard let uploadData = fetchUploadData(id: id, type: type) else {
-            return
-        }
-
-        coreData.deleteRecord(uploadData)
+        let request = fetchUploadDataRequest(id: id, type: type)
+        coreData.deleteRecords(withRequest: request)
     }
 
     /// Updates the attempt count of the upload data for the given identifier.
@@ -189,13 +195,18 @@ class EmbraceUploadCache {
         type: EmbraceUploadType,
         attemptCount: Int
     ) {
-        guard let uploadData = fetchUploadData(id: id, type: type) else {
-            return
-        }
 
-        coreData.context.performAndWait { [weak self] in
+        let request = fetchUploadDataRequest(id: id, type: type)
+        coreData.fetchAndPerform(withRequest: request) { 
+            [weak self] records in
+
+            guard let uploadData = records.first else {
+                return
+            }
+
             uploadData.attemptCount = attemptCount
-            self?.coreData.save()
+            
+            try? self?.coreData.context.save()
         }
     }
 

--- a/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
+++ b/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
@@ -71,6 +71,23 @@ class CoreDataWrapperTests: XCTestCase {
         }
     }
 
+    func test_fetchFirstAndPerform() throws {
+        // given a wrapper with data
+        _ = MockRecord.create(context: wrapper.context, id: "a")
+        _ = MockRecord.create(context: wrapper.context, id: "z")
+        wrapper.save()
+
+        // when fetching data and performing a block
+        let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
+        request.sortDescriptors = [NSSortDescriptor(key: "id", ascending: true)]
+
+        wrapper.fetchFirstAndPerform(withRequest: request) { record in
+
+            // then the data is correct
+            XCTAssertEqual(record!.id, "a")
+        }
+    }
+
     func test_count() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "test1")

--- a/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
+++ b/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
@@ -54,6 +54,23 @@ class CoreDataWrapperTests: XCTestCase {
         XCTAssertEqual(result.first!.id, "test")
     }
 
+    func test_fetchAndPerform() throws {
+        // given a wrapper with data
+        _ = MockRecord.create(context: wrapper.context, id: "test")
+        wrapper.save()
+
+        // when fetching data and performing a block
+        let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
+        request.predicate = NSPredicate(format: "id == %@", "test")
+
+        wrapper.fetchAndPerform(withRequest: request) { records in
+
+            // then the data is correct
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].id, "test")
+        }
+    }
+
     func test_count() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "test1")
@@ -97,6 +114,21 @@ class CoreDataWrapperTests: XCTestCase {
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         let result = wrapper.fetch(withRequest: request)
         
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func test_deleteRecords_withRequest() throws {
+        // given a wrapper with data
+        let record1 = MockRecord.create(context: wrapper.context, id: "test1")
+        let record2 = MockRecord.create(context: wrapper.context, id: "test2")
+        wrapper.save()
+
+        // when deleting the record
+        let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
+        wrapper.deleteRecords(withRequest: request)
+
+        // then the record is deleted
+        let result = wrapper.fetch(withRequest: request)
         XCTAssertEqual(result.count, 0)
     }
 }


### PR DESCRIPTION
This PR addresses 2 things:
* Changes the order of operations when sending (and deleting) sessions, so the spans and metadata are cleaned up before hand. This change was made to fix a potential race condition that we detected.
* Improves code around fetches with Core Data. The previous implementation was pretty lazy and caused a lot of jumps between threads that were not needed.