### PR TITLE
Add macOS support; fix CADisplayLink bug

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform_args: ["iOS tvOS"] # using a single string will run platforms in parallel
+        platform_args: ["iOS tvOS" "macOS"] # using a single string will run platforms in parallel
         xcode_version: ["15.4"]
     steps:
     - name: Select Xcode

--- a/.swiftpm/xcode/xcshareddata/xcschemes/EmbraceIO-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/EmbraceIO-Package.xcscheme
@@ -454,6 +454,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BrandGame"
+               BuildableName = "BrandGame"
+               BlueprintName = "BrandGame"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -690,6 +704,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BrandGame"
+            BuildableName = "BrandGame"
+            BlueprintName = "BrandGame"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -697,15 +721,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EmbraceCore"
-            BuildableName = "EmbraceCore"
-            BlueprintName = "EmbraceCore"
+            BlueprintIdentifier = "BrandGame"
+            BuildableName = "BrandGame"
+            BlueprintName = "BrandGame"
             ReferencedContainer = "container:">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
+++ b/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
@@ -43,6 +43,13 @@
 		7BCB66282AC4742800ABD33A /* MenuList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB66272AC4742800ABD33A /* MenuList.swift */; };
 		7BCB662A2AC4767B00ABD33A /* MainMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB66292AC4767B00ABD33A /* MainMenu.swift */; };
 		7BCB662E2AC476BC00ABD33A /* NetworkStressTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB662D2AC476BC00ABD33A /* NetworkStressTest.swift */; };
+		9618109E2E1592B4009CC62C /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9618109D2E1592B4009CC62C /* EmbraceCore */; };
+		961810A02E1592B4009CC62C /* EmbraceCrash in Frameworks */ = {isa = PBXBuildFile; productRef = 9618109F2E1592B4009CC62C /* EmbraceCrash */; };
+		961810A22E1592B4009CC62C /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 961810A12E1592B4009CC62C /* EmbraceCrashlyticsSupport */; };
+		961810A42E1592B4009CC62C /* EmbraceIO in Frameworks */ = {isa = PBXBuildFile; productRef = 961810A32E1592B4009CC62C /* EmbraceIO */; };
+		961810A62E1592B4009CC62C /* EmbraceMacros in Frameworks */ = {isa = PBXBuildFile; productRef = 961810A52E1592B4009CC62C /* EmbraceMacros */; };
+		961810A82E1592B4009CC62C /* EmbraceSemantics in Frameworks */ = {isa = PBXBuildFile; productRef = 961810A72E1592B4009CC62C /* EmbraceSemantics */; };
+		961810AA2E217326009CC62C /* Cocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961810A92E217326009CC62C /* Cocoa.swift */; };
 		FA3B0A112C3C2A5600315578 /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A102C3C2A5600315578 /* EmbraceCore */; };
 		FA3B0A132C3C2A5600315578 /* EmbraceCrash in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A122C3C2A5600315578 /* EmbraceCrash */; };
 		FA3B0A152C3C2A5600315578 /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A142C3C2A5600315578 /* EmbraceCrashlyticsSupport */; };
@@ -134,6 +141,7 @@
 		7BCB66272AC4742800ABD33A /* MenuList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuList.swift; sourceTree = "<group>"; };
 		7BCB66292AC4767B00ABD33A /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
 		7BCB662D2AC476BC00ABD33A /* NetworkStressTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStressTest.swift; sourceTree = "<group>"; };
+		961810A92E217326009CC62C /* Cocoa.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cocoa.swift; sourceTree = "<group>"; };
 		FA4C5F322C486E13005C0371 /* CreateSpanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSpanView.swift; sourceTree = "<group>"; };
 		FA4C5F342C487B45005C0371 /* AttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesView.swift; sourceTree = "<group>"; };
 		FA4FA4F92C62DBB600E66300 /* NoSpacesTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSpacesTextField.swift; sourceTree = "<group>"; };
@@ -158,10 +166,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B3BD2192BBC5A1600938444 /* StdoutExporter in Frameworks */,
+				961810A62E1592B4009CC62C /* EmbraceMacros in Frameworks */,
 				FAEF5A132C6BA46F00484474 /* EmbraceCrash in Frameworks */,
+				961810A42E1592B4009CC62C /* EmbraceIO in Frameworks */,
 				FA3B0A132C3C2A5600315578 /* EmbraceCrash in Frameworks */,
 				FA716C822C45B94A00AD0161 /* EmbraceCrashlyticsSupport in Frameworks */,
 				FA3B0A152C3C2A5600315578 /* EmbraceCrashlyticsSupport in Frameworks */,
+				9618109E2E1592B4009CC62C /* EmbraceCore in Frameworks */,
 				FA716C7E2C45B94A00AD0161 /* EmbraceCore in Frameworks */,
 				FA716C802C45B94A00AD0161 /* EmbraceCrash in Frameworks */,
 				FA716C842C45B94A00AD0161 /* EmbraceIO in Frameworks */,
@@ -172,9 +183,12 @@
 				FAF85DF52C45B1C6002306FF /* EmbraceCore in Frameworks */,
 				FAF85DF92C45B1C6002306FF /* EmbraceCrashlyticsSupport in Frameworks */,
 				FAF85DF72C45B1C6002306FF /* EmbraceCrash in Frameworks */,
+				961810A02E1592B4009CC62C /* EmbraceCrash in Frameworks */,
 				FAEF5A152C6BA46F00484474 /* EmbraceCrashlyticsSupport in Frameworks */,
 				FAEF5A192C6BA46F00484474 /* EmbraceSemantics in Frameworks */,
 				FAEF5A112C6BA46F00484474 /* EmbraceCore in Frameworks */,
+				961810A82E1592B4009CC62C /* EmbraceSemantics in Frameworks */,
+				961810A22E1592B4009CC62C /* EmbraceCrashlyticsSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -294,6 +308,7 @@
 			isa = PBXGroup;
 			children = (
 				7B5630A42AC1331000E0DF39 /* Color+Random.swift */,
+				961810A92E217326009CC62C /* Cocoa.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -548,6 +563,12 @@
 				FAEF5A142C6BA46F00484474 /* EmbraceCrashlyticsSupport */,
 				FAEF5A162C6BA46F00484474 /* EmbraceIO */,
 				FAEF5A182C6BA46F00484474 /* EmbraceSemantics */,
+				9618109D2E1592B4009CC62C /* EmbraceCore */,
+				9618109F2E1592B4009CC62C /* EmbraceCrash */,
+				961810A12E1592B4009CC62C /* EmbraceCrashlyticsSupport */,
+				961810A32E1592B4009CC62C /* EmbraceIO */,
+				961810A52E1592B4009CC62C /* EmbraceMacros */,
+				961810A72E1592B4009CC62C /* EmbraceSemantics */,
 			);
 			productName = BrandGame;
 			productReference = 7B56308A2ABE743400E0DF39 /* BrandGame.app */;
@@ -579,7 +600,7 @@
 			mainGroup = 7B5630812ABE743400E0DF39;
 			packageReferences = (
 				7B3BD1FD2BBC5A1600938444 /* XCRemoteSwiftPackageReference "opentelemetry-swift" */,
-				FAEF5A0F2C6BA46F00484474 /* XCLocalSwiftPackageReference "../.." */,
+				9618109C2E1592B4009CC62C /* XCLocalSwiftPackageReference "../../../embrace-apple-sdk" */,
 			);
 			productRefGroup = 7B56308B2ABE743400E0DF39 /* Products */;
 			projectDirPath = "";
@@ -686,6 +707,7 @@
 				FA9505162B86640F00562A4C /* LoggingView.swift in Sources */,
 				7B3143B92AFDC8EC00BA0D2F /* RightBracketShape.swift in Sources */,
 				7B3143B52AFDC50E00BA0D2F /* LeftDotShape.swift in Sources */,
+				961810AA2E217326009CC62C /* Cocoa.swift in Sources */,
 				7B62ADA32B0068280087C2AE /* SimonMinigameView.swift in Sources */,
 				7B3143B32AFDC2D300BA0D2F /* LeftBracketShape.swift in Sources */,
 				7B4FFC2D2B1E5B7B006239F7 /* Endpoints+InfoPlist.swift in Sources */,
@@ -828,7 +850,7 @@
 				CURRENT_PROJECT_VERSION = 5;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"BrandGame/Preview Content\"";
-				DEVELOPMENT_TEAM = L5RVT7J8CV;
+				DEVELOPMENT_TEAM = 2Z8M9MTEVV;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -846,6 +868,9 @@
 				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.embrace.BrandGame;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -860,7 +885,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"BrandGame/Preview Content\"";
-				DEVELOPMENT_TEAM = L5RVT7J8CV;
+				DEVELOPMENT_TEAM = 2Z8M9MTEVV;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -878,6 +903,9 @@
 				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.embrace.BrandGame;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -908,9 +936,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		FAEF5A0F2C6BA46F00484474 /* XCLocalSwiftPackageReference "../.." */ = {
+		9618109C2E1592B4009CC62C /* XCLocalSwiftPackageReference "../../../embrace-apple-sdk" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../..;
+			relativePath = "../../../embrace-apple-sdk";
 		};
 /* End XCLocalSwiftPackageReference section */
 
@@ -930,6 +958,30 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7B3BD1FD2BBC5A1600938444 /* XCRemoteSwiftPackageReference "opentelemetry-swift" */;
 			productName = StdoutExporter;
+		};
+		9618109D2E1592B4009CC62C /* EmbraceCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EmbraceCore;
+		};
+		9618109F2E1592B4009CC62C /* EmbraceCrash */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EmbraceCrash;
+		};
+		961810A12E1592B4009CC62C /* EmbraceCrashlyticsSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EmbraceCrashlyticsSupport;
+		};
+		961810A32E1592B4009CC62C /* EmbraceIO */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EmbraceIO;
+		};
+		961810A52E1592B4009CC62C /* EmbraceMacros */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EmbraceMacros;
+		};
+		961810A72E1592B4009CC62C /* EmbraceSemantics */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EmbraceSemantics;
 		};
 		FA3B0A102C3C2A5600315578 /* EmbraceCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/BrandGame/BrandGame/Utils/Cocoa.swift
+++ b/Examples/BrandGame/BrandGame/Utils/Cocoa.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+    
+
+import Foundation
+import SwiftUI
+
+#if os(macOS)
+import AppKit
+
+protocol ViewRepresentable: NSViewRepresentable where ViewType == NSViewType {
+    associatedtype ViewType: NSView
+    func makeView(context: Context) -> ViewType
+    func updateView(_ view: ViewType, context: Context)
+}
+
+extension ViewRepresentable {
+    func makeNSView(context: Context) -> Self.NSViewType {
+        makeView(context: context)
+    }
+    
+    func updateNSView(_ nsView: NSViewType, context: Context) {
+        updateView(nsView, context: context)
+    }
+}
+#else
+import UIKit
+
+protocol ViewRepresentable: UIViewRepresentable where ViewType == UIViewType {
+    associatedtype ViewType: UIView
+    func makeView(context: Context) -> ViewType
+    func updateView(_ view: ViewType, context: Context)
+}
+
+extension ViewRepresentable {
+    func makeUIView(context: Context) -> Self.UIViewType {
+        makeView(context: context)
+    }
+    
+    func updateUIView(_ nsView: UIViewType, context: Context) {
+        updateView(nsView, context: context)
+    }
+}
+#endif

--- a/Examples/BrandGame/BrandGame/View/Components/TextFields/NoSpacesTextField.swift
+++ b/Examples/BrandGame/BrandGame/View/Components/TextFields/NoSpacesTextField.swift
@@ -30,7 +30,9 @@ struct NoSpacesTextField: View {
                     text = modifiedString
                 }
             }
+        #if !os(macOS)
             .textInputAutocapitalization(.never)
+        #endif
             .disableAutocorrection(!autocorrectionEnabled)
     }
 }

--- a/Examples/BrandGame/BrandGame/View/Menu/MainMenu.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/MainMenu.swift
@@ -8,18 +8,44 @@ struct MainMenu: View {
 
     @Environment(\.dismiss) var dismiss
 
-    var body: some View {
+    private var dismissButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image(systemName: "chevron.down")
+        }
+    }
+    
+    func navigationView(_ content: () -> some View) -> some View {
+        #if os(macOS)
         NavigationStack {
+            ScrollView {
+                content()
+            }
+        }
+        #else
+        NavigationStack {
+            content()
+        }
+        #endif
+    }
+    var body: some View {
+        navigationView {
             MenuList()
                 .toolbar {
+#if !os(macOS)
                     ToolbarItem(placement: .topBarLeading) {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image(systemName: "chevron.down")
-                        }
+                        dismissButton
                     }
+#else
+                    ToolbarItem(placement: .cancellationAction) {
+                        dismissButton
+                    }
+#endif
                 }
+#if os(macOS)
+                .frame(height: 500)
+#endif
         }
     }
 }

--- a/Examples/BrandGame/BrandGame/View/Menu/OpenTelemetry/CreateSpanView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/OpenTelemetry/CreateSpanView.swift
@@ -74,9 +74,12 @@ struct CreateSpanView: View {
                 }
             }
         }.popUp("Span was created ✅", shouldShow: $showPopup)
+        #if !os(macOS)
             .textInputAutocapitalization(.never)
-            .autocorrectionDisabled()
             .navigationBarTitle("Create Span")
+        #endif
+            .autocorrectionDisabled()
+            
     }
 
     func removeAttributes(at offsets: IndexSet) {

--- a/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
@@ -65,7 +65,9 @@ struct SessionAttributesView: View {
             }
         }
         .popUp("\(property.type.rawValue) was \(action.rawValue)ed", shouldShow: $showPopUp)
+        #if !os(macOS)
         .navigationBarTitle("Session Attributes", displayMode: .inline)
+        #endif
     }
 }
 

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Browser/BrowserView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Browser/BrowserView.swift
@@ -19,7 +19,10 @@ struct BrowserView: View {
             HStack {
                 TextField("Enter URL", text: $urlString, onCommit: {
                     loadURL()
-                }).keyboardType(.URL)
+                })
+                #if !os(macOS)
+                .keyboardType(.URL)
+                #endif
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 Button {
                     loadURL()

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Browser/WebView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Browser/WebView.swift
@@ -5,16 +5,16 @@
 import SwiftUI
 import WebKit
 
-struct WebView: UIViewRepresentable {
+struct WebView: ViewRepresentable {
     @Binding var urlString: String
     var webView: WKWebView = WKWebView()
 
-    func makeUIView(context: Context) -> WKWebView {
+    func makeView(context: Context) -> WKWebView {
         webView.navigationDelegate = context.coordinator
         return webView
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {
+    func updateView(_ webView: WKWebView, context: Context) {
         if let url = URL(string: urlString) {
             webView.load(URLRequest(url: url))
         }

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/MemoryWarning/MemoryPressureSimulator.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/MemoryWarning/MemoryPressureSimulator.swift
@@ -2,7 +2,12 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import Foundation
+#if os(macOS)
+import AppKit
+#else
 import UIKit
+#endif
 
 @Observable
 class MemoryPressureSimulator {
@@ -20,17 +25,20 @@ class MemoryPressureSimulator {
         timer: Timer? = nil,
         notificationCenter: NotificationCenter = .default
     ) {
+        
         self.totalMemoryBytes = totalMemoryBytes
         self.isSimulating = isSimulating
         self.dataStorage = dataStorage
         self.timer = timer
         self.notificationCenter = notificationCenter
+        #if !os(macOS)
         self.notificationCenter.addObserver(
             self,
             selector: #selector(self.handleMemoryWarning),
             name: UIApplication.didReceiveMemoryWarningNotification,
             object: nil
         )
+        #endif
     }
 
     func startSimulating() {

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/MemoryWarning/MemoryPressureSimulatorView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/MemoryWarning/MemoryPressureSimulatorView.swift
@@ -3,8 +3,9 @@
 //
 
 import SwiftUI
+import EmbraceMacros
 
-struct MemoryPressureSimulatorView: View {
+@EmbraceTrace struct MemoryPressureSimulatorView: View {
     @State var simulator: MemoryPressureSimulator = .init()
 
     var body: some View {
@@ -38,7 +39,9 @@ struct MemoryPressureSimulatorView: View {
     }
 
     private func executeMemoryWarning() {
+        #if !os(macOS)
         UIApplication.shared.perform(Selector(("_performMemoryWarning")))
+        #endif
     }
 }
 

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Network/NetworkStressTest.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Network/NetworkStressTest.swift
@@ -138,6 +138,8 @@ struct NetworkStressTest: View {
 #Preview {
     NavigationStack {
         NetworkStressTest()
+        #if !os(macOS)
             .navigationBarTitleDisplayMode(.inline)
+        #endif
     }
 }

--- a/Examples/BrandGame/BrandGame/View/Menu/UserInfo/UserInfo.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/UserInfo/UserInfo.swift
@@ -106,7 +106,9 @@ struct UserInfo: View {
                 }
             }
         }
+        #if !os(macOS)
         .textInputAutocapitalization(.never)
+        #endif
         .autocorrectionDisabled()
         .onAppear {
             user.refresh()

--- a/Examples/BrandGame/BrandGame/main.swift
+++ b/Examples/BrandGame/BrandGame/main.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
+//
+
+import SwiftUI
+
+import EmbraceIO
+
+@main
+struct BrandGameApp: App {
+
+    @State var settings: AppSettings = AppSettings()
+
+    init() {
+        do {
+            try Embrace
+                .setup(options: embraceOptions)
+                .start()
+
+            addGitInfoProperties()
+            smokeTestIfNecessary()
+        } catch let exception {
+            print("Error starting Embrace \(exception.localizedDescription)")
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.settings, settings)
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ if ProcessInfo.processInfo.environment["EMBRACE_ENABLE_TUIST_OBJC_LINK"] != nil 
 let package = Package(
     name: "EmbraceIO",
     platforms: [
-        .iOS(.v13), .tvOS(.v13), .macOS(.v13), .watchOS(.v6)
+        .iOS(.v13), .tvOS(.v13), .macOS(.v14), .watchOS(.v6)
     ],
     products: [
         .library(name: "EmbraceIO", targets: ["EmbraceIO"]),
@@ -37,7 +37,7 @@ let package = Package(
         .library(name: "EmbraceCrash", targets: ["EmbraceCrash"]),
         .library(name: "EmbraceCrashlyticsSupport", targets: ["EmbraceCrashlyticsSupport"]),
         .library(name: "EmbraceSemantics", targets: ["EmbraceSemantics"]),
-        .library(name: "EmbraceMacros", targets: ["EmbraceMacros", "EmbraceCore"])
+        .library(name: "EmbraceMacros", targets: ["EmbraceMacros"]),
     ],
     dependencies: [
         .package(

--- a/Sources/EmbraceCore/Internal/MetricKit/MetricKitHandler.swift
+++ b/Sources/EmbraceCore/Internal/MetricKit/MetricKitHandler.swift
@@ -26,13 +26,13 @@ import EmbraceCommonInternal
     let sessionLinkGracePeriod: TimeInterval = 5
 
     func install() {
-#if !os(tvOS)
+#if !os(tvOS) && !os(macOS)
         MXMetricManager.shared.add(self)
 #endif
     }
 
     func uninstall() {
-#if !os(tvOS)
+#if !os(tvOS) && !os(macOS)
         MXMetricManager.shared.remove(self)
 #endif
     }
@@ -88,7 +88,7 @@ import EmbraceCommonInternal
     }
 }
 
-#if !os(tvOS)
+#if !os(tvOS) && !os(macOS)
 extension MetricKitHandler: MXMetricManagerSubscriber {
     func didReceive(_ payloads: [MXMetricPayload]) {
         // noop for now

--- a/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
+++ b/Sources/EmbraceCoreDataInternal/BackgroundTaskWrapper.swift
@@ -130,17 +130,19 @@ fileprivate class BackgroundTaskProvider {
     }
 }
 
-#else
-
+#elseif os(watchOS)
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
+import EmbraceCommonInternal
+#endif
 // TODO: Implement WatchOS Version
 class BackgroundTaskWrapper {
     
     let name: String
-    private var taskID: UIBackgroundTaskIdentifier
+//    private var taskID: UIBackgroundTaskIdentifier
     
-    init(name: String) {
+    init?(name: String, logger: InternalLogger) {
         self.name = name
-        self.taskID = .invalid
+//        self.taskID = .invalid
     }
     
     deinit {
@@ -154,5 +156,26 @@ class BackgroundTaskWrapper {
     private func endTask() {
     }
 }
-
+#else
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
+import EmbraceCommonInternal
+#endif
+class BackgroundTaskWrapper {
+    let name: String
+    
+    init?(name: String, logger: InternalLogger) {
+        self.name = name
+    }
+    
+    deinit {
+        endTask()
+    }
+    
+    func finish() {
+        endTask()
+    }
+    
+    private func endTask() {
+    }
+}
 #endif

--- a/Sources/EmbraceObjCUtilsInternal/include/EMBLoaderClass.h
+++ b/Sources/EmbraceObjCUtilsInternal/include/EMBLoaderClass.h
@@ -3,11 +3,17 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface EMBLoaderClass : NSObject
 
+@property CADisplayLink *displayLink;
++ (EMBLoaderClass *)shared;
+#if TARGET_OS_MAC
+- (void)onAppDidFinishLaunching:(NSNotification *)notification;
+#endif
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/EmbraceObjCUtilsInternal/source/EMBDisplayLinkProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/EMBDisplayLinkProxy.m
@@ -2,9 +2,18 @@
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
 
-#import <UIKit/Uikit.h>
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+  // iOS, tvOS, watchOS
+#import <UIKit/UIKit.h>
+#else
+  // macOS
+#import <Cocoa/Cocoa.h>
+#endif
 #import "EMBDisplayLinkProxy.h"
 #import "EMBStartupTracker.h"
+#import "EMBLoaderClass.h"
 
 @implementation EMBDisplayLinkProxy {
     BOOL hasRun;
@@ -24,8 +33,8 @@
         hasRun = YES;
         [EMBStartupTracker shared].firstFrameTime = [NSDate date];
         
-        // Invalidates the CADisplayLink
-        [CADisplayLink displayLinkWithTarget:self selector:@selector(onFrameUpdate)].paused = YES;
+        [[EMBLoaderClass shared].displayLink invalidate];
+        [EMBLoaderClass shared].displayLink = nil;
     }
 }
 

--- a/Sources/EmbraceObjCUtilsInternal/source/EMBStartupTracker.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/EMBStartupTracker.m
@@ -3,6 +3,7 @@
 //
 
 #import "EMBStartupTracker.h"
+#import "EMBLoaderClass.h"
 
 @implementation EMBStartupTracker
 
@@ -26,10 +27,17 @@
 - (void)trackDidFinishLaunching {
     self.appDidFinishLaunchingEndTime = nil;
 
+#if TARGET_OS_OSX
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onAppDidFinishLaunching:)
+                                                 name:@"NSApplicationDidFinishLaunchingNotification"
+                                               object:nil];
+#else
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onAppDidFinishLaunching:)
                                                  name:@"UIApplicationDidFinishLaunchingNotification"
                                                object:nil];
+#endif
 }
 
 - (void)onAppDidFinishLaunching:(NSNotification *)notification {
@@ -41,6 +49,9 @@
     }
 
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+#if TARGET_OS_OSX
+    [[EMBLoaderClass shared] onAppDidFinishLaunching:notification];
+#endif
 }
 
 @end

--- a/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewPerfTests.swift
+++ b/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewPerfTests.swift
@@ -7,6 +7,8 @@ import EmbraceOTelInternal
 import OpenTelemetryApi
 import OpenTelemetrySdk
 import SwiftUI
+
+#if canImport(UIKit)
 import UIKit
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
@@ -78,3 +80,4 @@ final class EmbraceTraceViewPerfTests: XCTestCase {
     }
     
 }
+#endif

--- a/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewTests.swift
+++ b/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewTests.swift
@@ -7,6 +7,7 @@ import EmbraceOTelInternal
 import OpenTelemetryApi
 import OpenTelemetrySdk
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
 
 extension RunLoop {
@@ -239,3 +240,4 @@ final class EmbraceTraceViewTests: XCTestCase {
         window.isHidden = true
     }
 }
+#endif

--- a/Tests/EmbraceMacrosTests/EmbraceMacrosTests.swift
+++ b/Tests/EmbraceMacrosTests/EmbraceMacrosTests.swift
@@ -8,12 +8,13 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 import EmbraceIO
+import EmbraceMacros
 
 #if canImport(EmbraceMacroPlugin)
 import EmbraceMacroPlugin
 
 let macros: [String: Macro.Type] = [
-    "embraceTrace": EmbraceTraceMacro.self
+    "EmbraceTrace": EmbraceTraceMacro.self
 ]
 #endif
 
@@ -22,11 +23,7 @@ final class EmbraceTraceMacroTests: XCTestCase {
     func testHappyPath_injectsTracingStubs() throws {
 #if canImport(EmbraceMacroPlugin)
         // can't get this working in a reliable way yet.
-        /*
         let source = """
-        import EmbraceIO
-        import EmbraceTrace
-        
         @EmbraceTrace
         struct MyView: View {
             var body: some View {
@@ -40,22 +37,25 @@ final class EmbraceTraceMacroTests: XCTestCase {
             var body: some View {
                 Text("Hello")
             }
-        
+
             // @EmbraceTrace
             // This is your new `body`. It's the same as you declared above.
             // The macro adds the `embraceTrace` view modifier to it
             // which will instrument this View for you.
             // Inspired by https://github.com/SwiftUIX/SwiftUIX
-        
+
             /// A private duplicate of the original `body` property.
             ///
             /// This property contains the exact same implementation as the original `body`,
             /// allowing the macro to preserve the original view hierarchy while still
             /// injecting performance tracing.
             private var _embraceOriginalBody: some View {
-                Text("Hello")
+                // We have not yet found a way to call into the actual original
+                // `body`, so duplicate it here.
+
+                    Text("Hello")
             }
-        
+
             /// A container view that wraps the original body implementation.
             ///
             /// This internal container provides a clean way to reference the original
@@ -64,19 +64,19 @@ final class EmbraceTraceMacroTests: XCTestCase {
             struct _EmbraceBodyContainer: View {
                 /// Reference to the parent view instance
                 let view: MyView
-        
+                
                 /// The body of the container, which simply returns the original view implementation
                 var body: some View {
                     view._embraceOriginalBody
                 }
             }
-        
+
             /// Redefines the `Body` typealias to use the traced view wrapper.
             ///
             /// This is a key part of the macro, as it changes the view's body type
             /// to be wrapped in the `EmbraceTraceView` performance monitoring wrapper.
-            typealias Body = EmbraceTraceView<_EmbraceBodyContainer>
-        
+            typealias Body = EmbraceTraceView<_EmbraceBodyContainer, Never>
+
             /// Implementation of the `body` property for the `View` protocol.
             ///
             /// This property is marked with `@_implements` to indicate that it satisfies
@@ -98,7 +98,6 @@ final class EmbraceTraceMacroTests: XCTestCase {
             expandedSource: expected,
             macros: macros
         )
-         */
         #else
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif


### PR DESCRIPTION
Add macOS support. A number of a calls/imports were disallowed on macOS, so I've modified those. I have also enabled macOS support for the BrandGame app.

Fix CADisplayLink bug: CADisplayLink was not being correctly invalidated (on all platforms), making `onFrameUpdate` be called on every frame update, which is extremely often.

This PR also allows us to test macro expansion, which can only be run on macOS.