### PR TITLE
Fixed unhandled exception when writing critical logs file

### DIFF
--- a/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
@@ -121,7 +121,7 @@ class DefaultInternalLogger: BaseInternalLogger {
                         break
                     }
 
-                    file.write(data)
+                    try file.write(contentsOf: data)
                     self.exportByteCount += data.count
                 }
 


### PR DESCRIPTION
We've seen some crashes with `_NSFileHandleRaiseOperationExceptionWhileReading`.
This most likely means there's no disk space or something along those lines.

We were using a deprecated method to write the file to disk (this version could raise unhandled exceptions).
This PR changes it so it now uses the correct throwable method so we can catch the exception.
