### PR TITLE
[EASY] cleaned up a few warnings

### DIFF
--- a/Sources/EmbraceIO/Options/Options+CaptureService.swift
+++ b/Sources/EmbraceIO/Options/Options+CaptureService.swift
@@ -91,7 +91,7 @@ public extension Embrace.Options {
     }
 }
 
-extension Embrace.Options: ExpressibleByStringLiteral {
+extension Embrace.Options: @retroactive ExpressibleByStringLiteral {
     public convenience init(stringLiteral value: String) {
         self.init(appId: value)
     }

--- a/Sources/EmbraceUploadInternal/Operations/AsyncOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/AsyncOperation.swift
@@ -63,3 +63,5 @@ class AsyncOperation: Operation {
         isFinished = true
     }
 }
+
+extension AsyncOperation: @unchecked Sendable {}

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceAttachmentUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceAttachmentUploadOperation.swift
@@ -58,6 +58,8 @@ class EmbraceAttachmentUploadOperation: EmbraceUploadOperation {
     }
 }
 
+extension EmbraceAttachmentUploadOperation: @unchecked Sendable {}
+
 extension Data {
     mutating func appendString(_ string: String) {
         if let data = string.data(using: .utf8) {

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -211,3 +211,5 @@ class EmbraceUploadOperation: AsyncOperation {
         return request
     }
 }
+
+extension EmbraceUploadOperation: @unchecked Sendable {}

--- a/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
+++ b/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
@@ -136,8 +136,8 @@ class CoreDataWrapperTests: XCTestCase {
 
     func test_deleteRecords_withRequest() throws {
         // given a wrapper with data
-        let record1 = MockRecord.create(context: wrapper.context, id: "test1")
-        let record2 = MockRecord.create(context: wrapper.context, id: "test2")
+        _ = MockRecord.create(context: wrapper.context, id: "test1")
+        _ = MockRecord.create(context: wrapper.context, id: "test2")
         wrapper.save()
 
         // when deleting the record

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogsBatchTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogsBatchTests.swift
@@ -116,7 +116,7 @@ private extension LogsBatchTests {
     }
 }
 
-extension LogsBatch.BatchingResult: Equatable {
+extension LogsBatch.BatchingResult: @retroactive Equatable {
     public static func == (lhs: LogsBatch.BatchingResult, rhs: LogsBatch.BatchingResult) -> Bool {
         switch (lhs, rhs) {
         case (.success(let lhsBatchState), .success(let rhsBatchState)):

--- a/Tests/EmbraceCoreTests/Payload/PayloadUtilTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/PayloadUtilTests.swift
@@ -37,6 +37,9 @@ final class PayloadUtilTests: XCTestCase {
 
     func test_convertSpanAttributes() throws {
         // given some span attributes
+        // NOTE: This test expects the array types to not pass
+        // `convertSpanAttributes`. Do not change them to `.array`
+        // as the test will fail.
         let attributes: [String: AttributeValue] = [
             "bool": .bool(true),
             "boolArray": .boolArray([true, false]),

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/DispatchQueue+DispatchableQueue.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/DispatchQueue+DispatchableQueue.swift
@@ -6,7 +6,7 @@ import Foundation
 import EmbraceCommonInternal
 
 // Only add this extension to Test Targets
-extension DispatchQueue: DispatchableQueue {
+extension DispatchQueue: @retroactive DispatchableQueue {
     public func async(_ block: @escaping () -> Void) {
         self.async(execute: block)
     }


### PR DESCRIPTION
This pull request addresses minor code maintenance by cleaning up several warnings throughout the project. It updates eight files, primarily by adding Swift-specific annotations such as @retroactive and @unchecked Sendable to extensions, and making small improvements to test files and syntax. The goal is to improve code quality and resolve existing warnings without introducing new features or altering core functionality. 