### PR TITLE
Adding reset upload cache API

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -142,6 +151,15 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
       }
     }
   ],

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -329,6 +329,9 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
 
                     // retry any remaining cached upload data
                     self?.upload?.retryCachedData()
+
+                    // remove old versions data
+                    self?.cleanUpOldVersionsData()
                 }
 
                 if let appId = options.appId {

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -421,6 +421,11 @@ To start the SDK you first need to configure it using an `Embrace.Options` insta
         }
     }
 
+    /// Call this if you want the Embrace SDK to clear the upload cache data on the next launch.
+    @objc public func resetUploadCache() {
+        Embrace.resetUploadCache = true
+    }
+
     /// Called every time the remote config changes
     @objc private func onConfigUpdated() {
         if let config = config {

--- a/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
@@ -151,7 +151,7 @@ public struct EmbraceFileSystem {
             return result
         }
 
-        for i in version...1 {
+        for i in stride(from: version - 1, to: 0, by: -1) {
             let components = [rootDirectoryName, "v\(i)"]
             let url = baseURL.appendingPathComponent(components.joined(separator: "/"))
             result.append(url)

--- a/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
@@ -5,6 +5,7 @@
 import Foundation
 
 public struct EmbraceFileSystem {
+    static let version = 6
     static let rootDirectoryName = "io.embrace.data"
     static let versionDirectoryName = "v6"
     static let storageDirectoryName = "storage"
@@ -133,5 +134,29 @@ public struct EmbraceFileSystem {
     /// ```
     static var criticalLogsURL: URL? {
         rootURL()?.appendingPathComponent(criticalLogsName)
+    }
+
+    /// Returns the possible subdirectories for data from old version that can be safely removed
+    /// ```
+    /// [
+    ///     io.embrace.data/<old_version1>/,
+    ///     io.embrace.data/<old_version2>/,
+    ///     ...
+    /// ]
+    /// ```
+    static func oldVersionsDirectories() -> [URL] {
+        var result: [URL] = []
+
+        guard let baseURL = systemDirectory(appGroupId: nil) else {
+            return result
+        }
+
+        for i in version...1 {
+            let components = [rootDirectoryName, "v\(i)"]
+            let url = baseURL.appendingPathComponent(components.joined(separator: "/"))
+            result.append(url)
+        }
+
+        return result
     }
 }

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -14,6 +14,7 @@ import EmbraceUploadInternal
 import OpenTelemetryApi
 
 extension Embrace {
+
     static func createStorage(options: Embrace.Options) throws -> EmbraceStorage {
 
         let partitionId = options.appId ?? EmbraceFileSystem.defaultPartitionId
@@ -66,7 +67,9 @@ extension Embrace {
             name: "EmbraceUploadStorage",
             baseURL: cacheUrl
         )
-        let cache = EmbraceUpload.CacheOptions(storageMechanism: storageMechanism)
+
+        let cache = EmbraceUpload.CacheOptions(storageMechanism: storageMechanism, resetCache: resetUploadCache)
+        resetUploadCache = false
 
         // metadata
         let metadata = EmbraceUpload.MetadataOptions(
@@ -95,6 +98,12 @@ extension Embrace {
         ManualSessionLifecycle(controller: controller)
     }
 #endif
+
+    static let resetUploadCacheKey = "emb.reset-upload-cache"
+    static var resetUploadCache: Bool {
+        get { UserDefaults.standard.bool(forKey: Embrace.resetUploadCacheKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Embrace.resetUploadCacheKey)}
+    }
 }
 
 /// Extension to handle observability of SDK startup

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -121,5 +121,20 @@ extension Embrace {
             .startSpan()
             .end()
     }
+}
 
+extension Embrace {
+    func cleanUpOldVersionsData() {
+        let urls = EmbraceFileSystem.oldVersionsDirectories()
+
+        for url in urls {
+            if FileManager.default.fileExists(atPath: url.path) {
+                do {
+                    try FileManager.default.removeItem(at: url)
+                } catch {
+                    Embrace.logger.error("Error removing data from an old version!:\n\(error)")
+                }
+            }
+        }
+    }
 }

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -26,6 +26,12 @@ class EmbraceUploadCache {
             try? FileManager.default.removeItem(at: url)
         }
 
+        // remove active cache if needed
+        if options.resetCache,
+           let cacheUrl = options.storageMechanism.fileURL {
+            try? FileManager.default.removeItem(at: cacheUrl)
+        }
+
         // create core data stack
         let coreDataOptions = CoreDataWrapper.Options(
             storageMechanism: options.storageMechanism,

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
@@ -22,16 +22,21 @@ public extension EmbraceUpload {
         /// Determines the maximum amount of days a request will be cached. Use 0 to disable.
         public let cacheDaysLimit: UInt
 
+        /// If enabled, the cache will be emptied when created
+        public let resetCache: Bool
+
         public init(
             storageMechanism: StorageMechanism,
             enableBackgroundTasks: Bool = true,
             cacheLimit: UInt = 0,
-            cacheDaysLimit: UInt = 7
+            cacheDaysLimit: UInt = 7,
+            resetCache: Bool = false,
         ) {
             self.storageMechanism = storageMechanism
             self.enableBackgroundTasks = enableBackgroundTasks
             self.cacheLimit = cacheLimit
             self.cacheDaysLimit = cacheDaysLimit
+            self.resetCache = resetCache
         }
     }
 }

--- a/Tests/EmbraceCoreTests/FileSystem/EmbraceFileSystemTests.swift
+++ b/Tests/EmbraceCoreTests/FileSystem/EmbraceFileSystemTests.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+    
+import XCTest
+@testable import EmbraceCore
+
+class EmbraceFileSystemTests: XCTestCase {
+    func test_oldVersionsURLs() throws {
+        let baseURL = try FileManager.default.url(
+            for: FileManager.SearchPathDirectory.applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+
+        let urls = EmbraceFileSystem.oldVersionsDirectories().map { $0.path }
+
+        for i in 1...EmbraceFileSystem.version - 1 {
+            let components = [EmbraceFileSystem.rootDirectoryName, "v\(i)"]
+            let url = baseURL.appendingPathComponent(components.joined(separator: "/"))
+            XCTAssert(urls.contains(url.path))
+        }
+    }
+}


### PR DESCRIPTION
This PR also adds code that removes any data from previous versions of SDK (v5) on start.