### PR TITLE
Hang Capture Service

### DIFF
--- a/Sources/EmbraceCaptureService/CaptureService.swift
+++ b/Sources/EmbraceCaptureService/CaptureService.swift
@@ -8,6 +8,7 @@ import OpenTelemetryApi
 #if !EMBRACE_COCOAPOD_BUILDING_SDK
     import EmbraceCommonInternal
     import EmbraceOTelInternal
+    import EmbraceConfiguration
 #endif
 
 /// Base class for all capture services (this class should never be used directly)
@@ -81,6 +82,24 @@ open class CaptureService: NSObject {
     /// This method is called by the Embrace SDK when it stops capturing data.
     /// You should override this method if your `CaptureService` needs to do something when stopped.
     @objc open func onStop() {
+
+    }
+
+    /// This method is called by the Embrace SDK when a new session starts.
+    /// You should override this method if your `CaptureService` needs to do something on a new session.
+    open func onSessionStart(_ session: EmbraceSession) {
+
+    }
+
+    /// This method is called by the Embrace SDK when a session will end.
+    /// You should override this method if your `CaptureService` needs to do something before a session ends.
+    open func onSessionWillEnd(_ session: EmbraceSession) {
+
+    }
+
+    /// This method is called by the Embrace SDK when the configuration is updated.
+    /// You should override this method if your `CaptureService` needs to do something.
+    open func onConfigUpdated(_ config: EmbraceConfigurable) {
 
     }
 }

--- a/Sources/EmbraceCommonInternal/Locks/UnfairLock.swift
+++ b/Sources/EmbraceCommonInternal/Locks/UnfairLock.swift
@@ -26,6 +26,9 @@ final public class UnfairLock {
         defer { os_unfair_lock_unlock(_lock) }
         return try f()
     }
+}
+
+extension UnfairLock {
 
     public func lock() {
         os_unfair_lock_lock(_lock)

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -88,6 +88,13 @@ public class RemoteConfig {
 }
 
 extension RemoteConfig: EmbraceConfigurable {
+    public var hangLimits: EmbraceConfiguration.HangLimits {
+        HangLimits(
+            hangPerSession: payload.hangLimitsHangPerSession,
+            samplesPerHang: payload.hangLimitsSamplesPerHang
+        )
+    }
+
     public var isSDKEnabled: Bool { isEnabled(threshold: payload.sdkEnabledThreshold) }
 
     public var isBackgroundSessionEnabled: Bool { isEnabled(threshold: payload.backgroundSessionThreshold) }

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -39,6 +39,9 @@ public struct RemoteConfigPayload: Decodable, Equatable {
     var internalLogsWarningLimit: Int
     var internalLogsErrorLimit: Int
 
+    var hangLimitsHangPerSession: UInt
+    var hangLimitsSamplesPerHang: UInt
+
     var networkPayloadCaptureRules: [NetworkPayloadCaptureRule]
 
     enum CodingKeys: String, CodingKey {
@@ -83,6 +86,12 @@ public struct RemoteConfigPayload: Decodable, Equatable {
             case info
             case warning
             case error
+        }
+
+        case hangLimits = "hang_limits"
+        enum HangLimitsCodingKeys: String, CodingKey {
+            case hangPerSession = "hang_per_session"
+            case samplesPerHang = "samples_per_hang"
         }
 
         case networkPayLoadCapture = "network_capture"
@@ -214,6 +223,29 @@ public struct RemoteConfigPayload: Decodable, Equatable {
             logsErrorLimit = defaultPayload.logsErrorLimit
         }
 
+        // hang limits
+        if rootContainer.contains(.hangLimits) {
+            let hangLimitsContainer = try rootContainer.nestedContainer(
+                keyedBy: CodingKeys.HangLimitsCodingKeys.self,
+                forKey: .hangLimits
+            )
+
+            hangLimitsHangPerSession =
+                try hangLimitsContainer.decodeIfPresent(
+                    UInt.self,
+                    forKey: CodingKeys.HangLimitsCodingKeys.hangPerSession
+                ) ?? defaultPayload.hangLimitsHangPerSession
+
+            hangLimitsSamplesPerHang =
+                try hangLimitsContainer.decodeIfPresent(
+                    UInt.self,
+                    forKey: CodingKeys.HangLimitsCodingKeys.samplesPerHang
+                ) ?? defaultPayload.hangLimitsSamplesPerHang
+        } else {
+            hangLimitsHangPerSession = defaultPayload.hangLimitsHangPerSession
+            hangLimitsSamplesPerHang = defaultPayload.hangLimitsSamplesPerHang
+        }
+
         // internal logs limit
         if rootContainer.contains(.internalLogLimits) {
             let internalLogsLimitsContainer = try rootContainer.nestedContainer(
@@ -322,6 +354,9 @@ public struct RemoteConfigPayload: Decodable, Equatable {
         internalLogsInfoLimit = 0
         internalLogsWarningLimit = 0
         internalLogsErrorLimit = 3
+
+        hangLimitsHangPerSession = 200
+        hangLimitsSamplesPerHang = 0
 
         networkPayloadCaptureRules = []
     }

--- a/Sources/EmbraceConfiguration/EmbraceConfigurable.swift
+++ b/Sources/EmbraceConfiguration/EmbraceConfigurable.swift
@@ -39,6 +39,8 @@ import Foundation
 
     var networkPayloadCaptureRules: [NetworkPayloadCaptureRule] { get }
 
+    var hangLimits: HangLimits { get }
+
     /// Tell the configurable implementation it should update if possible.
     /// - Parameters:
     ///     - completion: A completion block that takes two parameters (didChange, error). Completion block should pass `true`

--- a/Sources/EmbraceConfiguration/EmbraceConfigurable/DefaultConfig.swift
+++ b/Sources/EmbraceConfiguration/EmbraceConfigurable/DefaultConfig.swift
@@ -3,6 +3,8 @@
 //
 
 public class DefaultConfig: EmbraceConfigurable {
+    public var hangLimits: HangLimits = HangLimits()
+
     public let isSDKEnabled: Bool = true
 
     public let isBackgroundSessionEnabled: Bool = false

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// HangLimits manages limits for the app hangs generated through the SDK
+@objc public class HangLimits: NSObject {
+
+    /// Maximum number of captured hangs in a session.
+    public let hangPerSession: UInt
+
+    /// Maximum number of samples captures per hang.
+    public let samplesPerHang: UInt
+
+    public init(hangPerSession: UInt = 200, samplesPerHang: UInt = 0) {
+        self.hangPerSession = hangPerSession
+        self.samplesPerHang = samplesPerHang
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Self else {
+            return false
+        }
+        return hangPerSession == other.hangPerSession && samplesPerHang == other.samplesPerHang
+    }
+}

--- a/Sources/EmbraceCore/Capture/CaptureServices.swift
+++ b/Sources/EmbraceCore/Capture/CaptureServices.swift
@@ -73,12 +73,37 @@ final class CaptureServices {
             }
         }
 
+        // Ensure the hang service has the right config
+        if let limits = config?.hangLimits {
+            services
+                .compactMap { $0 as? HangCaptureService }
+                .forEach { $0.limits = limits }
+        }
+
+        if let config {
+            services.forEach { $0.onConfigUpdated(config) }
+        }
+
         // subscribe to session start notification
         // to update the crash reporter with the new session id
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(onSessionStart),
             name: Notification.Name.embraceSessionDidStart,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onSessionWillEnd),
+            name: Notification.Name.embraceSessionWillEnd,
+            object: nil
+        )
+
+        Embrace.notificationCenter.addObserver(
+            self,
+            selector: #selector(onConfigUpdated),
+            name: Notification.Name.embraceConfigUpdated,
             object: nil
         )
     }
@@ -92,6 +117,7 @@ final class CaptureServices {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        Embrace.notificationCenter.removeObserver(self)
     }
 
     func addMetricKitServices(
@@ -145,7 +171,21 @@ final class CaptureServices {
     @objc func onSessionStart(notification: Notification) {
         if let session = notification.object as? EmbraceSession {
             crashReporter?.currentSessionId = session.idRaw
+            for service in services { service.onSessionStart(session) }
         }
+    }
+
+    @objc func onSessionWillEnd(notification: Notification) {
+        if let session = notification.object as? EmbraceSession {
+            for service in services { service.onSessionWillEnd(session) }
+        }
+    }
+
+    @objc func onConfigUpdated(notification: Notification) {
+        guard let config = notification.object as? EmbraceConfigurable else {
+            return
+        }
+        for service in services { service.onConfigUpdated(config) }
     }
 }
 

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -1,0 +1,175 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import OpenTelemetryApi
+
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
+    import EmbraceCaptureService
+    import EmbraceCommonInternal
+    import EmbraceOTelInternal
+    import EmbraceSemantics
+    import EmbraceConfiguration
+#endif
+
+/// Service that generates OpenTelemetry span events for hangs.
+@objc(EMBHangCaptureService)
+public final class HangCaptureService: CaptureService {
+
+    public init(
+        limits: HangLimits = HangLimits()
+    ) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.mainThread = pthread_self()
+        self.limitData = EmbraceMutex(LimitData(limits: limits))
+        super.init()
+    }
+
+    public override func onInstall() {
+        // Since we use `limits.hangPerSession` as a gate for the watchdog,
+        // we need to wait until the remote config is actually loaded from disk
+        // which happens just before this call.
+        watchdog = limits.hangPerSession > 0 ? HangWatchdog() : nil
+        watchdog?.hangObserver = self
+        watchdog?.logger = logger
+    }
+
+    public override func onSessionStart(_ session: any EmbraceSession) {
+        limitData.withLock { $0.hangsInSessionCount = 0 }
+    }
+
+    public override func onSessionWillEnd(_ session: any EmbraceSession) {
+        let value = limitData.withLock { $0.hangsInSessionCount }
+        try? Embrace.client?.metadata.updateProperty(key: "emb-thread-blockage", value: "\(value)")
+    }
+
+    public override func onConfigUpdated(_ config: any EmbraceConfigurable) {
+        self.limitData.withLock { $0.limits = config.hangLimits }
+    }
+
+    private var mainThread: pthread_t
+    private var watchdog: HangWatchdog?
+    private let queue = DispatchQueue(label: "io.embrace.hang.service")
+
+    private var span: OpenTelemetryApi.Span?
+
+    struct LimitData {
+        var limits: HangLimits = HangLimits()
+        var hangsInSessionCount: UInt = 0
+        var samplesInHangCount: UInt = 0
+    }
+    var limitData: EmbraceMutex<LimitData>
+
+    public var limits: HangLimits {
+        get {
+            limitData.withLock { $0.limits }
+        }
+        set {
+            limitData.withLock { $0.limits = newValue }
+        }
+    }
+}
+
+extension HangCaptureService: HangObserver {
+
+    // Hang span documented here:
+    // https://www.notion.so/embraceio/ANRs-1d77e3c9985281c58765d8c622443e2c
+
+    public func hangStarted(at: NanosecondClock, duration: NanosecondClock) {
+
+        logger?.debug("[Watchdog] Hang started, at \(at.date) after waiting \(duration.uptime.milliseconds) ms")
+
+        // Keep tabs on how many hang spans we've created
+        guard
+            limitData.withLock({
+                $0.samplesInHangCount = 0
+                $0.hangsInSessionCount += 1
+                return $0.hangsInSessionCount <= $0.limits.hangPerSession
+            })
+        else {
+            let limitData = self.limitData.withLock { $0 }
+            logger?.warning(
+                "[Watchdog] Dropping hang due to surpassing limit, \(limitData.hangsInSessionCount) of \(limitData.limits.hangPerSession)")
+            return
+        }
+
+        // build the span
+        guard
+            let builder = buildSpan(
+                name: "emb-thread-blockage",
+                type: SpanType(primary: .performance, secondary: "thread_blockage"),
+                attributes: [:]
+            )
+        else {
+            logger?.warning("[Watchdog] failed to create emb-thread-blockage span.")
+            return
+        }
+
+        queue.async { [self] in
+            span =
+                builder
+                .setStartTime(time: at.date)
+                .setAttribute(key: "last_known_time_unix_nano", value: .int(Int(at.realtime)))
+                .setAttribute(key: "interval_code", value: .int(0))
+                .setAttribute(key: "thread_priority", value: .int(0))
+                .startSpan()
+        }
+    }
+
+    public func hangUpdated(at: NanosecondClock, duration: NanosecondClock) {
+        logger?.debug("[Watchdog] Hang for \(duration.uptime.milliseconds) ms")
+
+        guard
+            limitData.withLock({
+                $0.samplesInHangCount += 1
+                return $0.samplesInHangCount <= $0.limits.samplesPerHang
+            })
+        else {
+            return
+        }
+
+        // Are we over the limit or don't have a span for some reason?
+        guard let span else {
+            return
+        }
+
+        // Capture the stack now
+        let pre = NanosecondClock.current
+        // TODO: Implement stacktrace collection here. Currently, frames is empty and stacktraces are not captured.
+        let frames: [String] = []
+        let post = NanosecondClock.current
+
+        // process it later
+        queue.async {
+
+            let stackString = frames.joined()
+
+            span.addEvent(
+                name: "perf.thread_blockage_sample",
+                attributes: [
+                    "sample_overhead": .int(Int(post.monotonic - pre.monotonic)),
+                    "frame_count": .int(frames.count),
+                    "thread_state": .string("BLOCKED"),
+                    "sample_code": .int(0),
+                    "stacktrace": .string(stackString)
+                ],
+                timestamp: at.date
+            )
+        }
+    }
+
+    public func hangEnded(at: NanosecondClock, duration: NanosecondClock) {
+        logger?.debug("[Watchdog] Hang ended at \(at.date) after \(duration.uptime.milliseconds) ms")
+
+        // Are we over the limit or don't have a span for some reason?
+        guard let span else {
+            return
+        }
+
+        queue.async {
+            span.end(time: at.date)
+            self.span = nil
+        }
+    }
+}

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/HangWatchdog.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/HangWatchdog.swift
@@ -1,0 +1,317 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
+    import EmbraceCommonInternal
+#endif
+
+/// Protocol for objects that observe hang detection events.
+/// Implement these methods to handle the various phases of a detected hang.
+///
+/// - hangStarted: Called when a hang is first detected on a background queue.
+/// - hangUpdated: Called periodically while a hang persists on a background queue.
+/// - hangEnded: Called when the hang ends on the hung thread.
+public protocol HangObserver: AnyObject {
+    func hangStarted(at: NanosecondClock, duration: NanosecondClock)
+    func hangUpdated(at: NanosecondClock, duration: NanosecondClock)
+    func hangEnded(at: NanosecondClock, duration: NanosecondClock)
+}
+
+/// A watchdog that detects and reports RunLoop hangs exceeding a specified threshold.
+/// Use this class to monitor app responsiveness by receiving callbacks when
+/// the monitored RunLoop is blocked beyond acceptable durations.
+/// Initialize as early as possible during app launch to start monitoring.
+final public class HangWatchdog {
+
+    /// Default hang threshold defined by Apple (0.25 seconds).
+    public static let defaultAppleHangThreshold: TimeInterval = 0.249
+
+    /// The interval, in seconds, that the monitored RunLoop must be blocked
+    /// before it is considered a hang.
+    /// Default is 0.25 seconds (250 milliseconds).
+    public let threshold: TimeInterval
+
+    /// The HangObserver instance that receives callbacks for hang start,
+    /// hang update, and hang end events.
+    public weak var hangObserver: HangObserver? {
+        set { hangData.withLock { $0.hangObserver = newValue } }
+        get { hangData.withLock { $0.hangObserver } }
+    }
+
+    /// Returns true if we're currently in a hang.
+    public var inHang: Bool {
+        hangData.withLock { $0.hanging }
+    }
+
+    /// The time in nanoseconds since the start of the hang.
+    /// 0 if not in a hang.
+    public var timeSinceHangStart: NanosecondClock? {
+        hangData.withLock {
+            guard $0.hanging else {
+                return nil
+            }
+            return .current - $0.enterTime
+        }
+    }
+
+    /// Initializes a new HangWatchdog instance.
+    /// - Parameters:
+    ///   - threshold: The hang threshold in seconds.
+    ///   - runLoop: The RunLoop to monitor for hangs.
+    public init(
+        threshold: TimeInterval = HangWatchdog.defaultAppleHangThreshold,
+        runLoop: RunLoop = .main
+    ) {
+        self.threshold = threshold
+        self.runLoop = runLoop
+        self.hangObserver = nil
+        self.scheduleThread()
+        self.scheduleObserver()
+    }
+
+    deinit {
+        if let observer {
+            CFRunLoopRemoveObserver(runLoop.getCFRunLoop(), observer, .commonModes)
+        }
+        if let watchdogTimer {
+            CFRunLoopTimerInvalidate(watchdogTimer)
+        }
+        if let watchdogRunLoop {
+            // This will stop the runloop and effectively
+            // exit the _watchdogThread_.
+            CFRunLoopStop(watchdogRunLoop.getCFRunLoop())
+        }
+        if let watchdogThread {
+            // This effectively does nothing.
+            // We're not checking for it anywhere.
+            // But I like to be complete and have
+            // this here for if we ever decide to
+            // do anything special.
+            watchdogThread.cancel()
+
+            // Here we should really join the watchdogThread.
+            // There's no way to do that from a `Thread`.
+            // We could use a semaphore and wait to be signaled
+            // from the thread exit but at this point it's
+            // unlikely to be useful.
+        }
+    }
+
+    /// Private.
+
+    // The RunLoop observer that receives activities
+    // and flag the timings between events.
+    private var observer: CFRunLoopObserver?
+
+    // The hi-priority thread used to ping the watchdog
+    // _runLoop_.
+    private var watchdogThread: Thread?
+
+    // The RunLoop created on the watchdog thread that
+    // allows us to use a timer to ping the watched _runLoop_.
+    private var watchdogRunLoop: RunLoop?
+
+    // A timer that pings the watchdog thread while
+    // we're waiting for the watched _runLoop_ to resolve
+    // running all events.
+    private var watchdogTimer: CFRunLoopTimer?
+
+    // the RunLoop we are watching for hangs.
+    private let runLoop: RunLoop
+
+    // Logger
+    internal var logger: InternalLogger?
+
+    /// Internal structure for tracking whether a hang is active and recording
+    /// the timestamp when the RunLoop was entered.
+    private struct HangData {
+        var hanging: Bool = false
+        var enterTime: NanosecondClock = .current
+        weak var hangObserver: HangObserver?
+    }
+    private var hangData = EmbraceMutex(HangData())
+}
+
+// MARK: - Private Watchdog
+
+extension HangWatchdog {
+
+    private func _logInfo(_ msg: String) {
+        if let logger {
+            logger.info(msg)
+        } else {
+            print(msg)
+        }
+    }
+
+    /// Sets up a dedicated high-priority thread with its own RunLoop
+    /// to perform hang detection pings without blocking the monitored RunLoop.
+    private func scheduleThread() {
+
+        runLoopPrecondition(runloop: runLoop)
+
+        _logInfo("[Watchdog] schedule thread")
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        watchdogThread = Thread { [weak self] in
+            let rl = RunLoop.current
+            rl.add(NSMachPort(), forMode: .common)
+            self?.watchdogRunLoop = rl
+            semaphore.signal()
+            rl.run()
+        }
+        watchdogThread?.name = "com.embrace.watchdog"
+        watchdogThread?.threadPriority = 1.0  // 1 is the max priority.
+        watchdogThread?.start()
+
+        // We need to get the watchdog thread runloop,
+        // so we simply wait here until it's set on
+        // that thread.
+        semaphore.wait()
+
+        _logInfo("[Watchdog] thread is a-go")
+
+        // Start out by scheduling pings to make sure we catch
+        // anything that happens before any run loops are running (startup).
+        _logInfo("[Watchdog] schedule first ping")
+        schedulePings()
+    }
+
+    /// Adds a CFRunLoopObserver to the monitored RunLoop that listens for
+    /// .beforeWaiting and .afterWaiting activities to detect hang start and end events.
+    private func scheduleObserver() {
+
+        runLoopPrecondition(runloop: runLoop)
+
+        _logInfo("[Watchdog] schedule observers")
+
+        // A hang starts when it takes more than 250ms between
+        // two .beforeWaiting run loop events.
+        // ref: https://developer.apple.com/documentation/xcode/understanding-hangs-in-your-app#Understand-hangs
+        observer = CFRunLoopObserverCreateWithHandler(
+            kCFAllocatorDefault,
+            CFRunLoopActivity(arrayLiteral: [.beforeWaiting, .afterWaiting]).rawValue,
+            true,
+            0
+        ) { [weak self] _, activity in
+            guard let self else { return }
+
+            // kill the timer
+            if let timer = self.watchdogTimer {
+                CFRunLoopTimerInvalidate(timer)
+                self.watchdogTimer = nil
+            }
+
+            // before the wait period, we want to check if the previous
+            // cycle took more time than it should have and flag it.
+            if activity == .beforeWaiting {
+
+                // check for a hang that needs to end
+                let (observer, now, hangTime): (HangObserver?, NanosecondClock?, NanosecondClock?) = hangData.withLock {
+                    guard $0.hanging else {
+                        return (nil, nil, nil)
+                    }
+                    $0.hanging = false
+
+                    // update the time value
+                    let now: NanosecondClock = .current
+                    let hangTime = now - $0.enterTime
+
+                    return ($0.hangObserver, now, hangTime)
+                }
+
+                // log it if needed
+                if let observer, let now, let hangTime {
+                    observer.hangEnded(at: now, duration: hangTime)
+                }
+            }
+
+            // After waiting, we start processing events.
+            // This means we need to watch for hangs in
+            // this period.
+            else if activity == .afterWaiting {
+                self.schedulePings()
+            }
+
+        }
+        if let obs = observer {
+            CFRunLoopAddObserver(runLoop.getCFRunLoop(), obs, .commonModes)
+            _logInfo("[Watchdog] observers are a-go")
+        }
+    }
+
+    /// Schedules a CFRunLoopTimer on the watchdog thread to measure how long
+    /// the monitored RunLoop remains blocked. Triggers hangObserver callbacks:
+    /// hangStarted, hangUpdated, and hangEnded.
+    private func schedulePings() {
+
+        runLoopPrecondition(runloop: runLoop)
+
+        // store the time
+        let startTime: NanosecondClock = .current
+        hangData.withLock { $0.enterTime = startTime }
+
+        let threasholdInNs = UInt64(threshold * 1_000_000_000)
+
+        // Run the timer on the watchdog run loop to ping it
+        // until this callback is entered again and resolves any hang.
+        watchdogTimer = CFRunLoopTimerCreateWithHandler(
+            kCFAllocatorDefault,
+            CFAbsoluteTimeGetCurrent(),
+            threshold,
+            0,
+            0
+        ) { [weak self] _ in
+
+            guard let self else { return }
+            precondition(Thread.current == self.watchdogThread)
+
+            let now: NanosecondClock = .current
+            let (observer, startHang, enterTime, hangTime) = hangData.withLock {
+                let enterTime = $0.enterTime
+                let hangTime = now - enterTime
+
+                // Hangtime is based on uptime, we don't count the time the app is suspended.
+                let isHang = hangTime.uptime >= threasholdInNs
+
+                let startHang = isHang && $0.hanging == false
+                if startHang { $0.hanging = true }
+
+                return (isHang ? $0.hangObserver : nil, startHang, enterTime, hangTime)
+            }
+
+            if let observer {
+
+                // Hang Start
+                if startHang {
+                    observer.hangStarted(at: enterTime, duration: hangTime)
+                }
+
+                // Always send a hang update. If the hang just started, then we simply
+                // sent a delayed start, so now send the update so the receiver
+                // can do whatever they also do on update, such as take a backtrace.
+
+                // Hang Update
+                observer.hangUpdated(at: now, duration: hangTime)
+            }
+        }
+        if let timer = watchdogTimer {
+            CFRunLoopAddTimer(watchdogRunLoop?.getCFRunLoop(), timer, .commonModes)
+        }
+    }
+}
+
+// MARK: - Private Helpers
+
+/// Ensures that the provided RunLoop matches the current thread’s RunLoop.
+/// - Parameter runloop: The RunLoop expected to be current.
+public func runLoopPrecondition(runloop: @autoclosure () -> RunLoop) {
+    precondition(
+        {
+            runloop() == RunLoop.current
+        }())
+}

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/NanosecondClock.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/NanosecondClock.swift
@@ -1,0 +1,87 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A clock that works in nanoseconds
+/// and contains the 3 basic times needed to
+/// work with performance and interact with the outside world.
+public struct NanosecondClock: Sendable {
+
+    public typealias Nanoseconds = UInt64
+
+    /// The clock for the current time.
+    public static var current: NanosecondClock { NanosecondClock() }
+
+    /// Uptime in nanoseconds, not incrementing during sleep.
+    /// CLOCK_UPTIME_RAW
+    public let uptime: Nanoseconds
+
+    /// Monotonic time in nanoseconds, increments during sleep.
+    /// using CLOCK_MONOTONIC_RAW.
+    public let monotonic: Nanoseconds
+
+    /// Walltime (real time, unix epoch) in nanoseconds.
+    /// using CLOCK_REALTIME.
+    public let realtime: Nanoseconds
+
+    /// Private intializers
+    private init() {
+        // There will always be a very small skew,
+        // but it's unimportant for our use case.
+        self.init(
+            uptime: clock_gettime_nsec_np(CLOCK_UPTIME_RAW),
+            monotonic: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW),
+            realtime: clock_gettime_nsec_np(CLOCK_REALTIME)
+        )
+    }
+
+    private init(_ value: Nanoseconds) {
+        self.uptime = value
+        self.monotonic = value
+        self.realtime = value
+    }
+
+    private init(uptime: Nanoseconds, monotonic: Nanoseconds, realtime: Nanoseconds) {
+        self.uptime = uptime
+        self.monotonic = monotonic
+        self.realtime = realtime
+    }
+}
+
+extension NanosecondClock {
+
+    /// Substract one clock from another
+    static func - (lhs: NanosecondClock, rhs: NanosecondClock) -> NanosecondClock {
+        return NanosecondClock(
+            uptime: lhs.uptime &- rhs.uptime,
+            monotonic: lhs.monotonic &- rhs.monotonic,
+            realtime: lhs.realtime &- rhs.realtime
+        )
+    }
+}
+
+extension NanosecondClock {
+
+    /// Get a `Date` from the clock.
+    @inlinable
+    public var date: Date {
+        Date(timeIntervalSince1970: realtime.seconds)
+    }
+}
+
+extension NanosecondClock.Nanoseconds {
+
+    /// Convert nanoseconds to milliseconds
+    @inlinable
+    public var milliseconds: UInt64 {
+        self / 1_000_000
+    }
+
+    /// Convert nanoseconds to seconds
+    @inlinable
+    public var seconds: Double {
+        Double(self) / 1_000_000_000.0
+    }
+}

--- a/Sources/EmbraceCore/Capture/UX/View/ViewCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/ViewCaptureService.swift
@@ -59,20 +59,10 @@
 
             super.init()
 
-            Embrace.notificationCenter.addObserver(
-                self,
-                selector: #selector(onConfigUpdated),
-                name: .embraceConfigUpdated, object: nil
-            )
             updateBlockList(config: Embrace.client?.config.configurable)
         }
 
-        deinit {
-            Embrace.notificationCenter.removeObserver(self)
-        }
-
-        @objc private func onConfigUpdated(_ notification: Notification) {
-            let config = notification.object as? EmbraceConfigurable
+        @objc public override func onConfigUpdated(_ config: EmbraceConfigurable) {
             updateBlockList(config: config)
         }
 

--- a/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
@@ -106,7 +106,6 @@ public class CoreDataWrapper {
             throw loadPersistentStoreError
         }
 
-
         context = container.newBackgroundContext()
     }
 

--- a/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
+++ b/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
@@ -61,4 +61,8 @@ import Foundation
     ) -> PushNotificationCaptureService {
         return PushNotificationCaptureService(options: options)
     }
+
+    static func hangWatchdog() -> HangCaptureService {
+        return HangCaptureService()
+    }
 }

--- a/Sources/EmbraceIO/Capture/CaptureServiceBuilder.swift
+++ b/Sources/EmbraceIO/Capture/CaptureServiceBuilder.swift
@@ -77,6 +77,11 @@ public class CaptureServiceBuilder: NSObject {
             add(.lowPowerMode())
         }
 
+        // hang
+        if !services.contains(where: { $0 is HangCaptureService }) {
+            add(.hangWatchdog())
+        }
+
         return self
     }
 }

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -1,0 +1,225 @@
+import EmbraceCommonInternal
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import TestSupport
+import XCTest
+
+@testable import EmbraceCore
+@testable import EmbraceOTelInternal
+
+// swiftlint:disable force_cast
+
+final class HangWatchdogTests: XCTestCase {
+
+    // MARK: - Test Properties
+
+    private var watchdog: HangWatchdog!
+    private var mockObserver: MockHangObserver!
+
+    // MARK: - Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        mockObserver = MockHangObserver()
+    }
+
+    override func tearDown() {
+        watchdog = nil
+        mockObserver = nil
+        super.tearDown()
+    }
+
+    // MARK: - Test Cases
+
+    func testInitialization() {
+        // Test that the watchdog initializes with default parameters
+        watchdog = HangWatchdog()
+        XCTAssertEqual(watchdog.threshold, HangWatchdog.defaultAppleHangThreshold)
+        XCTAssertNil(watchdog.hangObserver)
+
+        // Test custom threshold
+        let customThreshold: TimeInterval = 0.5
+        watchdog = HangWatchdog(threshold: customThreshold)
+        XCTAssertEqual(watchdog.threshold, customThreshold)
+    }
+
+    func testObserverAssignment() {
+        // Test that observer can be assigned
+        watchdog = HangWatchdog()
+        watchdog.hangObserver = mockObserver
+        XCTAssertTrue(watchdog.hangObserver === mockObserver)
+    }
+
+    func testHangDetection() {
+        // Create expectation for hang detection
+        let hangExpectation = expectation(description: "Hang should be detected")
+
+        // Set up observer with callback
+        mockObserver.onHangStarted = { _, _ in
+            hangExpectation.fulfill()
+        }
+
+        // Create watchdog with shorter threshold for testing
+        watchdog = HangWatchdog(threshold: 0.1)
+        watchdog.hangObserver = mockObserver
+
+        // Simulate hang by blocking the main thread
+        DispatchQueue.main.async {
+            // Block thread for longer than threshold
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+
+        // Wait for expectation with timeout
+        wait(for: [hangExpectation], timeout: 0.5)
+
+        // Verify hang was detected
+        XCTAssertTrue(mockObserver.hangStartedCalled)
+        XCTAssertGreaterThan(mockObserver.lastHangDuration, UInt64(0.1 * 1_000_000_000))
+    }
+
+    func testHangUpdates() {
+        // Create expectations
+        let hangStartedExpectation = expectation(description: "Hang should start")
+        let hangUpdatedExpectation = expectation(description: "Hang should be updated")
+
+        // Set up observer with callbacks
+        mockObserver.onHangStarted = { _, _ in
+            hangStartedExpectation.fulfill()
+        }
+
+        mockObserver.onHangUpdated = { _, _ in
+            hangUpdatedExpectation.fulfill()
+            self.watchdog.hangObserver = nil
+        }
+
+        // Create watchdog with shorter threshold for testing
+        watchdog = HangWatchdog(threshold: 0.05)
+        watchdog.hangObserver = mockObserver
+
+        // Simulate hang by blocking the main thread for longer than update interval
+        DispatchQueue.main.async {
+            // Block thread long enough to trigger multiple updates
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+
+        // Wait for expectations
+        wait(for: [hangStartedExpectation, hangUpdatedExpectation], timeout: 0.5)
+
+        // Verify hang was updated
+        XCTAssertTrue(mockObserver.hangStartedCalled)
+        XCTAssertTrue(mockObserver.hangUpdatedCalled)
+    }
+
+    func testHangEnd() {
+        // Create expectations
+        let hangEndedExpectation = expectation(description: "Hang should end")
+
+        // Set up observer
+        mockObserver.onHangEnded = { _, _ in
+            hangEndedExpectation.fulfill()
+        }
+
+        // Create watchdog with shorter threshold for testing
+        watchdog = HangWatchdog(threshold: 0.05)
+        watchdog.hangObserver = mockObserver
+
+        // Simulate hang that starts and ends
+        DispatchQueue.main.async {
+            // Block thread for longer than threshold
+            Thread.sleep(forTimeInterval: 0.1)
+            // Then let it resume
+        }
+
+        // Wait for hang to end
+        wait(for: [hangEndedExpectation], timeout: 0.5)
+
+        // Verify hang ended was called
+        XCTAssertTrue(mockObserver.hangEndedCalled)
+    }
+
+    func testNoHangForShortDelays() {
+        // Set up observer
+        let hangStartedExpectation = expectation(description: "Hang should not be detected")
+        hangStartedExpectation.isInverted = true  // We expect this NOT to be fulfilled
+
+        mockObserver.onHangStarted = { _, _ in
+            hangStartedExpectation.fulfill()
+        }
+
+        // Create watchdog
+        watchdog = HangWatchdog(threshold: 0.1)
+        watchdog.hangObserver = mockObserver
+
+        // Simulate delay shorter than threshold
+        DispatchQueue.main.async {
+            Thread.sleep(forTimeInterval: 0.05)  // Less than threshold
+        }
+
+        // Wait briefly to ensure no hang is detected
+        wait(for: [hangStartedExpectation], timeout: 0.3)
+
+        // Verify no hang was detected
+        XCTAssertFalse(mockObserver.hangStartedCalled)
+    }
+
+    func testDeinitCleanup() {
+        // Create and destroy watchdog to test cleanup
+        autoreleasepool {
+            let localWatchdog = HangWatchdog(threshold: 0.1)
+            localWatchdog.hangObserver = mockObserver
+            // Let watchdog go out of scope
+        }
+
+        // No assertions needed - we're testing that deinit doesn't crash
+    }
+}
+
+// MARK: - Test Helpers
+
+class MockHangObserver: HangObserver {
+
+    // Callback handlers
+    var onHangStarted: ((UInt64, UInt64) -> Void)?
+    var onHangUpdated: ((UInt64, UInt64) -> Void)?
+    var onHangEnded: ((UInt64, UInt64) -> Void)?
+
+    // Tracking properties
+    var hangStartedCalled = false
+    var hangUpdatedCalled = false
+    var hangEndedCalled = false
+
+    var hangStartedCallCount = 0
+    var hangUpdatedCallCount = 0
+    var hangEndedCallCount = 0
+
+    var lastStartTime: UInt64 = 0
+    var lastUpdateTime: UInt64 = 0
+    var lastEndTime: UInt64 = 0
+    var lastHangDuration: UInt64 = 0
+
+    func hangStarted(at: NanosecondClock, duration: NanosecondClock) {
+        hangStartedCalled = true
+        hangStartedCallCount += 1
+        lastStartTime = at.monotonic
+        lastHangDuration = duration.monotonic
+        onHangStarted?(at.monotonic, duration.monotonic)
+    }
+
+    func hangUpdated(at: NanosecondClock, duration: NanosecondClock) {
+        hangUpdatedCalled = true
+        hangUpdatedCallCount += 1
+        lastUpdateTime = at.monotonic
+        lastHangDuration = duration.monotonic
+        onHangUpdated?(at.monotonic, duration.monotonic)
+    }
+
+    func hangEnded(at: EmbraceCore.NanosecondClock, duration: EmbraceCore.NanosecondClock) {
+        hangEndedCalled = true
+        hangEndedCallCount += 1
+        lastEndTime = at.monotonic
+        lastHangDuration = duration.monotonic
+        onHangEnded?(at.monotonic, duration.monotonic)
+    }
+}
+
+// swiftlint:enable force_cast

--- a/Tests/EmbraceCoreTests/Capture/UX/View/ViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/View/ViewCaptureServiceTests.swift
@@ -115,7 +115,7 @@
             config.viewControllerClassNameBlocklist = ["MyCustomViewController", "MySpecialViewController"]
             // Is config says it should capture, then it capture service shouldn't block
             config.uiInstrumentationCaptureHostingControllers = true
-            Embrace.notificationCenter.post(name: .embraceConfigUpdated, object: config)
+            service.onConfigUpdated(config)
 
             // then the blocklist is updated
             XCTAssert(service.blockList.safeValue.types.isEmpty)

--- a/Tests/EmbraceCoreTests/Public/Embrace+SetupTests.swift
+++ b/Tests/EmbraceCoreTests/Public/Embrace+SetupTests.swift
@@ -2,8 +2,9 @@
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
 
-@testable import EmbraceCore
 import XCTest
+
+@testable import EmbraceCore
 
 class EmbraceSetupTests: XCTestCase {
     func test_setupOnNonMainThread_shouldThrowInvalidThreadError() {
@@ -32,4 +33,3 @@ class EmbraceSetupTests: XCTestCase {
         wait(for: [expectation])
     }
 }
-

--- a/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
@@ -21,7 +21,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         // then the list contains all the default services
         let list = builder.build()
 
-        var count = 3
+        var count = 4
 
         XCTAssertNotNil(list.first(where: { $0 is URLSessionCaptureService }))
 
@@ -37,6 +37,8 @@ class CaptureServiceBuilderTests: XCTestCase {
 
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
+
+        XCTAssertNotNil(list.first(where: { $0 is HangCaptureService }))
 
         XCTAssertEqual(list.count, count)
 
@@ -57,7 +59,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         // then the list contains the correct services
         let list = builder.build()
 
-        var count = 3
+        var count = 4
 
         #if canImport(UIKit) && !os(watchOS)
             count += 2
@@ -73,6 +75,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
+        XCTAssertNotNil(list.first(where: { $0 is HangCaptureService }))
 
         let service = list.first(where: { $0 is URLSessionCaptureService }) as! URLSessionCaptureService
         XCTAssertFalse(service.options.injectTracingHeader)
@@ -99,7 +102,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         // then the list contains the correct services
         let list = builder.build()
 
-        var count = 2
+        var count = 3
 
         #if canImport(WebKit)
             count += 1
@@ -107,6 +110,7 @@ class CaptureServiceBuilderTests: XCTestCase {
         #endif
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
+        XCTAssertNotNil(list.first(where: { $0 is HangCaptureService }))
 
         XCTAssertEqual(list.count, count)
     }
@@ -210,6 +214,20 @@ class CaptureServiceBuilderTests: XCTestCase {
 
         XCTAssertEqual(list.count, 1)
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
+    }
+
+    func test_addHangCaptureService() throws {
+        // given a builder
+        let builder = CaptureServiceBuilder()
+
+        // when adding a HangCaptureService
+        builder.add(.hangWatchdog())
+
+        // then the list contains the capture service
+        let list = builder.build()
+
+        XCTAssertEqual(list.count, 1)
+        XCTAssertNotNil(list.first(where: { $0 is HangCaptureService }))
     }
 
     func test_addLowPowerModeCaptureService() throws {

--- a/Tests/TestSupport/EditableConfig.swift
+++ b/Tests/TestSupport/EditableConfig.swift
@@ -5,6 +5,8 @@
 import EmbraceConfiguration
 
 public class EditableConfig: EmbraceConfigurable {
+    public var hangLimits: HangLimits = HangLimits()
+
     public var isSDKEnabled: Bool = true
 
     public var isBackgroundSessionEnabled: Bool = false
@@ -52,7 +54,8 @@ public class EditableConfig: EmbraceConfigurable {
         isMetricKitHangCaptureEnabled: Bool = false,
         isSwiftUiViewInstrumentationEnabled: Bool = false,
         internalLogLimits: InternalLogLimits = InternalLogLimits(),
-        networkPayloadCaptureRules: [NetworkPayloadCaptureRule] = []
+        networkPayloadCaptureRules: [NetworkPayloadCaptureRule] = [],
+        hangLimits: HangLimits = HangLimits()
     ) {
         self.isSDKEnabled = isSdkEnabled
         self.isBackgroundSessionEnabled = isBackgroundSessionEnabled
@@ -65,6 +68,7 @@ public class EditableConfig: EmbraceConfigurable {
         self.isSwiftUiViewInstrumentationEnabled = isSwiftUiViewInstrumentationEnabled
         self.internalLogLimits = internalLogLimits
         self.networkPayloadCaptureRules = networkPayloadCaptureRules
+        self.hangLimits = hangLimits
     }
 }
 

--- a/Tests/TestSupport/Mocks/MockEmbraceConfigurable.swift
+++ b/Tests/TestSupport/Mocks/MockEmbraceConfigurable.swift
@@ -8,6 +8,7 @@ import Foundation
 import XCTest
 
 public class MockEmbraceConfigurable: EmbraceConfigurable {
+
     public init(
         isSDKEnabled: Bool = false,
         isBackgroundSessionEnabled: Bool = false,
@@ -26,7 +27,8 @@ public class MockEmbraceConfigurable: EmbraceConfigurable {
         internalLogLimits: InternalLogLimits = InternalLogLimits(),
         networkPayloadCaptureRules: [NetworkPayloadCaptureRule] = [],
         updateCompletionParamDidUpdate: Bool = false,
-        updateCompletionParamError: Error? = nil
+        updateCompletionParamError: Error? = nil,
+        hangLimits: HangLimits = HangLimits()
     ) {
         self._isSDKEnabled = isSDKEnabled
         self._isBackgroundSessionEnabled = isBackgroundSessionEnabled
@@ -43,6 +45,7 @@ public class MockEmbraceConfigurable: EmbraceConfigurable {
         self._spanEventsLimits = spanEventsLimits
         self._logsLimits = logsLimits
         self._internalLogLimits = internalLogLimits
+        self._hangLimits = hangLimits
         self._networkPayloadCaptureRules = networkPayloadCaptureRules
         self.updateCompletionParamDidUpdate = updateCompletionParamDidUpdate
         self.updateCompletionParamError = updateCompletionParamError
@@ -235,6 +238,18 @@ public class MockEmbraceConfigurable: EmbraceConfigurable {
         }
         set {
             _internalLogLimits = newValue
+        }
+    }
+
+    private var _hangLimits: HangLimits
+    public let hangLimitsExpectation = XCTestExpectation(description: "hangLimits called")
+    public var hangLimits: HangLimits {
+        get {
+            hangLimitsExpectation.fulfill()
+            return _hangLimits
+        }
+        set {
+            _hangLimits = newValue
         }
     }
 


### PR DESCRIPTION
This PR creates a service to capture hangs. Hangs are sent in the same manner as they are on Android as [described here](https://www.notion.so/embraceio/ANRs-1d77e3c9985281c58765d8c622443e2c). A similar span is also sent using iOS terminology as an interim in order for it to appear in the timeline.

- Currently stack traces are not sent, this is for a future PR.
- The iOS span appears as "emb_thread_blockage" in the Performance timeline.
- Limit is set to 200 hangs per session. Currently hard coded.
- Limit is set to 0 samples per hang. Currently hard coded.
- Add a session attribute named `emb-thread-blockage` with the count of hangs in the session.
- ~~Currently using `ux` for the type, I think it needs to be `perf.thread_blockage`.~~

**Client Work**
- [x] Add limits.
- [x] Figure out what spans to log (ANR or Hang), and get backend work done accordingly.
- [ ] If there's an un-terminated hang span on startup, we should determine that a crash occurred due to a watchdog event (SIGKILL 0x8badf00d), but still close the span and have it appear in the timeline.
- [x] Understand the overflow error that is currently commented out.

**Backend work**
- [x] Make sure the correct naming is used on each platform. (iOS => Hang)
- [x] Show `perf.thread_blockage` spans in timeline.
- [x] Add remote config limits, here's the structure used in the app:
```
hang_limits: {
    hang_per_session: Uint,
    samples_per_hang: Uint
}
```

# Gate
Set hang_per_session = 0 to ensure the watchdog doesn't run.

# Visuals
<img width="1234" height="939" alt="Screenshot 2025-09-03 at 1 36 48 PM" src="https://github.com/user-attachments/assets/b8f04c3b-87a3-4382-a39d-02d9fcb601b9" />


