### PR TITLE
CoreData Date issues

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -142,6 +151,15 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/CoreDataWrapper.swift
@@ -138,7 +138,9 @@ public class CoreDataWrapper {
             }
 
             do {
-                try context.save()
+                if context.hasChanges {
+                    try context.save()
+                }
             } catch {
                 let name = context.name ?? "???"
                 self.logger.critical("Error saving CoreData \"\(name)\": \(error.localizedDescription)")

--- a/Sources/EmbraceStorageInternal/Records/LogRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/LogRecord.swift
@@ -111,6 +111,7 @@ extension LogRecord: EmbraceStorageRecord {
         let timestampAttribute = NSAttributeDescription()
         timestampAttribute.name = "timestamp"
         timestampAttribute.attributeType = .dateAttributeType
+        timestampAttribute.defaultValue = Date()
 
         // child
         let keyAttribute = NSAttributeDescription()

--- a/Sources/EmbraceStorageInternal/Records/MetadataRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/MetadataRecord.swift
@@ -95,6 +95,7 @@ extension MetadataRecord: EmbraceStorageRecord {
         let collectedAtAttribute = NSAttributeDescription()
         collectedAtAttribute.name = "collectedAt"
         collectedAtAttribute.attributeType = .dateAttributeType
+        collectedAtAttribute.defaultValue = Date()
 
         entity.properties = [
             keyAttribute,

--- a/Sources/EmbraceStorageInternal/Records/SessionRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/SessionRecord.swift
@@ -125,6 +125,7 @@ extension SessionRecord: EmbraceStorageRecord {
         let startTimeAttribute = NSAttributeDescription()
         startTimeAttribute.name = "startTime"
         startTimeAttribute.attributeType = .dateAttributeType
+        startTimeAttribute.defaultValue = Date()
 
         let endTimeAttribute = NSAttributeDescription()
         endTimeAttribute.name = "endTime"

--- a/Sources/EmbraceStorageInternal/Records/SpanRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/SpanRecord.swift
@@ -106,6 +106,7 @@ extension SpanRecord: EmbraceStorageRecord {
         let startTimeAttribute = NSAttributeDescription()
         startTimeAttribute.name = "startTime"
         startTimeAttribute.attributeType = .dateAttributeType
+        startTimeAttribute.defaultValue = Date()
 
         let endTimeAttribute = NSAttributeDescription()
         endTimeAttribute.name = "endTime"


### PR DESCRIPTION
This PR attempts to address the crash we've seen regarding non-optional Dates in CoreData.

1. It sets a default value in the model for all non-optional Dates.
2. We noticed there were some places where we were fetching an object in an operation (performAndWait), then reading / modifying that object in another performAndWait block. This PR combines those operations into 1 in all places that makes sense.