### PR TITLE
[EMBR-7647][UI_TESTS_APP] Add support for Critical Log type

### DIFF
--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/Tests/LoggingErrorMessageTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/Tests/LoggingErrorMessageTest.swift
@@ -49,7 +49,8 @@ class LoggingErrorMessageTest: PayloadTest {
 
         testItems.append(.init(target: loggedMessage, expected: "exists", recorded: "exists", result: .success))
 
-        testItems.append(.init(target: "Severity", expected: loggedMessageSeverity.text, recorded: log.severity?.description))
+
+        testItems.append(.init(target: "Severity", expected: expectedSeverityText(loggedMessageSeverity), recorded: log.severity?.description))
 
         testItems.append(.init(target: "Stacktrace", expected: stacktraceExpected ? "found" : "missing", recorded: log.attributes["emb.stacktrace.ios"] != nil ? "found" : "missing"))
 
@@ -77,13 +78,33 @@ class LoggingErrorMessageTest: PayloadTest {
         return .init(items: testItems)
     }
 
+    private func expectedSeverityText(_ severity: LogSeverity) -> String {
+        switch severity {
+
+        case .trace:
+            return "TRACE"
+        case .debug:
+            return "DEBUG"
+        case .info:
+            return "INFO"
+        case .warn:
+            return "WARN"
+        case .error:
+            return "ERROR"
+        case .fatal:
+            return "FATAL"
+        case .critical:
+            return "FATAL4"
+        }
+    }
+
     private var stacktraceExpected: Bool {
         switch stackTraceBehavior {
         case .notIncluded:
             return false
         case .default, .custom:
             switch loggedMessageSeverity {
-            case .trace, .debug, .info, .fatal:
+            case .trace, .debug, .info, .fatal, .critical:
                 return false
             case .warn, .error:
                 return true

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/ViewModels/LoggingTestMessageViewModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/ViewModels/LoggingTestMessageViewModel.swift
@@ -63,7 +63,7 @@ class LoggingTestMessageViewModel: LogTestUIComponentViewModel {
 
 extension LogSeverity: @retroactive CaseIterable {
     public static var allCases: [LogSeverity] {
-        [.trace, .debug, .info, .warn, .error, .fatal]
+        [.trace, .debug, .info, .warn, .error, .fatal, .critical]
     }
 }
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/Views/LoggingTestsSeverityTypeView.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Logging/Views/LoggingTestsSeverityTypeView.swift
@@ -12,7 +12,7 @@ struct LoggingTestsSeverityTypeView: View {
     var body: some View {
         Picker("", selection: $logSeverity) {
             ForEach(LogSeverity.allCases, id: \.self) { option in
-                Text(option.text)
+                Text((option == .critical ? "CRITICAL" : option.text).lowercased())
                     .accessibilityIdentifier(identifier(for: option))
             }
         }
@@ -34,6 +34,8 @@ struct LoggingTestsSeverityTypeView: View {
             return "LogSeverity_Error"
         case .fatal:
             return "LogSeverity_Fatal"
+        case .critical:
+            return "LogSeverity_Critical"
         }
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataResourceTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Metadata/Tests/MetadataResourceTest.swift
@@ -40,7 +40,6 @@ class MetadataResourceTest: PayloadTest {
          "emb.session.upload_index",
          "emb.app.environment",
          "emb.device.disk_size",
-         "os.name",
          "telemetry.sdk.language"]
     }
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
@@ -57,6 +57,8 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
             identifier = "LogSeverity_Error"
         case .fatal:
             identifier = "LogSeverity_Fatal"
+        case .critical:
+            identifier = "LogSeverity_Critical"
         }
 
         app.buttons[identifier].tap()


### PR DESCRIPTION
Adds support for the new "Critical" log type and removes check for "os.name" existance on resource attributes since this property has been removed at that stage and will be added to the payload via other methods.