### PR TITLE
Ignoring AVFoundation related URLSessionTasks

### DIFF
--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
@@ -89,6 +89,16 @@ public final class URLSessionCaptureService: CaptureService, URLSessionTaskHandl
     var ignoredURLs: [String] {
         return options.ignoredURLs
     }
+
+    static private let avTaskTypes: [AnyClass] = [
+        "__NSCFBackgroundAVAggregateAssetDownloadTask",
+        "__NSCFBackgroundAVAssetDownloadTask",
+        "__NSCFBackgroundAVAggregateAssetDownloadTaskNoChildTask"
+    ].compactMap { NSClassFromString($0) }
+
+    var ignoredTaskTypes: [AnyClass] {
+        return Self.avTaskTypes
+    }
 }
 
 // swiftlint:disable line_length

--- a/Tests/EmbraceCoreTests/Capture/Network/DefaultURLSessionTaskHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DefaultURLSessionTaskHandlerTests.swift
@@ -211,6 +211,14 @@ class DefaultURLSessionTaskHandlerTests: XCTestCase {
         thenHTTPNetworkSpanShouldBeCreated()
     }
 
+    func testIgnoredTaskTypes() {
+        givenTaskHandler()
+        givenIgnoredTaskTypes()
+        givenAnURLSessionTask(urlString: "https://ThisIsAUrl/with/some/path")
+        whenInvokingCreate(withoutWaiting: true)
+        thenNoSpanShouldBeCreated()
+    }
+
     // MARK: - AddData Tests
 
     func testOnPayloadCaptureDisabled_addData_doesntDoAnything() {
@@ -277,6 +285,10 @@ extension DefaultURLSessionTaskHandlerTests {
 
     fileprivate func givenIgnoredURLs() {
         dataSource.ignoredURLs = ["embrace.io"]
+    }
+
+    fileprivate func givenIgnoredTaskTypes() {
+        dataSource.ignoredTaskTypes = [URLSessionTask.self]
     }
 
     fileprivate func givenHandlerCreatedASpan(withResponse response: URLResponse? = nil) {

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockURLSessionTaskHandlerDataSource.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockURLSessionTaskHandlerDataSource.swift
@@ -15,4 +15,6 @@ class MockURLSessionTaskHandlerDataSource: URLSessionTaskHandlerDataSource {
     var injectTracingHeader = false
     var requestsDataSource: URLSessionRequestsDataSource?
     var ignoredURLs: [String] = []
+
+    var ignoredTaskTypes: [AnyClass] = []
 }


### PR DESCRIPTION
This is to prevent crashes like `Application threw exception NSGenericException: AVAssetDownloadTask does not support originalRequest property`.

I pretty much copied the fix from the OTel sdk.

Note: Noticed some code duplication around the "finish" method in the handler, so I cleaned that up as well.
