### PR TITLE
Improving one time capture services

### DIFF
--- a/Sources/EmbraceCore/Capture/OneTimeServices/AppInfoCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/OneTimeServices/AppInfoCaptureService.swift
@@ -12,71 +12,47 @@ import OpenTelemetryApi
 class AppInfoCaptureService: ResourceCaptureService {
 
     override func onStart() {
-        // bundle version
-        addResource(
-            key: AppResourceKey.bundleVersion.rawValue,
-            value: .string(EMBDevice.bundleVersion)
-        )
 
-        // environment
-        addResource(
-            key: AppResourceKey.environment.rawValue,
-            value: .string(EMBDevice.environment)
-        )
+        let isPreWarm = ProcessInfo.processInfo.environment["ActivePrewarm"] == "1" ? "true" : "false"
 
-        // environment detail
-        addResource(
-            key: AppResourceKey.detailedEnvironment.rawValue,
-            value: .string(EMBDevice.environmentDetail)
-        )
+        var resourcesMap: [String: String] = [
+            // bundle version
+            AppResourceKey.bundleVersion.rawValue: EMBDevice.bundleVersion,
 
-        // framework
-        addResource(
-            key: AppResourceKey.framework.rawValue,
-            value: .int(Embrace.client?.options.platform.frameworkId ?? -1)
-        )
+            // environment
+            AppResourceKey.environment.rawValue: EMBDevice.environment,
 
-        // sdk version
-        addResource(
-            key: AppResourceKey.sdkVersion.rawValue,
-            value: .string(EmbraceMeta.sdkVersion)
-        )
+            // environment detail
+            AppResourceKey.detailedEnvironment.rawValue: EMBDevice.environmentDetail,
+
+            // framework
+            AppResourceKey.framework.rawValue: String(Embrace.client?.options.platform.frameworkId ?? -1),
+
+            // sdk version
+            AppResourceKey.sdkVersion.rawValue: EmbraceMeta.sdkVersion,
+
+            // process id
+            AppResourceKey.processIdentifier.rawValue: ProcessIdentifier.current.hex,
+
+            // pre-warm
+            AppResourceKey.processPreWarm.rawValue: isPreWarm
+        ]
 
         // app version
         if let appVersion = EMBDevice.appVersion {
-            addResource(
-                key: AppResourceKey.appVersion.rawValue,
-                value: .string(appVersion)
-            )
+            resourcesMap[AppResourceKey.appVersion.rawValue] = appVersion
         }
 
         // build UUID
         if let buildUUID = EMBDevice.buildUUID {
-            addResource(
-                key: AppResourceKey.buildID.rawValue,
-                value: .string(buildUUID.withoutHyphen)
-            )
+            resourcesMap[AppResourceKey.buildID.rawValue] = buildUUID.withoutHyphen
         }
-
-        // process identifier
-        addResource(
-            key: AppResourceKey.processIdentifier.rawValue,
-            value: .string(ProcessIdentifier.current.hex)
-        )
 
         // process start time
         if let processStartTime = ProcessMetadata.startTime {
-            addResource(
-                key: AppResourceKey.processStartTime.rawValue,
-                value: .int(processStartTime.nanosecondsSince1970Truncated)
-            )
+            resourcesMap[AppResourceKey.processStartTime.rawValue] = String(processStartTime.nanosecondsSince1970Truncated)
         }
 
-        // pre-warm
-        let isPreWarm = ProcessInfo.processInfo.environment["ActivePrewarm"] == "1"
-        addResource(
-            key: AppResourceKey.processPreWarm.rawValue,
-            value: .bool(isPreWarm)
-        )
+        addRequiredResources(resourcesMap)
     }
 }

--- a/Sources/EmbraceCore/Capture/OneTimeServices/DeviceInfoCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/OneTimeServices/DeviceInfoCaptureService.swift
@@ -12,66 +12,41 @@ import OpenTelemetrySdk
 class DeviceInfoCaptureService: ResourceCaptureService {
 
     override func onStart() {
-        // jailbroken
-        addResource(
-            key: DeviceResourceKey.isJailbroken.rawValue,
-            value: .string(String(EMBDevice.isJailbroken))
-        )
 
-        // locale
-        addResource(
-            key: DeviceResourceKey.locale.rawValue,
-            value: .string(EMBDevice.locale)
-        )
+        let resourcesMap: [String: String] = [
+            // jailbroken
+            DeviceResourceKey.isJailbroken.rawValue: EMBDevice.isJailbroken ? "true" : "false",
 
-        // timezone
-        addResource(
-            key: DeviceResourceKey.timezone.rawValue,
-            value: .string(EMBDevice.timezoneDescription)
-        )
+            // locale
+            DeviceResourceKey.locale.rawValue: EMBDevice.locale,
 
-        // disk space
-        addResource(
-            key: DeviceResourceKey.totalDiskSpace.rawValue,
-            value: .int(EMBDevice.totalDiskSpace.intValue)
-        )
+            // timezone
+            DeviceResourceKey.timezone.rawValue: EMBDevice.timezoneDescription,
 
-        // os version
-        addResource(
-            key: ResourceAttributes.osVersion.rawValue,
-            value: .string(EMBDevice.operatingSystemVersion)
-        )
+            // disk space
+            DeviceResourceKey.totalDiskSpace.rawValue: String(EMBDevice.totalDiskSpace.intValue),
 
-        // os build
-        addResource(
-            key: DeviceResourceKey.osBuild.rawValue,
-            value: .string(EMBDevice.operatingSystemBuild)
-        )
+            // os version
+            ResourceAttributes.osVersion.rawValue: EMBDevice.operatingSystemVersion,
 
-        // os variant
-        addResource(
-            key: DeviceResourceKey.osVariant.rawValue,
-            value: .string(EMBDevice.operatingSystemType)
-        )
+            // os build
+            DeviceResourceKey.osBuild.rawValue: EMBDevice.operatingSystemBuild,
 
-        // os type
-        // Should always be "darwin" as can be seen in semantic convention docs:
-        // https://opentelemetry.io/docs/specs/semconv/resource/os/
-        addResource(
-            key: ResourceAttributes.osType.rawValue,
-            value: .string("darwin")
-        )
+            // os variant
+            DeviceResourceKey.osVariant.rawValue: EMBDevice.operatingSystemType,
 
-        // model
-        addResource(
-            key: ResourceAttributes.deviceModelIdentifier.rawValue,
-            value: .string(EMBDevice.model)
-        )
+            // os type
+            // Should always be "darwin" as can be seen in semantic convention docs:
+            // https://opentelemetry.io/docs/specs/semconv/resource/os/
+            ResourceAttributes.osType.rawValue: "darwin",
 
-        // architecture
-        addResource(
-            key: DeviceResourceKey.architecture.rawValue,
-            value: .string(EMBDevice.architecture)
-        )
+            // model
+            ResourceAttributes.deviceModelIdentifier.rawValue: EMBDevice.model,
+
+            // architecture
+            DeviceResourceKey.architecture.rawValue: EMBDevice.architecture
+        ]
+
+        addRequiredResources(resourcesMap)
     }
 }

--- a/Sources/EmbraceCore/Capture/ResourceCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/ResourceCaptureService.swift
@@ -10,25 +10,19 @@ import EmbraceStorageInternal
 import OpenTelemetryApi
 
 protocol ResourceCaptureServiceHandler: AnyObject {
-    func addResource(key: String, value: AttributeValue)
+    func addRequiredResources(_ map: [String: String])
 }
 
 class ResourceCaptureService: CaptureService {
     weak var handler: ResourceCaptureServiceHandler?
 
-    func addResource(key: String, value: AttributeValue) {
-        handler?.addResource(key: key, value: value)
+    func addRequiredResources(_ map: [String: String]) {
+        handler?.addRequiredResources(map)
     }
 }
 
 extension EmbraceStorage: ResourceCaptureServiceHandler {
-    func addResource(key: String, value: AttributeValue) {
-        _ = addMetadata(
-            key: key,
-            value: value.description,
-            type: .requiredResource,
-            lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
-        )
+    func addRequiredResources(_ map: [String: String]) {
+        addRequiredResources(map, processId: .current)
     }
 }

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -61,6 +61,63 @@ extension EmbraceStorage {
         return nil
     }
 
+    /// Adds or updates all the given required resources
+    public func addRequiredResources(_ map: [String: String], processId: ProcessIdentifier = .current) {
+        
+        coreData.performOperation(name: "UpsertRequiredResources") { context in
+            guard let context else {
+                return
+            }
+
+            guard let description = NSEntityDescription.entity(forEntityName: MetadataRecord.entityName, in: context) else {
+                logger.error("Error finding entity description for MetadataRecord!")
+                return
+            }
+
+            for (key, value) in map {
+                // find if exists
+                let request = MetadataRecord.createFetchRequest()
+                request.fetchLimit = 1
+                request.predicate = NSPredicate(
+                    format: "key == %@ AND typeRaw == %@ AND lifespanRaw == %@ AND lifespanId == %@",
+                    key,
+                    MetadataRecordType.requiredResource.rawValue,
+                    MetadataRecordLifespan.process.rawValue,
+                    processId.hex
+                )
+
+                var record: MetadataRecord?
+                do {
+                    record = try context.fetch(request).first
+                } catch {
+                    logger.error("Error fetching required resource \(key)!")
+                }
+
+                // update
+                if let record = record {
+                    record.value = value
+
+                // create
+                } else {
+                    record = MetadataRecord(entity: description, insertInto: context)
+                    record?.key = key
+                    record?.value = value
+                    record?.typeRaw = MetadataRecordType.requiredResource.rawValue
+                    record?.lifespanRaw = MetadataRecordLifespan.process.rawValue
+                    record?.lifespanId = processId.hex
+                    record?.collectedAt = Date()
+                }
+            }
+
+            // save all
+            do {
+                try context.save()
+            } catch {
+                logger.error("Error when saving new required resources:\n\(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Returns the `MetadataRecord` for the given values.
     func fetchMetadataRecord(
         key: String,

--- a/Tests/EmbraceCoreTests/Capture/ResourceCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/ResourceCaptureServiceTests.swift
@@ -11,20 +11,23 @@ import TestSupport
 
 class ResourceCaptureServiceTests: XCTestCase {
 
-    func test_addResource() throws {
+    func test_addRequiredResource() throws {
         // given a resource capture service
         let service = ResourceCaptureService()
         let handler = try EmbraceStorage.createInMemoryDb()
         service.handler = handler
 
         // when adding a resource
-        service.addResource(key: "test", value: .string("value"))
+        let map = [
+            "key1": "value1",
+            "key2": "value2",
+            "key3": "value3"
+        ]
+        service.addRequiredResources(map)
 
         // then the resource is added to the storage
         let metadata: [MetadataRecord] = handler.fetchAll()
-        XCTAssertEqual(metadata.count, 1)
-        XCTAssertEqual(metadata[0].key, "test")
-        XCTAssertEqual(metadata[0].value, "value")
+        XCTAssertEqual(metadata.count, 3)
         XCTAssertEqual(metadata[0].typeRaw, "requiredResource")
         XCTAssertEqual(metadata[0].lifespanRaw, "process")
         XCTAssertEqual(metadata[0].lifespanId, ProcessIdentifier.current.hex)


### PR DESCRIPTION
These capture services were very slow because we were adding resources one by one.
This PR changes them so now all of the resources get added in a single core data operation.