### PR TITLE
CoreDataWrapper PerformOperation to return value

### DIFF
--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -146,20 +146,15 @@ extension EmbraceStorage {
         lifespan: MetadataRecordLifespan,
         lifespanId: String = ""
     ) -> EmbraceMetadata? {
-
-        var result: EmbraceMetadata?
-
         coreData.performOperation { context in
             // fetch existing metadata
             let request = fetchMetadataRequest(key: key, type: type, lifespan: lifespan, lifespanId: lifespanId)
             guard let metadata = fetchMetadata(request: request, context: context) else {
-                return
+                return nil
             }
 
-            result = metadata.toImmutable()
+            return metadata.toImmutable()
         }
-
-        return result
     }
 
     /// Updates the `MetadataRecord` for the given key, type and lifespan with a new given value.
@@ -172,20 +167,15 @@ extension EmbraceStorage {
         lifespan: MetadataRecordLifespan,
         lifespanId: String
     ) -> EmbraceMetadata? {
-
-        var result: EmbraceMetadata?
-
         coreData.performOperation(save: true) { context in
             // fetch existing metadata
             let request = fetchMetadataRequest(key: key, type: type, lifespan: lifespan, lifespanId: lifespanId)
             guard let metadata = fetchMetadata(request: request, context: context) else {
-                return
+                return nil
             }
             metadata.value = value
-            result = metadata.toImmutable()
+            return metadata.toImmutable()
         }
-
-        return result
     }
 
     /// Removes all `MetadataRecords` that don't correspond to the given session and process ids.
@@ -279,32 +269,29 @@ extension EmbraceStorage {
     /// Increments the numeric value by 1 of a permanent resource for the given key.
     /// If no record exists it will create one with a value of 1.
     public func incrementCountForPermanentResource(key: String) -> Int {
-
-        var result: Int = 1
-
         coreData.performOperation(save: true) { context in
             // fetch existing metadata
             let request = fetchMetadataRequest(key: key, type: .requiredResource, lifespan: .permanent)
 
             // update it if it exists
             if let metadata = fetchMetadata(request: request, context: context) {
-                result = (Int(metadata.value) ?? 0) + 1
-                metadata.value = String(result)
-
+                let val = (Int(metadata.value) ?? 0) + 1
+                metadata.value = String(val)
+                return val
             // create it with a value of 1 if it doesn't exist
             } else {
+                let val = 1
                 _ = MetadataRecord.create(
                     context: context,
                     key: key,
-                    value: "1",
+                    value: String(val),
                     type: .requiredResource,
                     lifespan: .permanent,
                     lifespanId: ""
                 )
+                return val
             }
         }
-
-        return result
     }
 
     /// Returns immutable copies of all records with types `.requiredResource` or `.resource`

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
@@ -36,9 +36,6 @@ extension EmbraceStorage {
         cleanExit: Bool = false,
         appTerminated: Bool = false
     ) -> EmbraceSession? {
-        
-        var result: EmbraceSession? = nil
-        
         coreData.performOperation { _ in
             
             // update existing?
@@ -56,8 +53,7 @@ extension EmbraceStorage {
                 cleanExit: cleanExit,
                 appTerminated: appTerminated
             ) {
-                result = session
-                return
+                return session
             }
             
             // create new
@@ -76,13 +72,11 @@ extension EmbraceStorage {
                 appTerminated: appTerminated
             ) {
                 coreData.save()
-                result = session
-                return
+                return session
             }
             
+            return nil
         }
-        
-        return result
     }
 
     func fetchSessionRequest(id: SessionIdentifier) -> NSFetchRequest<SessionRecord> {
@@ -106,14 +100,12 @@ extension EmbraceStorage {
         cleanExit: Bool = false,
         appTerminated: Bool = false
     ) -> EmbraceSession? {
-        var result: EmbraceSession?
-
         coreData.performOperation { context in
             
             // fetch existing session
             let request = fetchSessionRequest(id: id)
             guard let session = coreData.fetch(withRequest: request).first else {
-                return
+                return nil
             }
 
             session.state = state.rawValue
@@ -132,10 +124,8 @@ extension EmbraceStorage {
             }
 
             coreData.save()
-            result = session.toImmutable()
+            return session.toImmutable()
         }
-
-        return result
     }
 
 

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -107,8 +107,6 @@ class EmbraceUploadCache {
     /// - Returns: Boolean indicating if the operation was successful
     @discardableResult func saveUploadData(id: String, type: EmbraceUploadType, data: Data) -> Bool {
 
-        var result = false
-
         coreData.performOperation { context in
 
             // update if it already exists
@@ -117,9 +115,7 @@ class EmbraceUploadCache {
                 if let uploadData = try context.fetch(request).first {
                     uploadData.data = data
                     try context.save()
-
-                    result = true
-                    return
+                    return true
                 }
             } catch {
                 logger.warning("Error upading upload data:\n\(error.localizedDescription)")
@@ -140,14 +136,13 @@ class EmbraceUploadCache {
 
                 do {
                     try context.save()
-                    result = true
+                    return true
                 } catch {
                     context.delete(record)
                 }
             }
+            return false
         }
-
-        return result
     }
 
     // Checks the amount of records stored and deletes the oldest ones if the total amount

--- a/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
+++ b/Tests/EmbraceCoreDataInternalTests/CoreDataWrapperTests.swift
@@ -10,143 +10,188 @@ import EmbraceCommonInternal
 import TestSupport
 
 class CoreDataWrapperTests: XCTestCase {
-
+    
     var wrapper: CoreDataWrapper!
-
+    
     override func setUpWithError() throws {
         let storageMechanism: StorageMechanism = .inMemory(name: testName)
         let options = CoreDataWrapper.Options(storageMechanism: storageMechanism, enableBackgroundTasks: false, entities: [MockRecord.entityDescription])
         try wrapper = CoreDataWrapper(options: options, logger: MockLogger())
     }
-
+    
     func skip_test_destroy() throws {
         // given a wrapper with data on disk
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
         let storageMechanism: StorageMechanism = .onDisk(name: testName, baseURL: url)
         let options = CoreDataWrapper.Options(storageMechanism: storageMechanism, enableBackgroundTasks: false, entities: [MockRecord.entityDescription])
         try wrapper = CoreDataWrapper(options: options, logger: MockLogger())
-
+        
         _ = MockRecord.create(context: wrapper.context, id: "test")
         wrapper.save()
-
+        
         XCTAssert(FileManager.default.fileExists(atPath: storageMechanism.fileURL!.path))
-
+        
         // when destroying the stack
         wrapper.destroy()
-
+        
         // then the db file is removed
         XCTAssertFalse(FileManager.default.fileExists(atPath: storageMechanism.fileURL!.path))
     }
-
+    
     func test_fetch() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "test")
         wrapper.save()
-
+        
         // when fetching data
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         request.predicate = NSPredicate(format: "id == %@", "test")
-
+        
         let result = wrapper.fetch(withRequest: request)
-
+        
         // then the data is correct
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first!.id, "test")
     }
-
+    
     func test_fetchAndPerform() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "test")
         wrapper.save()
-
+        
         // when fetching data and performing a block
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         request.predicate = NSPredicate(format: "id == %@", "test")
-
+        
         wrapper.fetchAndPerform(withRequest: request) { records in
-
+            
             // then the data is correct
             XCTAssertEqual(records.count, 1)
             XCTAssertEqual(records[0].id, "test")
         }
     }
-
+    
     func test_fetchFirstAndPerform() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "a")
         _ = MockRecord.create(context: wrapper.context, id: "z")
         wrapper.save()
-
+        
         // when fetching data and performing a block
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         request.sortDescriptors = [NSSortDescriptor(key: "id", ascending: true)]
-
+        
         wrapper.fetchFirstAndPerform(withRequest: request) { record in
-
+            
             // then the data is correct
             XCTAssertEqual(record!.id, "a")
         }
     }
-
+    
     func test_count() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "test1")
         _ = MockRecord.create(context: wrapper.context, id: "test2")
         _ = MockRecord.create(context: wrapper.context, id: "test3")
         wrapper.save()
-
+        
         // when fetching count
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         let result = wrapper.count(withRequest: request)
-
+        
         // then the data is correct
         XCTAssertEqual(result, 3)
     }
-
+    
     func test_deleteRecord() throws {
         // given a wrapper with data
         let record = MockRecord.create(context: wrapper.context, id: "test")
         wrapper.save()
-
+        
         // when deleting the record
         wrapper.deleteRecord(record)
-
+        
         // then the record is deleted
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         let result = wrapper.fetch(withRequest: request)
-
+        
         XCTAssertEqual(result.count, 0)
     }
-
+    
     func test_deleteRecords() throws {
         // given a wrapper with data
         let record1 = MockRecord.create(context: wrapper.context, id: "test1")
         let record2 = MockRecord.create(context: wrapper.context, id: "test2")
         wrapper.save()
-
+        
         // when deleting the record
         wrapper.deleteRecords([record1, record2])
-
+        
         // then the record is deleted
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         let result = wrapper.fetch(withRequest: request)
-
+        
         XCTAssertEqual(result.count, 0)
     }
-
+    
     func test_deleteRecords_withRequest() throws {
         // given a wrapper with data
         _ = MockRecord.create(context: wrapper.context, id: "test1")
         _ = MockRecord.create(context: wrapper.context, id: "test2")
         wrapper.save()
-
+        
         // when deleting the record
         let request = NSFetchRequest<MockRecord>(entityName: MockRecord.entityName)
         wrapper.deleteRecords(withRequest: request)
-
+        
         // then the record is deleted
         let result = wrapper.fetch(withRequest: request)
         XCTAssertEqual(result.count, 0)
+    }
+    
+    func test_performOperation_returnsNil() throws {
+        let expectedReturnValue: Int? = nil
+        let val = wrapper.performOperation { _ in
+            expectedReturnValue
+        }
+        XCTAssertEqual(val, expectedReturnValue)
+    }
+    
+    func test_performOperation_returnsOptionalValue() throws {
+        let expectedReturnValue: Int? = 12
+        let val = wrapper.performOperation { _ in
+            expectedReturnValue
+        }
+        XCTAssertEqual(val, expectedReturnValue)
+    }
+    
+    func test_performOperation_returnsValue() throws {
+        let expectedReturnValue: Int = 12
+        let val = wrapper.performOperation { _ in
+            expectedReturnValue
+        }
+        XCTAssertEqual(val, expectedReturnValue)
+    }
+    
+    /// This test is just here to show one that would not compile
+    /// due to a missing return value.
+    /// ERROR: `Missing return in closure expected to return 'Int'`
+    /**
+    func test_performOperation_returnsValueWontCompile() throws {
+        let expectedReturnValue: Int = 12
+        let val = wrapper.performOperation { _ in
+            guard true else {
+                return expectedReturnValue
+            }
+            //return expectedReturnValue
+        }
+        XCTAssertEqual(val, expectedReturnValue)
+    }
+     */
+    
+    func test_performOperation_noValue() throws {
+        // this test just ensure things compile.
+        wrapper.performOperation { _ in }
     }
 }
 


### PR DESCRIPTION
This adds the option to return a value from PerformOperation, it's also ok to just return void (or not return value). Updated performOp calls and added a few test as well to make sure everything still works well.