### PR TITLE
Uppercasing HTTP method on request spans for consistency

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -84,7 +84,7 @@ final class DefaultURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
             var attributes: [String: String] = [:]
             attributes[SpanSemantics.NetworkRequest.keyUrl] = request.url?.absoluteString ?? "N/A"
 
-            let httpMethod = request.httpMethod ?? ""
+            let httpMethod = request.httpMethod?.uppercased() ?? ""
             if !httpMethod.isEmpty {
                 attributes[SpanSemantics.NetworkRequest.keyMethod] = httpMethod
             }


### PR DESCRIPTION
Seems that the http methods can in fact be lower case some times.
The backend does handle this, but for the sake of consistency we're going to uppercase them on the SDKs before sending the spans.