### PR TITLE
Background task wrapper for core data operations

### DIFF
--- a/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
@@ -6,7 +6,9 @@ import Foundation
 
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
 import EmbraceCommonInternal
+#endif
 
 /// This class is a wrapper around `UIApplication.shared.beginBackgroundTask`.
 /// Based off https://developer.apple.com/forums/thread/85066 and https://developer.apple.com/forums/thread/729335

--- a/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
@@ -1,0 +1,78 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+import EmbraceCommonInternal
+
+/// This class is a wrapper around `UIApplication.shared.beginBackgroundTask`.
+/// Based off https://developer.apple.com/forums/thread/85066 and https://developer.apple.com/forums/thread/729335
+class BackgroundTaskWrapper {
+
+    let name: String
+    private var taskID: UIBackgroundTaskIdentifier
+
+    init?(name: String, logger: InternalLogger) {
+        self.name = name
+        self.taskID = .invalid
+
+        let taskID = UIApplication.shared.beginBackgroundTask(withName: name) {
+            logger.critical("Background task \(name) cancelled!")
+            self.endTask()
+        }
+
+        // handle weird case where the task can't be created
+        if taskID == .invalid {
+            return nil
+        }
+        self.taskID = taskID
+    }
+
+    deinit {
+        self.endTask()
+    }
+
+    func finish() {
+        self.endTask()
+    }
+
+    private func endTask() {
+        guard self.taskID != .invalid else {
+            return
+        }
+
+        UIApplication.shared.endBackgroundTask(self.taskID)
+        self.taskID = .invalid
+    }
+}
+
+#else
+
+// TODO: Implement WatchOS Version
+class BackgroundTaskWrapper {
+
+    let name: String
+    private var taskID: UIBackgroundTaskIdentifier
+
+    init(name: String) {
+        self.name = name
+        self.taskID = .invalid
+    }
+
+    deinit {
+        self.endTask()
+    }
+
+    func finish() {
+        self.endTask()
+    }
+
+    private func endTask() {
+
+    }
+}
+
+#endif

--- a/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
@@ -26,11 +26,13 @@ class BackgroundTaskWrapper {
         // which should never be the main thread.
         // Leaving the check anyways just in case.
         if Thread.isMainThread {
+            logger.critical("Failed to create background task \(name), called from main thread!")
             return nil
         }
 
         // do not create task if there's not enough time until suspension
         if UIApplication.shared.backgroundTimeRemaining <= 5 {
+            logger.critical("Failed to create background task \(name), not enough time!")
             return nil
         }
 
@@ -44,6 +46,7 @@ class BackgroundTaskWrapper {
 
         // handle case where the task can't be created
         if taskID == .invalid {
+            logger.critical("Failed to create background task \(name), no valid ID!")
             return nil
         }
         self.taskID = taskID

--- a/Sources/EmbraceCoreDataInternal/CoreDataWrapper+Options.swift
+++ b/Sources/EmbraceCoreDataInternal/CoreDataWrapper+Options.swift
@@ -14,14 +14,19 @@ public extension CoreDataWrapper {
         /// Determines where the db is going to be stored
         public let storageMechanism: StorageMechanism
 
+        /// All operations are executed inside a background tasks if enabled
+        public let enableBackgroundTasks: Bool
+
         /// Array on NSEntityDescriptions that define the db model
         public let entities: [NSEntityDescription]
 
         public init(
             storageMechanism: StorageMechanism,
+            enableBackgroundTasks: Bool = true,
             entities: [NSEntityDescription]
         ) {
             self.storageMechanism = storageMechanism
+            self.enableBackgroundTasks = enableBackgroundTasks
             self.entities = entities
         }
     }

--- a/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
@@ -17,9 +17,12 @@ public class CoreDataWrapper {
 
     let logger: InternalLogger
 
+    private let isTesting: Bool
+
     public init(options: CoreDataWrapper.Options, logger: InternalLogger) throws {
         self.options = options
         self.logger = logger
+        self.isTesting = ProcessInfo.processInfo.isTesting
 
         // create model
         let model = NSManagedObjectModel()
@@ -30,7 +33,7 @@ public class CoreDataWrapper {
         self.container = NSPersistentContainer(name: name, managedObjectModel: model)
 
         // force db on memory during tests
-        if ProcessInfo.processInfo.isTesting {
+        if isTesting {
             let description = NSPersistentStoreDescription()
             description.type = NSInMemoryStoreType
             self.container.persistentStoreDescriptions = [description]
@@ -66,7 +69,7 @@ public class CoreDataWrapper {
     /// Removes the database file
     /// - Note: Only used in tests!!!
     public func destroy() {
-        guard ProcessInfo.processInfo.isTesting else {
+        guard isTesting else {
             return
         }
 
@@ -104,17 +107,41 @@ public class CoreDataWrapper {
         }
     }
 
+    /// Synchronously performs the given block on the current context.
+    /// This will also create a background task to perform the operation.
+    /// If the background task can't be created, the block will be called without a context.
+    public func performOperation(name: String, _ block: (NSManagedObjectContext?) -> Void) {
+
+        if isTesting {
+            context.performAndWait {
+                block(context)
+            }
+        } else {
+            context.performAndWait {
+                let taskName = options.storageMechanism.name + "_" + name
+                guard let task = BackgroundTaskWrapper(name: taskName, logger: logger) else {
+                    logger.critical("Failed to create background task \(taskName)!")
+                    block(nil)
+                    return
+                }
+
+                block(context)
+                task.finish()
+            }
+        }
+    }
+
     /// Synchronously saves all changes on the current context to disk
     public func save() {
-        context.performAndWait { [weak self] in
-            guard let self else {
+        performOperation(name: "Save") { [weak self] context in
+            guard let self, let context else {
                 return
             }
 
             do {
-                try self.context.save()
+                try context.save()
             } catch {
-                let name = self.context.name ?? "???"
+                let name = context.name ?? "???"
                 self.logger.critical("Error saving CoreData \"\(name)\": \(error.localizedDescription)")
             }
         }
@@ -124,8 +151,8 @@ public class CoreDataWrapper {
     public func fetch<T>(withRequest request: NSFetchRequest<T>) -> [T] where T: NSManagedObject {
 
         var result: [T] = []
-        context.performAndWait { [weak self] in
-            guard let self else {
+        performOperation(name: "Fetch") { [weak self] context in
+            guard let self, let context else {
                 return
             }
 
@@ -138,53 +165,53 @@ public class CoreDataWrapper {
         return result
     }
 
-    public func fetchAndPerform<T>(
-            withRequest request: NSFetchRequest<T>,
-            block: (([T]) -> Void)) where T: NSManagedObject {
+    /// Synchronously fetches the records that satisfy the given request and calls the block with them.
+    public func fetchAndPerform<T>(withRequest request: NSFetchRequest<T>, block: (([T]) -> Void)) where T: NSManagedObject {
 
-            context.performAndWait { [weak self] in
-                guard let self else {
-                    return
-                }
-
-                do {
-                    let result = try self.context.fetch(request)
-                    block(result)
-                } catch {
-                    self.logger.critical("Error fetching with perform!!!:\n\(error.localizedDescription)")
-                }
-            }
-        }
-
-        public func fetchFirstAndPerform<T>(
-            withRequest request: NSFetchRequest<T>,
-            block: ((T?) -> Void)) where T: NSManagedObject {
-
-            context.performAndWait { [weak self] in
-                guard let self else {
-                    return
-                }
-
-                do {
-                    let result = try self.context.fetch(request)
-                    block(result.first)
-                } catch {
-                    self.logger.critical("Error fetching first with perform!!!:\n\(error.localizedDescription)")
-                }
-            }
-        }
-
-    /// Synchronously fetches the count of records that satisfy the given request
-    public func count<T>(withRequest request: NSFetchRequest<T>) -> Int where T: NSManagedObject {
-
-        var result: Int = 0
-        context.performAndWait { [weak self] in
-            guard let self else {
+        performOperation(name: "FetchAndPerform") { [weak self] context in
+            guard let self, let context else {
+                block([])
                 return
             }
 
             do {
-                result = try self.context.count(for: request)
+                let result = try context.fetch(request)
+                block(result)
+            } catch {
+                self.logger.critical("Error fetching with perform!!!:\n\(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Synchronously fetches the first record that satisfy the given request and calls the block with it.
+    public func fetchFirstAndPerform<T>(withRequest request: NSFetchRequest<T>, block: ((T?) -> Void)) where T: NSManagedObject {
+
+        performOperation(name: "FetchFirstAndPerform") { [weak self] context in
+            guard let self, let context else {
+                block(nil)
+                return
+            }
+
+            do {
+                let result = try context.fetch(request)
+                block(result.first)
+            } catch {
+                self.logger.critical("Error fetching first with perform!!!:\n\(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Synchronously fetches the count of records that satisfy the given request.
+    public func count<T>(withRequest request: NSFetchRequest<T>) -> Int where T: NSManagedObject {
+
+        var result: Int = 0
+        performOperation(name: "Count") { [weak self] context in
+            guard let self, let context else {
+                return
+            }
+
+            do {
+                result = try context.count(for: request)
             } catch {
                 self.logger.critical("Error fetching count!!!:\n\(error.localizedDescription)")
             }
@@ -192,43 +219,46 @@ public class CoreDataWrapper {
         return result
     }
 
-    /// Synchronously deletes record from the database and saves
+    /// Synchronously deletes record from the database and saves.
     public func deleteRecord<T>(_ record: T) where T: NSManagedObject {
         deleteRecords([record])
     }
 
-    /// Synchronously deletes requested records from the database and saves
+    /// Synchronously deletes requested records from the database and saves.
     public func deleteRecords<T>(_ records: [T]) where T: NSManagedObject {
-        context.performAndWait { [weak self] in
-            guard let self else {
+        
+        performOperation(name: "DeleteRecords") { [weak self] context in
+            guard let self, let context else {
                 return
             }
 
             for record in records {
-                self.context.delete(record)
+                context.delete(record)
             }
 
             do {
-                try self.context.save()
+                try context.save()
             } catch {
                 self.logger.critical("Error deleting records!!!:\n\(error.localizedDescription)")
             }
         }
     }
 
+    /// Synchronously deletes requested records that satisfy the given request from the database and saves.
     public func deleteRecords<T>(withRequest request: NSFetchRequest<T>)where T: NSManagedObject {
-        context.performAndWait { [weak self] in
-            guard let self else {
+        
+        performOperation(name: "DeleteRecords") { [weak self] context in
+            guard let self, let context else {
                 return
             }
 
             do {
-                let records = try self.context.fetch(request)
+                let records = try context.fetch(request)
                 for record in records {
-                    self.context.delete(record)
+                    context.delete(record)
                 }
 
-                try self.context.save()
+                try context.save()
             } catch {
                 self.logger.critical("Error deleting records with request:\n\(error.localizedDescription)")
             }

--- a/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
@@ -112,7 +112,7 @@ public class CoreDataWrapper {
     /// If the background task can't be created, the block will be called without a context.
     public func performOperation(name: String, _ block: (NSManagedObjectContext?) -> Void) {
 
-        if isTesting {
+        if options.enableBackgroundTasks == false {
             context.performAndWait {
                 block(context)
             }

--- a/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
@@ -120,7 +120,6 @@ public class CoreDataWrapper {
             context.performAndWait {
                 let taskName = options.storageMechanism.name + "_" + name
                 guard let task = BackgroundTaskWrapper(name: taskName, logger: logger) else {
-                    logger.critical("Failed to create background task \(taskName)!")
                     block(nil)
                     return
                 }

--- a/Sources/EmbraceStorageInternal/EmbraceStorage+Options.swift
+++ b/Sources/EmbraceStorageInternal/EmbraceStorage+Options.swift
@@ -14,6 +14,9 @@ public extension EmbraceStorage {
         /// Determines where the db is going to be
         public let storageMechanism: StorageMechanism
 
+        /// All operations are executed inside a background tasks if enabled
+        public let enableBackgroundTasks: Bool
+
         /// Dictionary containing the storage limits per span type
         public var spanLimits: [SpanType: Int] = [:]
 
@@ -29,8 +32,9 @@ public extension EmbraceStorage {
         /// Use this initializer to create a storage object that is persisted locally to disk
         /// - Parameters:
         ///   - storageMechanism: The StorageMechanism to use
-        public init(storageMechanism: StorageMechanism) {
+        public init(storageMechanism: StorageMechanism, enableBackgroundTasks: Bool = true) {
             self.storageMechanism = storageMechanism
+            self.enableBackgroundTasks = enableBackgroundTasks
         }
     }
 }

--- a/Sources/EmbraceStorageInternal/EmbraceStorage.swift
+++ b/Sources/EmbraceStorageInternal/EmbraceStorage.swift
@@ -41,6 +41,7 @@ public class EmbraceStorage: Storage {
 
         let coreDataOptions = CoreDataWrapper.Options(
             storageMechanism: options.storageMechanism,
+            enableBackgroundTasks: options.enableBackgroundTasks,
             entities: entities
         )
         self.coreData = try CoreDataWrapper(options: coreDataOptions, logger: logger)

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -122,13 +122,16 @@ extension EmbraceStorage {
 
         var result: EmbraceMetadata?
 
-        coreData.context.performAndWait {
-            metadata.value = value
+        coreData.performOperation(name: "UpdateMetadata") { context in
+            guard let context else {
+                return
+            }
 
+            metadata.value = value
             result = metadata.toImmutable()
 
             do {
-                try coreData.context.save()
+                try context.save()
             } catch {
                 logger.error("Error updating metadata! key: \(key), lifespan \(lifespan.rawValue), id \(lifespanId)")
             }
@@ -243,12 +246,16 @@ extension EmbraceStorage {
 
         var result: Int = 1
 
-        coreData.context.performAndWait {
+        coreData.performOperation(name: "IncrementCountForPermanentResource") { context in
+            guard let context else {
+                return
+            }
+
             result = (Int(record.value) ?? 0) + 1
             record.value = String(result)
 
             do {
-                try coreData.context.save()
+                try context.save()
             } catch {
                 logger.error("Error updating metadata counter! key: \(key)")
             }

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
@@ -41,7 +41,11 @@ extension EmbraceStorage {
         if let session = fetchSessionRecord(id: id) {
             var result: EmbraceSession?
 
-            coreData.context.performAndWait {
+            coreData.performOperation(name: "UpdateExistingSession") { context in
+                guard let context else {
+                    return
+                }
+
                 session.state = state.rawValue
                 session.processIdRaw = processId.hex
                 session.traceId = traceId
@@ -60,7 +64,7 @@ extension EmbraceStorage {
                 result = session.toImmutable()
 
                 do {
-                    try coreData.context.save()
+                    try context.save()
                 } catch {
                     logger.error("Error updating session \(id.toString)!")
                 }

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
@@ -42,7 +42,11 @@ extension EmbraceStorage {
         if let span = fetchSpanRecord(id: id, traceId: traceId) {
             var result: EmbraceSpan?
 
-            coreData.context.performAndWait {
+            coreData.performOperation(name: "UpdateExistingSpan") { context in
+                guard let context else {
+                    return
+                }
+
                 // prevent modifications on closed spans!
                 if span.endTime == nil {
                     span.name = name
@@ -54,7 +58,7 @@ extension EmbraceStorage {
                     span.sessionIdRaw = sessionId?.toString
 
                     do {
-                        try coreData.context.save()
+                        try context.save()
                     } catch {
                         logger.error("Error updating span \(id)!")
                     }

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -29,6 +29,7 @@ class EmbraceUploadCache {
         // create core data stack
         let coreDataOptions = CoreDataWrapper.Options(
             storageMechanism: options.storageMechanism,
+            enableBackgroundTasks: options.enableBackgroundTasks,
             entities: [UploadDataRecord.entityDescription]
         )
         self.coreData = try CoreDataWrapper(options: coreDataOptions, logger: logger)

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -108,9 +108,19 @@ class EmbraceUploadCache {
 
         // update if it already exists
         if let record = fetchUploadData(id: id, type: type) {
-            coreData.context.performAndWait { [weak self] in
+
+            coreData.performOperation(name: "UpdateExistingUploadData") { context in
+                guard let context else {
+                    return
+                }
+
                 record.data = data
-                self?.coreData.save()
+
+                do {
+                    try context.save()
+                } catch {
+                    logger.error("Error updating upload data \(id)!")
+                }
             }
 
             return true
@@ -122,9 +132,13 @@ class EmbraceUploadCache {
         // insert new
         var result = true
 
-        coreData.context.performAndWait {
+        coreData.performOperation(name: "CreateUploadData") { context in
+            guard let context else {
+                return
+            }
+
             if let record = UploadDataRecord.create(
-                context: coreData.context,
+                context: context,
                 id: id,
                 type: type.rawValue,
                 data: data,
@@ -133,9 +147,9 @@ class EmbraceUploadCache {
             ) {
 
                 do {
-                    try coreData.context.save()
+                    try context.save()
                 } catch {
-                    coreData.context.delete(record)
+                    context.delete(record)
                     result = false
                 }
             } else {
@@ -153,27 +167,29 @@ class EmbraceUploadCache {
             return
         }
 
-        coreData.context.performAndWait { [weak self] in
-            guard let strongSelf = self else {
+        coreData.performOperation(name: "CheckCountLimit") { [weak self] context in
+            guard let self, let context else {
                 return
             }
 
             do {
                 let request = NSFetchRequest<UploadDataRecord>(entityName: UploadDataRecord.entityName)
-                let count = try strongSelf.coreData.context.count(for: request)
+                let count = try context.count(for: request)
 
-                if count >= strongSelf.options.cacheLimit {
+                if count >= self.options.cacheLimit {
                     request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true)]
-                    request.fetchLimit = max(0, count - Int(strongSelf.options.cacheLimit) + 10)
+                    request.fetchLimit = max(0, count - Int(self.options.cacheLimit) + 10)
 
-                    let result = try strongSelf.coreData.context.fetch(request)
+                    let result = try context.fetch(request)
                     for uploadData in result {
-                        strongSelf.coreData.context.delete(uploadData)
+                        context.delete(uploadData)
                     }
 
-                    strongSelf.coreData.save()
+                    try context.save()
                 }
-            } catch { }
+            } catch { 
+                logger.error("error checking count limit:\n\(error.localizedDescription)")
+            }
         }
     }
 

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
@@ -13,6 +13,9 @@ public extension EmbraceUpload {
         /// Determines where the db is going to be
         let storageMechanism: StorageMechanism
 
+        /// All operations are executed inside a background tasks if enabled
+        public let enableBackgroundTasks: Bool
+
         /// Determines the maximum amount of cached requests that will be cached. Use 0 to disable.
         public let cacheLimit: UInt
 
@@ -21,10 +24,12 @@ public extension EmbraceUpload {
 
         public init(
             storageMechanism: StorageMechanism,
+            enableBackgroundTasks: Bool = true,
             cacheLimit: UInt = 0,
             cacheDaysLimit: UInt = 7
         ) {
             self.storageMechanism = storageMechanism
+            self.enableBackgroundTasks = enableBackgroundTasks
             self.cacheLimit = cacheLimit
             self.cacheDaysLimit = cacheDaysLimit
         }

--- a/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
+++ b/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
@@ -15,7 +15,7 @@ class CoreDataWrapperTests: XCTestCase {
 
     override func setUpWithError() throws {
         let storageMechanism: StorageMechanism = .inMemory(name: testName)
-        let options = CoreDataWrapper.Options(storageMechanism: storageMechanism, entities: [MockRecord.entityDescription])
+        let options = CoreDataWrapper.Options(storageMechanism: storageMechanism, enableBackgroundTasks: false, entities: [MockRecord.entityDescription])
         try wrapper = CoreDataWrapper(options: options, logger: MockLogger())
     }
 
@@ -23,7 +23,7 @@ class CoreDataWrapperTests: XCTestCase {
         // given a wrapper with data on disk
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
         let storageMechanism: StorageMechanism = .onDisk(name: testName, baseURL: url)
-        let options = CoreDataWrapper.Options(storageMechanism: storageMechanism, entities: [MockRecord.entityDescription])
+        let options = CoreDataWrapper.Options(storageMechanism: storageMechanism, enableBackgroundTasks: false, entities: [MockRecord.entityDescription])
         try wrapper = CoreDataWrapper(options: options, logger: MockLogger())
 
         _ = MockRecord.create(context: wrapper.context, id: "test")

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -39,7 +39,7 @@ final class SessionControllerTests: XCTestCase {
 
         uploadTestOptions = EmbraceUpload.Options(
             endpoints: testEndpointOptions(testName: testName),
-            cache: EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName)),
+            cache: EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false),
             metadata: Self.testMetadataOptions,
             redundancy: Self.testRedundancyOptions,
             urlSessionConfiguration: uploadUrlSessionconfig

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -46,7 +46,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         uploadOptions = EmbraceUpload.Options(
             endpoints: testEndpointOptions(forTest: testName),
-            cache: EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName)),
+            cache: EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false),
             metadata: UnsentDataHandlerTests.testMetadataOptions,
             redundancy: UnsentDataHandlerTests.testRedundancyOptions,
             urlSessionConfiguration: urlSessionconfig

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests+ClearDataDate.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests+ClearDataDate.swift
@@ -10,7 +10,7 @@ import EmbraceCommonInternal
 extension EmbraceUploadCacheTests {
     func test_clearStaleDataIfNeeded_basedOn_date() throws {
         // setting the maximum allowed days
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: (testName)), cacheDaysLimit: 15)
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: (testName)), enableBackgroundTasks: false, cacheDaysLimit: 15)
         let cache = try EmbraceUploadCache(options: options, logger: MockLogger())
 
         // given some upload cache
@@ -97,7 +97,7 @@ extension EmbraceUploadCacheTests {
 
     func test_clearStaleDataIfNeeded_basedOn_date_noLimit() throws {
         // disabling maximum allowed days
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), cacheDaysLimit: 0)
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false, cacheDaysLimit: 0)
         let cache = try EmbraceUploadCache(options: options, logger: MockLogger())
 
         // given some upload cache
@@ -169,7 +169,7 @@ extension EmbraceUploadCacheTests {
 
     func test_clearStaleDataIfNeeded_basedOn_date_noRecords() throws {
         // setting minimum allowed time
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), cacheDaysLimit: 1)
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false, cacheDaysLimit: 1)
         let cache = try EmbraceUploadCache(options: options, logger: MockLogger())
 
         // when attempting to remove data from an empty cache
@@ -181,7 +181,7 @@ extension EmbraceUploadCacheTests {
 
     func test_clearStaleDataIfNeeded_basedOn_date_didNotHitTimeLimit() throws {
         // disabling maximum allowed days
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), cacheDaysLimit: 17)
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false, cacheDaysLimit: 17)
         let cache = try EmbraceUploadCache(options: options, logger: MockLogger())
 
         // given some upload cache

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests.swift
@@ -22,7 +22,7 @@ class EmbraceUploadCacheTests: XCTestCase {
     }
 
     func test_fetchUploadData() throws {
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName))
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)
         let cache = try EmbraceUploadCache(options: options, logger: logger)
 
         // given inserted upload data
@@ -46,7 +46,7 @@ class EmbraceUploadCacheTests: XCTestCase {
     }
 
     func test_fetchAllUploadData() throws {
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName))
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)
         let cache = try EmbraceUploadCache(options: options, logger: logger)
 
         // given inserted upload datas
@@ -87,7 +87,7 @@ class EmbraceUploadCacheTests: XCTestCase {
     }
 
     func test_saveUploadData() throws {
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName))
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)
         let cache = try EmbraceUploadCache(options: options, logger: logger)
 
         // given inserted upload data
@@ -113,7 +113,7 @@ class EmbraceUploadCacheTests: XCTestCase {
 
     func test_saveUploadData_limit() throws {
         // given a cache with a limit of 1
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), cacheLimit: 1)
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false, cacheLimit: 1)
         let cache = try EmbraceUploadCache(options: options, logger: logger)
 
         // given inserted upload datas
@@ -140,7 +140,7 @@ class EmbraceUploadCacheTests: XCTestCase {
     }
 
     func test_deleteUploadData() throws {
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName))
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)
         let cache = try EmbraceUploadCache(options: options, logger: logger)
 
         // given inserted upload data
@@ -176,7 +176,7 @@ class EmbraceUploadCacheTests: XCTestCase {
     }
 
     func test_updateAttemptCount() throws {
-        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName))
+        let options = EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)
         let cache = try EmbraceUploadCache(options: options, logger: logger)
 
         // given inserted upload data

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -25,7 +25,7 @@ class EmbraceUploadTests: XCTestCase {
 
         testOptions = EmbraceUpload.Options(
             endpoints: testEndpointOptions(testName: testName),
-            cache: EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName)),
+            cache: EmbraceUpload.CacheOptions(storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false),
             metadata: EmbraceUploadTests.testMetadataOptions,
             redundancy: EmbraceUploadTests.testRedundancyOptions,
             urlSessionConfiguration: urlSessionconfig

--- a/Tests/TestSupport/Extensions/EmbraceStorage+Extension.swift
+++ b/Tests/TestSupport/Extensions/EmbraceStorage+Extension.swift
@@ -9,7 +9,7 @@ import EmbraceCommonInternal
 public extension EmbraceStorage {
     static func createInMemoryDb() throws -> EmbraceStorage {
         let storage = try EmbraceStorage(
-            options: .init(storageMechanism: .inMemory(name: UUID().uuidString)),
+            options: .init(storageMechanism: .inMemory(name: UUID().uuidString), enableBackgroundTasks: false),
             logger: MockLogger()
         )
         return storage
@@ -18,7 +18,7 @@ public extension EmbraceStorage {
     static func createInDiskDb(fileName: String) throws -> EmbraceStorage {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
         let storage = try EmbraceStorage(
-            options: .init(storageMechanism: .onDisk(name: fileName, baseURL: url)),
+            options: .init(storageMechanism: .onDisk(name: fileName, baseURL: url), enableBackgroundTasks: false),
             logger: MockLogger()
         )
 


### PR DESCRIPTION
We've seen a lot of app terminations due to a deadlock.
We suspect this happens when our core data operations are performed in the background and the OS suspends the app.

This PR wraps all of our core data operations inside background tasks which should prevent the OS from suspending the app until the operations are done.
This is probably not gonna fix 100% of the cases, but should fix the vast majority of them.