### PR TITLE
[EASY] Missing header in umbrella

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/include/EmbraceObjCUtilsInternal.h
+++ b/Sources/EmbraceObjCUtilsInternal/include/EmbraceObjCUtilsInternal.h
@@ -12,6 +12,7 @@
 #import "EMBURLSessionDelegateForwarder.h"
 #import "EMBURLSessionDelegateProxy.h"
 #import "EMBWKNavigationDelegateProxy.h"
+#import "EMBURLSessionDelegateProxyFunctions.h"
 
 #import "EMBLoaderClass.h"
 #import "EMBDisplayLinkProxy.h"


### PR DESCRIPTION
There was a missing header in an umbrella header which might have been leading to requiring some hoops to import the module.