### PR TITLE
Custom Processors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -142,6 +151,15 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,15 +37,6 @@
       }
     },
     {
-      "identity" : "opentracing-objc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/opentracing-objc",
-      "state" : {
-        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
-        "version" : "0.5.2"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -151,15 +142,6 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "thrift-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
-      "state" : {
-        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
-        "version" : "1.1.2"
       }
     },
     {

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -222,12 +222,17 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
         logController?.sdkStateProvider = self
 
         // setup otel
-        EmbraceOTel.setup(spanProcessors: .processors(
+        var processors = Array.processors(
             for: storage,
             sessionController: sessionController,
             export: options.export,
             sdkStateProvider: self
-        ))
+        )
+        if let extraProcessors = options.processors?.map({ $0.processor }) {
+            processors.append(contentsOf: extraProcessors)
+        }
+
+        EmbraceOTel.setup(spanProcessors: processors)
 
         let logBatcher = DefaultLogBatcher(
             repository: storage,

--- a/Sources/EmbraceCore/Options/Embrace+Options.swift
+++ b/Sources/EmbraceCore/Options/Embrace+Options.swift
@@ -25,7 +25,8 @@ extension Embrace {
         @objc public let logLevel: LogLevel
         @objc public let export: OpenTelemetryExport?
         @objc public let runtimeConfiguration: EmbraceConfigurable?
-
+        @objc public let processors: [OpenTelemetryProcessor]?
+        
         /// Default initializer for `Embrace.Options` that requires an array of `CaptureServices` to be passed.
         ///
         /// If you wish to use the default `CaptureServices`, please refer to the `Embrace.Options`
@@ -40,6 +41,7 @@ extension Embrace {
         ///   - crashReporter: The `CrashReporter` to be installed.
         ///   - logLevel: The `LogLevel` to use for console logs.
         ///   - export: `OpenTelemetryExport` object to export telemetry using OpenTelemetry protocols
+        ///   - processors: `OpenTelemetryProcessor` objects to do extra processing
         @objc public init(
             appId: String,
             appGroupId: String? = nil,
@@ -48,7 +50,8 @@ extension Embrace {
             captureServices: [CaptureService],
             crashReporter: CrashReporter?,
             logLevel: LogLevel = .default,
-            export: OpenTelemetryExport? = nil
+            export: OpenTelemetryExport? = nil,
+            processors: [OpenTelemetryProcessor]? = nil
         ) {
             self.appId = appId
             self.appGroupId = appGroupId
@@ -59,6 +62,7 @@ extension Embrace {
             self.logLevel = logLevel
             self.export = export
             self.runtimeConfiguration = nil
+            self.processors = processors
         }
 
         /// Initializer for `Embrace.Options` that does not require an appId.
@@ -89,6 +93,7 @@ extension Embrace {
             self.logLevel = logLevel
             self.export = export
             self.runtimeConfiguration = runtimeConfiguration
+            self.processors = nil
         }
     }
 }

--- a/Sources/EmbraceCore/Public/OpenTelemetryProcessor.swift
+++ b/Sources/EmbraceCore/Public/OpenTelemetryProcessor.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import OpenTelemetrySdk
+
+/// Class used to set custom Processors when initializing the Embrace SDK.
+@objc(EMBOpenTelemetryProcessor)
+public class OpenTelemetryProcessor: NSObject {
+    
+    public let processor: SpanProcessor
+
+    public init(processor: SpanProcessor) {
+        self.processor = processor
+    }
+}

--- a/Sources/EmbraceIO/Options/Options+CaptureService.swift
+++ b/Sources/EmbraceIO/Options/Options+CaptureService.swift
@@ -56,17 +56,20 @@ public extension Embrace.Options {
     ///   - appId: The `appId` of the project.
     ///   - appGroupId: The app group identifier used by the app, if any.
     ///   - platform: `Platform` in which the app will run. Defaults to `.iOS`.
+    ///   - processors: Extra `OpenTelemetryProcessor`s to include.
     @objc convenience init(
         appId: String,
         appGroupId: String? = nil,
-        platform: Platform = .default
+        platform: Platform = .default,
+        processors: [OpenTelemetryProcessor]? = nil
     ) {
         self.init(
             appId: appId,
             appGroupId: appGroupId,
             platform: platform,
             captureServices: .automatic,
-            crashReporter: EmbraceCrashReporter()
+            crashReporter: EmbraceCrashReporter(),
+            processors: processors
         )
     }
 

--- a/Sources/EmbraceIO/Options/Options+CaptureService.swift
+++ b/Sources/EmbraceIO/Options/Options+CaptureService.swift
@@ -56,6 +56,31 @@ public extension Embrace.Options {
     ///   - appId: The `appId` of the project.
     ///   - appGroupId: The app group identifier used by the app, if any.
     ///   - platform: `Platform` in which the app will run. Defaults to `.iOS`.
+    @objc convenience init(
+        appId: String,
+        appGroupId: String? = nil,
+        platform: Platform = .default
+    ) {
+        self.init(
+            appId: appId,
+            appGroupId: appGroupId,
+            platform: platform,
+            captureServices: .automatic,
+            crashReporter: EmbraceCrashReporter(),
+            processors: nil
+        )
+    }
+    
+    /// Convenience initializer for `Embrace.Options` that automatically includes the default `CaptureServices`, `CrashReporter` and `OpenTelemetryProcessor`'s.
+    /// You can see list of platform service defaults in ``CaptureServiceBuilder.addDefaults``.
+    ///
+    /// If you wish to customize which `CaptureServices` and `CrashReporter` are installed, please refer to the `Embrace.Options`
+    /// initializer found in the `EmbraceCore` target.
+    ///
+    /// - Parameters:
+    ///   - appId: The `appId` of the project.
+    ///   - appGroupId: The app group identifier used by the app, if any.
+    ///   - platform: `Platform` in which the app will run. Defaults to `.iOS`.
     ///   - processors: Extra `OpenTelemetryProcessor`s to include.
     @objc convenience init(
         appId: String,
@@ -72,7 +97,7 @@ public extension Embrace.Options {
             processors: processors
         )
     }
-
+    
     /// Initializer for `Embrace.Options` that does not require an appId.
 
     /// Use this initializer if you don't want the SDK to send data to Embrace's servers.

--- a/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
+++ b/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
@@ -6,6 +6,7 @@ import XCTest
 import EmbraceCore
 import EmbraceConfigInternal
 import EmbraceConfiguration
+import EmbraceOTelInternal
 import TestSupport
 
 final class Embrace_OptionsTests: XCTestCase {
@@ -28,7 +29,19 @@ final class Embrace_OptionsTests: XCTestCase {
         XCTAssertEqual(options.export, export)
         XCTAssertNil(options.appId)
     }
-
+    
+    func test_init_withProcessors() throws {
+        let processor = OpenTelemetryProcessor(processor: InMemorySpanProcessor())
+        let options = Embrace.Options(
+            appId: "myApp",
+            captureServices: [],
+            crashReporter: nil,
+            processors: [processor]
+        )
+        XCTAssertEqual(options.processors, [processor])
+        XCTAssertNotNil(options.appId)
+    }
+    
     func test_init_withRuntimeConfiguration_usesInjectedObject() throws {
         let mockObj = MockEmbraceConfigurable()
 

--- a/Tests/TestSupport/Mocks/SpanProcessor/InMemorySpanProcessor.swift
+++ b/Tests/TestSupport/Mocks/SpanProcessor/InMemorySpanProcessor.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceOTelInternal
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import Foundation
+
+public class InMemorySpanProcessor: SpanProcessor {
+
+    public var isStartRequired: Bool
+    public var isEndRequired: Bool
+    
+    public private(set) var startedSpans: [SpanId: SpanData] = [:]
+    public private(set) var endedSpans: [SpanId: SpanData] = [:]
+    public private(set) var isShutdown: Bool = false
+    
+    private var onFlush: (() -> Void)? = nil
+    
+    public convenience init() {
+        self.init(isStartRequired: false, isEndRequired: false)
+    }
+    
+    public init(isStartRequired: Bool, isEndRequired: Bool) {
+        self.isStartRequired = isStartRequired
+        self.isEndRequired = isEndRequired
+    }
+    
+    public func onFlush(completion: (() -> Void)?) {
+        self.onFlush = completion
+    }
+    
+    public func onStart(parentContext: OpenTelemetryApi.SpanContext?, span: any OpenTelemetrySdk.ReadableSpan) {
+        let data = span.toSpanData()
+        startedSpans[data.spanId] = data
+    }
+    
+    public func onEnd(span: any OpenTelemetrySdk.ReadableSpan) {
+        let data = span.toSpanData()
+        startedSpans[data.spanId] = data
+    }
+    
+    public func forceFlush(timeout: TimeInterval?) {
+        onFlush?()
+    }
+    
+    public func shutdown(explicitTimeout: TimeInterval?) {
+        isShutdown = true
+    }
+}


### PR DESCRIPTION
NOTE: I can use an exporter for the time being if this requires more thought. But there are differences between the two that make a processor a better choice for what I'm doing. The main one being processors have start and end calls for each span, which allows me to keep this crash resilient.

----

This PR allows developers to supply custom OpenTelemetry span processors to the Embrace SDK by expanding the configuration API and updating internal initialization logic. It also ensures these changes are robustly tested. This unlocks advanced telemetry customization for integrators.

1. **Custom OpenTelemetry Processors Support**
   - Added support for injecting custom OpenTelemetry `SpanProcessor` instances into the Embrace SDK.
   - New class `OpenTelemetryProcessor` was introduced to wrap custom processors.

2. **API Changes**
   - `Embrace.Options` now includes an optional `processors` property, allowing developers to specify additional span processors when initializing the SDK.
   - Initializers for `Embrace.Options` and related convenience initializers were updated to accept this new `processors` parameter.

3. **Internal Initialization Updated**
   - When the SDK is started, it now collects span processors from both the standard set and any custom processors provided in `options.processors`, ensuring they’re included in OpenTelemetry setup.

4. **Dependency Updates**
   - The `Package.resolved` file was updated to add or revise dependencies, specifically for OpenTracing and Thrift-Swift libraries.

5. **Tests Expanded**
   - Added and expanded tests to cover initialization with custom processors, ensuring correct assignment and usage.
   - New mock implementation `InMemorySpanProcessor` was introduced for testing purposes.

