### PR TITLE
[EMBR-7958] Fix potential race condition on First Frame Time capture

### DIFF
--- a/Sources/EmbraceCore/Internal/Startup/StartupInstrumentation.swift
+++ b/Sources/EmbraceCore/Internal/Startup/StartupInstrumentation.swift
@@ -99,6 +99,10 @@ public class StartupInstrumentation: NSObject {
             $0.rootSpan = parent
             $0.firstFrameSpan = firstFrameSpan
         }
+
+        if let firstFrameTime = provider.firstFrameTime {
+            endSpans(firstFrameTime)
+        }
     }
 
     func buildSecondarySpans(_ appDidFinishLaunchingTime: Date?) {


### PR DESCRIPTION
There's a potential race condition when setting up the spans for startup instrumentation. If the first frame time was already captured when `buildMainSpans()` is called, then the spans would never terminate because the chain of events to call `endSpans()` would not trigger. This PR checks if the time already exists, it terminates the spans right after creating them.