### PR TITLE
Fixing clean exit not being updated before sending sessions

### DIFF
--- a/Sources/EmbraceCore/Session/Upload/DefaultSessionUploader.swift
+++ b/Sources/EmbraceCore/Session/Upload/DefaultSessionUploader.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
+import EmbraceCommonInternal
+import EmbraceStorageInternal
+import EmbraceUploadInternal
+#endif
+
+// used for tests
+protocol SessionUploader {
+    func uploadSession(_ session: EmbraceSession, storage: EmbraceStorage, upload: EmbraceUpload)
+}
+
+class DefaultSessionUploader: SessionUploader {
+    func uploadSession(_ session: EmbraceSession, storage: EmbraceStorage, upload: EmbraceUpload) {
+        UnsentDataHandler.sendSession(session, storage: storage, upload: upload)
+    }
+}

--- a/Tests/EmbraceCoreTests/Session/MockSessionUploader.swift
+++ b/Tests/EmbraceCoreTests/Session/MockSessionUploader.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+    
+@testable import EmbraceCore
+import EmbraceCommonInternal
+import EmbraceStorageInternal
+import EmbraceUploadInternal
+
+class MockSessionUploader: SessionUploader {
+
+    var didCallUploadSession: Bool = false
+    var uploadedSession: EmbraceSession? = nil
+
+    func uploadSession(_ session: EmbraceSession, storage: EmbraceStorage, upload: EmbraceUpload) {
+        didCallUploadSession = true
+        uploadedSession = session
+    }
+}

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -181,6 +181,25 @@ final class SessionControllerTests: XCTestCase {
         XCTAssertEqual(sessions.first!.idRaw, session!.idRaw)
         XCTAssertEqual(sessions.first!.state, "foreground")
         XCTAssertEqual(sessions.first!.endTime!.timeIntervalSince1970, endTime.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertEqual(sessions.first!.cleanExit, true)
+    }
+
+    func test_endSession_updatesLocalSessionBeforeUploading() throws {
+        // given a started session
+        let uploader = MockSessionUploader()
+        let controller = SessionController(storage: storage, upload: upload, uploader: uploader, config: nil)
+        controller.sdkStateProvider = sdkStateProvider
+        controller.startSession(state: .foreground)
+
+        // when ending the session
+        controller.endSession()
+        wait(delay: .longTimeout)
+
+        // then a session was sent with the corrent values
+        XCTAssert(uploader.didCallUploadSession)
+        XCTAssertNotNil(uploader.uploadedSession)
+        XCTAssertNotNil(uploader.uploadedSession!.endTime)
+        XCTAssert(uploader.uploadedSession!.cleanExit)
     }
 
     func test_endSession_saves_endsSessionSpan() throws {


### PR DESCRIPTION
The local copy of the current session was not being updated in the SessionController before being uploaded.
This resulted in pretty much all sessions being flagged as UEs.