### PR TITLE
Fixing potential race condition when a session ends

### DIFF
--- a/Sources/EmbraceCore/Payload/Builders/SessionPayloadBuilder.swift
+++ b/Sources/EmbraceCore/Payload/Builders/SessionPayloadBuilder.swift
@@ -13,28 +13,29 @@ class SessionPayloadBuilder {
     static var resourceName = "emb.session.upload_index"
 
     class func build(for session: EmbraceSession, storage: EmbraceStorage) -> PayloadEnvelope<[SpanPayload]>? {
-        guard let sessionId = session.id else {
-            return nil
-        }
 
         // increment counter or create resource if needed
         let counter = storage.incrementCountForPermanentResource(key: resourceName)
+
+        // fetch properties
+        let properties = storage.fetchCustomProperties(sessionId: session.idRaw, processId: session.processIdRaw)
 
         // build spans
         let (spans, spanSnapshots) = SpansPayloadBuilder.build(
             for: session,
             storage: storage,
-            sessionNumber: counter
+            customProperties: properties,
+            sessionNumber: counter,
         )
 
         // build resources payload
-        let resources: [EmbraceMetadata] = storage.fetchResourcesForSessionId(sessionId)
+        let resources: [EmbraceMetadata] = storage.fetchResources(sessionId: session.idRaw, processId: session.processIdRaw)
         let resourcePayload =  ResourcePayload(from: resources)
 
         // build metadata payload
         var metadata: [EmbraceMetadata] = []
-        let properties = storage.fetchCustomPropertiesForSessionId(sessionId)
-        let tags = storage.fetchPersonaTagsForSessionId(sessionId)
+
+        let tags = storage.fetchPersonaTags(sessionId: session.idRaw, processId: session.processIdRaw)
         metadata.append(contentsOf: properties)
         metadata.append(contentsOf: tags)
         let metadataPayload =  MetadataPayload(from: metadata)

--- a/Sources/EmbraceCore/Payload/Builders/SpansPayloadBuilder.swift
+++ b/Sources/EmbraceCore/Payload/Builders/SpansPayloadBuilder.swift
@@ -17,7 +17,8 @@ class SpansPayloadBuilder {
     class func build(
         for session: EmbraceSession,
         storage: EmbraceStorage,
-        sessionNumber: Int = -1
+        customProperties: [EmbraceMetadata] = [],
+        sessionNumber: Int = -1,
     ) -> (spans: [SpanPayload], spanSnapshots: [SpanPayload]) {
 
         let endTime = session.endTime ?? session.lastHeartbeatTime
@@ -34,6 +35,7 @@ class SpansPayloadBuilder {
         if let sessionSpanPayload = buildSessionSpanPayload(
             for: session,
             storage: storage,
+            customProperties: customProperties,
             sessionNumber: sessionNumber
         ) {
             spans.append(sessionSpanPayload)
@@ -68,6 +70,7 @@ class SpansPayloadBuilder {
     class func buildSessionSpanPayload(
         for session: EmbraceSession,
         storage: EmbraceStorage,
+        customProperties: [EmbraceMetadata] = [],
         sessionNumber: Int
     ) -> SpanPayload? {
         do {
@@ -77,16 +80,11 @@ class SpansPayloadBuilder {
             if let rawData = sessionSpan?.data {
                 spanData = try JSONDecoder().decode(SpanData.self, from: rawData)
             }
-
-            var properties: [EmbraceMetadata] = []
-            if let sessionId = session.id {
-                properties = storage.fetchCustomPropertiesForSessionId(sessionId)
-            }
-
+            
             return SessionSpanUtils.payload(
                 from: session,
                 spanData: spanData,
-                properties: properties,
+                properties: customProperties,
                 sessionNumber: sessionNumber
             )
 

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -202,9 +202,22 @@ class SessionController: SessionControllable {
             // end log batches
             logBatcher?.forceEndCurrentBatch(waitUntilFinished: true)
 
-            currentSessionSpan?.end(time: now)
-            SessionSpanUtils.setCleanExit(span: currentSessionSpan, cleanExit: true)
+            // end span
+            if let currentSessionSpan {
+                // Ending span for otel processors
+                // Note: our processor wont trigger an update on the stored span
+                // to prevent race conditions.
+                currentSessionSpan.end(time: now)
 
+                // Manually updating the span record synchronously.
+                storage?.endSpan(
+                    id: currentSessionSpan.context.spanId.hexString,
+                    traceId: currentSessionSpan.context.traceId.hexString,
+                    endTime: now
+                )
+            }
+
+            // update session end time and clean exit
             if let sessionId = session.id {
                 currentSession = storage?.updateSession(sessionId: sessionId, endTime: now, cleanExit: true)
             }
@@ -213,9 +226,6 @@ class SessionController: SessionControllable {
             if session.state == SessionState.foreground.rawValue {
                 Embrace.notificationCenter.post(name: .embraceForegroundSessionDidEnd, object: now)
             }
-
-            // save session record
-            save()
 
             // upload session
             uploadSession()

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -35,10 +35,6 @@ struct SessionSpanUtils {
         span?.setAttribute(key: SpanSemantics.Session.keyTerminated, value: terminated)
     }
 
-    static func setCleanExit(span: Span?, cleanExit: Bool) {
-        span?.setAttribute(key: SpanSemantics.Session.keyCleanExit, value: cleanExit)
-    }
-
     static func payload(
         from session: EmbraceSession,
         spanData: SpanData? = nil,

--- a/Sources/EmbraceOTelInternal/Trace/Tracer/Span/Processor/SingleSpanProcessor.swift
+++ b/Sources/EmbraceOTelInternal/Trace/Tracer/Span/Processor/SingleSpanProcessor.swift
@@ -74,6 +74,14 @@ public class SingleSpanProcessor: SpanProcessor {
             return
         }
 
+        // Prevent exporting our session spans on end.
+        // This process is handled by the `SessionController` to prevent
+        // race conditions when a session ends and its payload gets built.
+        if let spanType = span.getAttributes()[SpanSemantics.keyEmbraceType]?.description,
+           spanType == SpanType.session.rawValue {
+            return
+        }
+
         var data = span.toSpanData()
         if data.hasEnded && data.status == .unset {
             if let errorCode = data.errorCode {

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
@@ -119,6 +119,31 @@ extension EmbraceStorage {
         return result
     }
 
+    /// Ends the stored `SpanRecord` synchronously with the given identifiers and end time.
+    /// Should only be used for sessions!
+    /// - Parameters:
+    ///   - id: Identifier of the span
+    ///   - traceId: Identifier of the trace containing this span
+    @discardableResult
+    public func endSpan(id: String, traceId: String, endTime: Date) -> EmbraceSpan? {
+        var result: EmbraceSpan?
+
+        let request = fetchSpanRequest(id: id, traceId: traceId)
+        coreData.fetchFirstAndPerform(withRequest: request) { span in
+            guard let span else { return }
+
+            // prevent modifications on closed spans!
+            if span.endTime == nil {
+                span.endTime = endTime
+                coreData.save()
+            }
+
+            result = span.toImmutable()
+        }
+
+        return result
+    }
+
     /// Fetches the stored `SpanRecord` synchronously with the given identifiers, if any.
     /// - Parameters:
     ///   - id: Identifier of the span

--- a/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
@@ -102,24 +102,6 @@ final class SessionSpanUtilsTests: XCTestCase {
         XCTAssertEqual(spanData.attributes["emb.terminated"], .bool(true))
     }
 
-    func test_setCleanExit() throws {
-        // given a session span
-        let span = SessionSpanUtils.span(
-            id: TestConstants.sessionId,
-            startTime: TestConstants.date,
-            state: .foreground,
-            coldStart: true
-        )
-
-        // when updating the clean exit flagvay
-        SessionSpanUtils.setCleanExit(span: span, cleanExit: true)
-        span.end()
-
-        // then it is updated correctly
-        let spanData = spanProcessor.endedSpans[0]
-        XCTAssertEqual(spanData.attributes["emb.clean_exit"], .bool(true))
-    }
-
     func test_payloadFromSesssion() throws {
         // given a session record
         let endTime = Date(timeIntervalSince1970: 60)

--- a/Tests/EmbraceStorageInternalTests/MetadataRecordTests.swift
+++ b/Tests/EmbraceStorageInternalTests/MetadataRecordTests.swift
@@ -444,6 +444,81 @@ class MetadataRecordTests: XCTestCase {
         XCTAssertNil(resources.first(where: { $0.key == "test6" }))
     }
 
+    func test_fetchResources() throws {
+        // given a session in storage
+        storage.addSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date()
+        )
+
+        // given inserted records
+        storage.addMetadata(
+            key: "test1",
+            value: "test",
+            type: .resource,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test2",
+            value: "test",
+            type: .resource,
+            lifespan: .process,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test3",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test4",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test5",
+            value: "test",
+            type: .resource,
+            lifespan: .permanent
+        )
+        storage.addMetadata(
+            key: "test6",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test7",
+            value: "test",
+            type: .customProperty,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+
+        // when fetching all resources by session id and process id
+        let resources = storage.fetchResources(sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.hex)
+
+        // then the correct records are fetched
+        XCTAssertEqual(resources.count, 3)
+        XCTAssertNotNil(resources.first(where: { $0.key == "test1" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test2" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test3" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test4" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test6" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test7" }))
+    }
+
     func test_fetchResourcesForSessionId() throws {
         // given a session in storage
         storage.addSession(
@@ -507,6 +582,156 @@ class MetadataRecordTests: XCTestCase {
 
         // when fetching all resources by session id
         let resources = storage.fetchResourcesForSessionId(TestConstants.sessionId)
+
+        // then the correct records are fetched
+        XCTAssertEqual(resources.count, 3)
+        XCTAssertNotNil(resources.first(where: { $0.key == "test1" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test2" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test3" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test4" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test6" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test7" }))
+    }
+
+    func test_fetchResourcesForProcessId() throws {
+        // given a session in storage
+        storage.addSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date()
+        )
+
+        // given inserted records
+        storage.addMetadata(
+            key: "test1",
+            value: "test",
+            type: .resource,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test2",
+            value: "test",
+            type: .resource,
+            lifespan: .process,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test3",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test4",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test5",
+            value: "test",
+            type: .resource,
+            lifespan: .permanent
+        )
+        storage.addMetadata(
+            key: "test6",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test7",
+            value: "test",
+            type: .customProperty,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+
+        // when fetching all resources by process id
+        let resources = storage.fetchResourcesForProcessId(TestConstants.processId)
+
+        // then the correct records are fetched
+        XCTAssertEqual(resources.count, 2)
+        XCTAssertNotNil(resources.first(where: { $0.key == "test1" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test2" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test3" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test4" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test6" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test7" }))
+    }
+
+    func test_fetchCustomProperties() throws {
+        // given a session in storage
+        storage.addSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date()
+        )
+
+        // given inserted records
+        storage.addMetadata(
+            key: "test1",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test2",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test3",
+            value: "test",
+            type: .customProperty,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test4",
+            value: "test",
+            type: .customProperty,
+            lifespan: .session,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test5",
+            value: "test",
+            type: .customProperty,
+            lifespan: .permanent
+        )
+        storage.addMetadata(
+            key: "test6",
+            value: "test",
+            type: .resource,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test7",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+
+        // when fetching all resources by session id and process id
+        let resources = storage.fetchCustomProperties(sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.hex)
 
         // then the correct records are fetched
         XCTAssertEqual(resources.count, 3)
@@ -592,5 +817,227 @@ class MetadataRecordTests: XCTestCase {
         XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
         XCTAssertNil(resources.first(where: { $0.key == "test6" }))
         XCTAssertNil(resources.first(where: { $0.key == "test7" }))
+    }
+
+    func test_fetchPersonaTags() throws {
+        // given a session in storage
+        storage.addSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date()
+        )
+
+        // given inserted records
+        storage.addMetadata(
+            key: "test1",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test2",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test3",
+            value: "test",
+            type: .requiredResource,
+            lifespan: .permanent
+        )
+        storage.addMetadata(
+            key: "test4",
+            value: "test",
+            type: .personaTag,
+            lifespan: .session,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test5",
+            value: "test",
+            type: .personaTag,
+            lifespan: .permanent,
+        )
+        storage.addMetadata(
+            key: "test6",
+            value: "test",
+            type: .personaTag,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test7",
+            value: "test",
+            type: .personaTag,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+
+        // when fetching all persona tags by session id and process id
+        let resources = storage.fetchPersonaTags(sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.hex)
+
+        // then the correct records are fetched
+        XCTAssertEqual(resources.count, 3)
+        XCTAssertNil(resources.first(where: { $0.key == "test1" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test2" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test3" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test4" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test6" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test7" }))
+    }
+
+    func test_fetchPersonaTagsForSessionId() throws {
+        // given a session in storage
+        storage.addSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date()
+        )
+
+        // given inserted records
+        storage.addMetadata(
+            key: "test1",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test2",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test3",
+            value: "test",
+            type: .requiredResource,
+            lifespan: .permanent
+        )
+        storage.addMetadata(
+            key: "test4",
+            value: "test",
+            type: .personaTag,
+            lifespan: .session,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test5",
+            value: "test",
+            type: .personaTag,
+            lifespan: .permanent,
+        )
+        storage.addMetadata(
+            key: "test6",
+            value: "test",
+            type: .personaTag,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test7",
+            value: "test",
+            type: .personaTag,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+
+        // when fetching all persona tags by session
+        let resources = storage.fetchPersonaTagsForSessionId(TestConstants.sessionId)
+
+        // then the correct records are fetched
+        XCTAssertEqual(resources.count, 3)
+        XCTAssertNil(resources.first(where: { $0.key == "test1" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test2" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test3" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test4" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test6" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test7" }))
+    }
+
+    func test_fetchPersonaTagsForProcessId() throws {
+        // given a session in storage
+        storage.addSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date()
+        )
+
+        // given inserted records
+        storage.addMetadata(
+            key: "test1",
+            value: "test",
+            type: .customProperty,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+        storage.addMetadata(
+            key: "test2",
+            value: "test",
+            type: .resource,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test3",
+            value: "test",
+            type: .requiredResource,
+            lifespan: .permanent
+        )
+        storage.addMetadata(
+            key: "test4",
+            value: "test",
+            type: .personaTag,
+            lifespan: .session,
+            lifespanId: "test"
+        )
+        storage.addMetadata(
+            key: "test5",
+            value: "test",
+            type: .personaTag,
+            lifespan: .permanent,
+        )
+        storage.addMetadata(
+            key: "test6",
+            value: "test",
+            type: .personaTag,
+            lifespan: .session,
+            lifespanId: TestConstants.sessionId.toString
+        )
+        storage.addMetadata(
+            key: "test7",
+            value: "test",
+            type: .personaTag,
+            lifespan: .process,
+            lifespanId: TestConstants.processId.hex
+        )
+
+        // when fetching all persona tags by session
+        let resources = storage.fetchPersonaTagsForProcessId(TestConstants.processId)
+
+        // then the correct records are fetched
+        XCTAssertEqual(resources.count, 2)
+        XCTAssertNil(resources.first(where: { $0.key == "test1" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test2" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test3" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test4" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test5" }))
+        XCTAssertNil(resources.first(where: { $0.key == "test6" }))
+        XCTAssertNotNil(resources.first(where: { $0.key == "test7" }))
     }
 }

--- a/Tests/EmbraceStorageInternalTests/SpanRecordTests.swift
+++ b/Tests/EmbraceStorageInternalTests/SpanRecordTests.swift
@@ -23,7 +23,7 @@ class SpanRecordTests: XCTestCase {
         storage.upsertSpan(
             id: "id",
             name: "a name",
-            traceId: "tradeId",
+            traceId: "traceId",
             type: .performance,
             data: Data(),
             startTime: Date()
@@ -33,6 +33,51 @@ class SpanRecordTests: XCTestCase {
         let spans: [SpanRecord] = storage.fetchAll()
         XCTAssertEqual(spans.count, 1)
         XCTAssertEqual(spans[0].id, "id")
+    }
+
+    func test_endSpan() throws {
+        // given inserted span
+        storage.upsertSpan(
+            id: "id",
+            name: "a name",
+            traceId: "traceId",
+            type: .performance,
+            data: Data(),
+            startTime: Date()
+        )
+
+        // when ending the span
+        storage.endSpan(id: "id", traceId: "traceId", endTime: Date())
+
+        // then span should be updated correctly
+        let spans: [SpanRecord] = storage.fetchAll()
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].id, "id")
+        XCTAssertNotNil(spans[0].endTime)
+    }
+
+    func test_endSpan_alreadyEnded() throws {
+        // given inserted span with an end time
+        let originalDate = Date(timeIntervalSince1970: 1)
+        storage.upsertSpan(
+            id: "id",
+            name: "a name",
+            traceId: "traceId",
+            type: .performance,
+            data: Data(),
+            startTime: Date(),
+            endTime: originalDate
+        )
+
+        // when attempting to end the span again
+        let date = Date(timeIntervalSince1970: 123)
+        storage.endSpan(id: "id", traceId: "traceId", endTime: date)
+
+        // then span should not be updated
+        let spans: [SpanRecord] = storage.fetchAll()
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].id, "id")
+        XCTAssertEqual(spans[0].endTime!.timeIntervalSince1970, originalDate.timeIntervalSince1970, accuracy: 0.01)
     }
 
     func test_fetchSpan() throws {


### PR DESCRIPTION
We've seen a lot of core data crashes related to an internal auto release pool.
Even though we don't understand exactly why that happens, we noticed these crashes happen when a session ends.

At this time, there's a few things happening at the same time:
1. We end the span, which triggers our processor and exporter to re-export the span into the database. This happens asynchronously.
2. We update our session record with the end time and other flags.
3. We fetch the session data and span to build the payload.

After analyzing the crashes, we determined that points 1 and 3 are usually happening at the same time, which was unintended.

This PR changes the process in the `SessionController` and `SingleSpanProcessor` so:
1. We end the OTel span, but don't update it in the database through the exporter anymore (this was done by adding a check so we never export a session span on end).
2. We manually set the end time on the span record in our database synchronously
3. Continue with the process

Even though we don't fully understand the crashes, I think these changes have the potential to address the real issue.

Note: I've also improved the code that builds the session payload by reducing the amount of fetches needed to get the resources, custom properties and persona tags.