### PR TITLE
Refactor ProcessIdentifier to be a UUID instead of UInt32

### DIFF
--- a/Sources/EmbraceCommonInternal/Identifiers/ProcessIdentifier.swift
+++ b/Sources/EmbraceCommonInternal/Identifiers/ProcessIdentifier.swift
@@ -4,56 +4,39 @@
 
 import Foundation
 
-/// The unique identifier for this process that has a higher cardinality than the system PID
 public struct ProcessIdentifier: Equatable {
-    public let value: UInt32
+    // this used to be a base 16 encoded UInt32,
+    // so handling it as a string is currently required
+    public let value: String
 
-    public init?(hex: String) {
-        guard let value = UInt32(hex, radix: 16) else {
-            return nil
-        }
+    public init(uuid value: UUID) {
+        self.value = value.uuidString
+    }
 
+    public init(string value: String) {
         self.value = value
     }
 
-    public init(value: UInt32) {
-        self.value = value
-    }
+    public var uuid: UUID? { UUID(uuidString: value) }
+}
 
-    ///  Returns the base16 encoding of this SpanId.
-    public var hex: String {
-        return String(format: "%08lx", value)
+extension ProcessIdentifier: Codable {}
+
+extension ProcessIdentifier {
+    public static var random: ProcessIdentifier {
+        ProcessIdentifier(uuid: UUID())
     }
 }
 
 extension ProcessIdentifier {
-    /// The identifier for the current process
     public static let current: ProcessIdentifier = .random
 }
 
-extension ProcessIdentifier {
-    /// Should not be used outside of testing
-    public static var random: ProcessIdentifier { ProcessIdentifier(value: .random(in: 1 ... .max)) }
+extension ProcessIdentifier: CustomStringConvertible {
+    public var description: String { value }
 }
 
-extension ProcessIdentifier: Codable {
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let hex = try container.decode(String.self)
-
-        guard let value = UInt32(hex, radix: 16) else {
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: "Encoded value is not a valid hex string"
-            )
-        }
-
-        self.init(value: value)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(hex)
-    }
+@objc(EMBCurrentProcessIdentifier)
+public class CurrentProcessIdentifier: NSObject {
+    @objc public static let value: String = ProcessIdentifier.current.value
 }

--- a/Sources/EmbraceCommonInternal/Storage/JournalMode.swift
+++ b/Sources/EmbraceCommonInternal/Storage/JournalMode.swift
@@ -1,7 +1,7 @@
 //
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
-    
+
 public enum JournalMode: String {
     case delete = "DELETE"
     case wal = "WAL"

--- a/Sources/EmbraceCommonInternal/Storage/Model/EmbraceLog.swift
+++ b/Sources/EmbraceCommonInternal/Storage/Model/EmbraceLog.swift
@@ -18,7 +18,7 @@ public protocol EmbraceLog {
 
 extension EmbraceLog {
     public var processId: ProcessIdentifier? {
-        return ProcessIdentifier(hex: processIdRaw)
+        return ProcessIdentifier(string: processIdRaw)
     }
 
     public var severity: LogSeverity {

--- a/Sources/EmbraceCommonInternal/Storage/Model/EmbraceSession.swift
+++ b/Sources/EmbraceCommonInternal/Storage/Model/EmbraceSession.swift
@@ -25,6 +25,6 @@ extension EmbraceSession {
     }
 
     public var processId: ProcessIdentifier? {
-        return ProcessIdentifier(hex: processIdRaw)
+        return ProcessIdentifier(string: processIdRaw)
     }
 }

--- a/Sources/EmbraceCommonInternal/Storage/Model/EmbraceSpan.swift
+++ b/Sources/EmbraceCommonInternal/Storage/Model/EmbraceSpan.swift
@@ -21,6 +21,6 @@ extension EmbraceSpan {
     }
 
     public var processId: ProcessIdentifier? {
-        return ProcessIdentifier(hex: processIdRaw)
+        return ProcessIdentifier(string: processIdRaw)
     }
 }

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -130,10 +130,11 @@ public struct RemoteConfigPayload: Decodable, Equatable {
         }
 
         // is wal mode enabled config
-        walModeThreshold = try rootContainer.decodeIfPresent(
-            Float.self,
-            forKey: .walModeThreshold
-        ) ?? defaultPayload.walModeThreshold
+        walModeThreshold =
+            try rootContainer.decodeIfPresent(
+                Float.self,
+                forKey: .walModeThreshold
+            ) ?? defaultPayload.walModeThreshold
 
         // ui load instrumentation
         uiLoadInstrumentationEnabled =

--- a/Sources/EmbraceCore/Capture/OneTimeServices/AppInfoCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/OneTimeServices/AppInfoCaptureService.swift
@@ -46,7 +46,7 @@ class AppInfoCaptureService: ResourceCaptureService {
             AppResourceKey.framework.rawValue: String(Embrace.client?.options.platform.frameworkId ?? -1),
 
             // process id
-            AppResourceKey.processIdentifier.rawValue: ProcessIdentifier.current.hex,
+            AppResourceKey.processIdentifier.rawValue: ProcessIdentifier.current.value,
 
             // pre-warm
             AppResourceKey.processPreWarm.rawValue: isPreWarm

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -36,7 +36,8 @@ extension Embrace {
         }
     }
 
-    static func createUpload(options: Embrace.Options, deviceId: String, configuration: EmbraceConfigurable) -> EmbraceUpload? {
+    static func createUpload(options: Embrace.Options, deviceId: String, configuration: EmbraceConfigurable)
+        -> EmbraceUpload? {
         guard let appId = options.appId else {
             return nil
         }

--- a/Sources/EmbraceCore/Public/Metadata/MetadataHandler.swift
+++ b/Sources/EmbraceCore/Public/Metadata/MetadataHandler.swift
@@ -83,6 +83,10 @@ public class MetadataHandler: NSObject {
         try addMetadata(key: key, value: value, type: .resource, lifespan: lifespan)
     }
 
+    public func addCriticalResource(key: String, value: String) {
+        storage?.addCriticalResources([key: value], processId: .current)
+    }
+
     /// Adds a property with the given key, value and lifespan.
     /// If there are 2 properties with the same key but different lifespans, the one with a shorter lifespan will be used.
     /// - Parameters:
@@ -238,7 +242,7 @@ extension MetadataHandler {
             }
             return sessionId
         } else if lifespan == .process {
-            return ProcessIdentifier.current.hex
+            return ProcessIdentifier.current.value
         } else {
             // permanent
             return MetadataRecord.lifespanIdForPermanent

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -69,7 +69,7 @@ class UnsentDataHandler {
         // send crash reports
         for report in crashReports {
 
-            var session: EmbraceSession? = nil
+            var session: EmbraceSession?
 
             // link session with crash report if possible
             if let sessionId = SessionIdentifier(string: report.sessionId) {
@@ -288,7 +288,7 @@ class UnsentDataHandler {
 
     static private func cleanMetadata(storage: EmbraceStorage, currentSessionId: String? = nil) {
         let sessionId = currentSessionId ?? Embrace.client?.currentSessionId()
-        storage.cleanMetadata(currentSessionId: sessionId, currentProcessId: ProcessIdentifier.current.hex)
+        storage.cleanMetadata(currentSessionId: sessionId, currentProcessId: ProcessIdentifier.current.value)
     }
 
     static func sendCriticalLogs(fileUrl: URL?, upload: EmbraceUpload?) {

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Log.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Log.swift
@@ -59,7 +59,7 @@ extension EmbraceStorage {
 
     public func fetchAll(excludingProcessIdentifier processIdentifier: ProcessIdentifier) -> [EmbraceLog] {
         let request = LogRecord.createFetchRequest()
-        request.predicate = NSPredicate(format: "processIdRaw != %@", processIdentifier.hex)
+        request.predicate = NSPredicate(format: "processIdRaw != %@", processIdentifier.value)
 
         // fetch
         var result: [EmbraceLog] = []

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -84,7 +84,7 @@ extension EmbraceStorage {
                 key,
                 MetadataRecordType.requiredResource.rawValue,
                 MetadataRecordLifespan.process.rawValue,
-                processId.hex
+                processId.value
             )
 
             var record: MetadataRecord?
@@ -105,7 +105,7 @@ extension EmbraceStorage {
                 record?.value = value
                 record?.typeRaw = MetadataRecordType.requiredResource.rawValue
                 record?.lifespanRaw = MetadataRecordLifespan.process.rawValue
-                record?.lifespanId = processId.hex
+                record?.lifespanId = processId.value
                 record?.collectedAt = Date()
             }
         }
@@ -375,7 +375,7 @@ extension EmbraceStorage {
             type: .and,
             subpredicates: [
                 resourcePredicate(),
-                lifespanPredicate(processId: processId.hex)
+                lifespanPredicate(processId: processId.value)
             ]
         )
 
@@ -466,7 +466,7 @@ extension EmbraceStorage {
             type: .and,
             subpredicates: [
                 personaTagPredicate(),
-                lifespanPredicate(processId: processId.hex)
+                lifespanPredicate(processId: processId.value)
             ]
         )
 

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
@@ -71,7 +71,7 @@ extension EmbraceStorage {
 
         return ImmutableSessionRecord(
             idRaw: id.toString,
-            processIdRaw: processId.hex,
+            processIdRaw: processId.value,
             state: state.rawValue,
             traceId: traceId,
             spanId: spanId,

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Span.swift
@@ -109,7 +109,7 @@ extension EmbraceStorage {
                 span.data = data
                 span.startTime = startTime
                 span.endTime = endTime
-                span.processIdRaw = processId.hex
+                span.processIdRaw = processId.value
                 span.sessionIdRaw = sessionId?.toString
                 coreData.save()
             }
@@ -168,7 +168,7 @@ extension EmbraceStorage {
         } else {
             request.predicate = NSPredicate(
                 format: "endTime != nil AND processIdRaw != %@",
-                ProcessIdentifier.current.hex)
+                ProcessIdentifier.current.value)
         }
 
         coreData.deleteRecords(withRequest: request)
@@ -182,7 +182,7 @@ extension EmbraceStorage {
         let request = SpanRecord.createFetchRequest()
         request.predicate = NSPredicate(
             format: "endTime = nil AND processIdRaw != %@",
-            ProcessIdentifier.current.hex
+            ProcessIdentifier.current.value
         )
 
         coreData.fetchAndPerform(withRequest: request) { [self] spans in

--- a/Sources/EmbraceStorageInternal/Records/LogRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/LogRecord.swift
@@ -37,7 +37,7 @@ public class LogRecord: NSManagedObject {
 
             let record = LogRecord(entity: description, insertInto: context)
             record.idRaw = id.toString
-            record.processIdRaw = processId.hex
+            record.processIdRaw = processId.value
             record.severityRaw = severity.rawValue
             record.body = body
             record.timestamp = timestamp

--- a/Sources/EmbraceStorageInternal/Records/SessionRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/SessionRecord.swift
@@ -53,7 +53,7 @@ public class SessionRecord: NSManagedObject {
 
         let record = SessionRecord(entity: description, insertInto: context)
         record.idRaw = id.toString
-        record.processIdRaw = processId.hex
+        record.processIdRaw = processId.value
         record.state = state.rawValue
         record.traceId = traceId
         record.spanId = spanId

--- a/Sources/EmbraceStorageInternal/Records/SpanRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/SpanRecord.swift
@@ -49,7 +49,7 @@ public class SpanRecord: NSManagedObject {
             record.data = data
             record.startTime = startTime
             record.endTime = endTime
-            record.processIdRaw = processId.hex
+            record.processIdRaw = processId.value
             record.sessionIdRaw = sessionId?.toString
 
             result = record.toImmutable()

--- a/Tests/EmbraceCommonInternalTests/Identifiers/ProcessIdentifierTests.swift
+++ b/Tests/EmbraceCommonInternalTests/Identifiers/ProcessIdentifierTests.swift
@@ -9,33 +9,9 @@ import XCTest
 final class ProcessIdentifierTests: XCTestCase {
 
     func test_init_value() throws {
-        let value: UInt32 = 123
-        let processIdentifier = ProcessIdentifier(value: value)
-        XCTAssertEqual(processIdentifier.value, value)
-    }
-
-    func test_init_hex_withEmptyString_returnsNil() throws {
-        XCTAssertNil(ProcessIdentifier(hex: ""))
-    }
-
-    func test_init_hex_withInvalidString_returnsNil() throws {
-        XCTAssertNil(ProcessIdentifier(hex: "Hello World"))
-    }
-
-    func test_init_hex_withShortString_returnsNonNil() throws {
-        XCTAssertEqual(ProcessIdentifier(hex: "0")?.value, 0)
-        XCTAssertEqual(ProcessIdentifier(hex: "001")?.value, 1)
-        XCTAssertEqual(ProcessIdentifier(hex: "F")?.value, 15)
-    }
-
-    func test_init_hex_withLongString_returnsNonNil() throws {
-        XCTAssertNotNil(ProcessIdentifier(hex: "0AA43212"))
-        XCTAssertNotNil(ProcessIdentifier(hex: "001423AB"))
-        XCTAssertNotNil(ProcessIdentifier(hex: "12345678"))
-
-        // returns nil if overflows UInt32.max
-        XCTAssertNotNil(ProcessIdentifier(hex: "FFFFFFFF"))
-        XCTAssertNil(ProcessIdentifier(hex: "1FFFFFFFF"))
+        let value: UUID = UUID()
+        let processIdentifier = ProcessIdentifier(uuid: value)
+        XCTAssertEqual(processIdentifier.value, value.uuidString)
     }
 
     func test_random_returnsNewValue() throws {
@@ -66,18 +42,4 @@ final class ProcessIdentifierTests: XCTestCase {
             XCTAssertTrue(error is DecodingError)
         }
     }
-
-    func test_decode_withValidString_returnsCorrectValue() throws {
-        let data = try JSONEncoder().encode("01")
-
-        let identifier = try JSONDecoder().decode(ProcessIdentifier.self, from: data)
-        XCTAssertEqual(identifier.value, 1)
-    }
-
-    func test_encode_encodesValueInHex() throws {
-        let processIdentifier = ProcessIdentifier(value: 1)
-        let data = try JSONEncoder().encode(processIdentifier)
-        XCTAssertEqual(String(data: data, encoding: .utf8), "\"00000001\"")
-    }
-
 }

--- a/Tests/EmbraceCoreTests/Capture/MetricKit/MetricKitCrashCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/MetricKit/MetricKitCrashCaptureServiceTests.swift
@@ -158,7 +158,7 @@ class MetricKitCrashCaptureServiceTests: XCTestCase {
             value: "metadata",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
 
         // given a capture service

--- a/Tests/EmbraceCoreTests/Capture/OneTimeServices/AppInfoCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/OneTimeServices/AppInfoCaptureServiceTests.swift
@@ -22,7 +22,7 @@ final class AppInfoCaptureServiceTests: XCTestCase {
         service.start()
 
         // then the app info resources are correctly stored
-        let processId = ProcessIdentifier.current.hex
+        let processId = ProcessIdentifier.current.value
 
         // bundle version
         let bundleVersion = handler.fetchMetadata(
@@ -92,7 +92,7 @@ final class AppInfoCaptureServiceTests: XCTestCase {
             lifespanId: processId
         )
         XCTAssertNotNil(processIdentifier)
-        XCTAssertEqual(processIdentifier!.value, ProcessIdentifier.current.hex)
+        XCTAssertEqual(processIdentifier!.value, ProcessIdentifier.current.value)
     }
 
     func test_notStarted() throws {

--- a/Tests/EmbraceCoreTests/Capture/OneTimeServices/DeviceInfoCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/OneTimeServices/DeviceInfoCaptureServiceTests.swift
@@ -23,7 +23,7 @@ final class DeviceInfoCaptureServiceTests: XCTestCase {
         service.start()
 
         // then the app info resources are correctly stored
-        let processId = ProcessIdentifier.current.hex
+        let processId = ProcessIdentifier.current.value
 
         let resources = handler.fetchResourcesForProcessId(.current)
         XCTAssertEqual(resources.count, 10)

--- a/Tests/EmbraceCoreTests/Capture/ResourceCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/ResourceCaptureServiceTests.swift
@@ -32,7 +32,7 @@ class ResourceCaptureServiceTests: XCTestCase {
         XCTAssertEqual(metadata.count, 3)
         XCTAssertEqual(metadata[0].typeRaw, "requiredResource")
         XCTAssertEqual(metadata[0].lifespanRaw, "process")
-        XCTAssertEqual(metadata[0].lifespanId, ProcessIdentifier.current.hex)
+        XCTAssertEqual(metadata[0].lifespanId, ProcessIdentifier.current.value)
     }
 
     func test_addCriticalResource() throws {
@@ -54,6 +54,6 @@ class ResourceCaptureServiceTests: XCTestCase {
         XCTAssertEqual(metadata.count, 3)
         XCTAssertEqual(metadata[0].typeRaw, "requiredResource")
         XCTAssertEqual(metadata[0].lifespanRaw, "process")
-        XCTAssertEqual(metadata[0].lifespanId, ProcessIdentifier.current.hex)
+        XCTAssertEqual(metadata[0].lifespanId, ProcessIdentifier.current.value)
     }
 }

--- a/Tests/EmbraceCoreTests/Payload/PayloadUtilTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/PayloadUtilTests.swift
@@ -19,7 +19,7 @@ final class PayloadUtilTests: XCTestCase {
                 value: "fake_value",
                 type: .requiredResource,
                 lifespan: .process,
-                lifespanId: ProcessIdentifier.current.hex
+                lifespanId: ProcessIdentifier.current.value
             )
         ]
         let fetcher = MockMetadataFetcher(metadata: mockResources)

--- a/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandler+PersonaTagTests.swift
+++ b/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandler+PersonaTagTests.swift
@@ -85,7 +85,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -124,7 +124,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -165,7 +165,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: "process",
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -203,7 +203,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: "process",
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.random.hex
+            lifespanId: ProcessIdentifier.random.value
         )
         storage.addMetadata(
             key: "session",
@@ -241,7 +241,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -283,7 +283,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -322,7 +322,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -362,7 +362,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",
@@ -400,7 +400,7 @@ final class MetadataHandler_PersonaTagTests: XCTestCase {
             value: PersonaTag.metadataValue,
             type: .personaTag,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "session",

--- a/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandlerTests.swift
@@ -283,7 +283,7 @@ final class MetadataHandlerTests: XCTestCase {
             value: "bar",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: otherProcessId.hex
+            lifespanId: otherProcessId.value
         )
 
         // When removed

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -569,7 +569,7 @@ class UnsentDataHandlerTests: XCTestCase {
             value: "test",
             type: .requiredResource,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "differentSessionId",
@@ -685,7 +685,7 @@ class UnsentDataHandlerTests: XCTestCase {
             value: "test",
             type: .requiredResource,
             lifespan: .process,
-            lifespanId: ProcessIdentifier.current.hex
+            lifespanId: ProcessIdentifier.current.value
         )
         storage.addMetadata(
             key: "differentProcessId",

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockMetadataFetcher.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockMetadataFetcher.swift
@@ -27,7 +27,7 @@ class MockMetadataFetcher: EmbraceStorageMetadataFetcher {
     func fetchResourcesForProcessId(_ processId: ProcessIdentifier) -> [EmbraceMetadata] {
         return metadata.filter { record in
             (record.type == .resource || record.type == .requiredResource) && record.lifespan == .process
-                && record.lifespanId == processId.hex
+                && record.lifespanId == processId.value
         }
     }
 
@@ -45,7 +45,7 @@ class MockMetadataFetcher: EmbraceStorageMetadataFetcher {
 
     func fetchPersonaTagsForProcessId(_ processId: ProcessIdentifier) -> [EmbraceMetadata] {
         return metadata.filter { record in
-            record.type == .personaTag && record.lifespan == .process && record.lifespanId == processId.hex
+            record.type == .personaTag && record.lifespan == .process && record.lifespanId == processId.value
         }
     }
 }

--- a/Tests/EmbraceStorageInternalTests/EmbraceStorageLoggingTests.swift
+++ b/Tests/EmbraceStorageInternalTests/EmbraceStorageLoggingTests.swift
@@ -38,7 +38,7 @@ class EmbraceStorageLoggingTests: XCTestCase {
     // MARK: - Fetch All Excluding Process Identifier
 
     func test_fetchAllExcludingProcessIdentifier_shouldFilterLogsProperly() throws {
-        let pid = ProcessIdentifier(value: 12345)
+        let pid = ProcessIdentifier(string: "12345")
         createInfoLog(pid: pid)
         createInfoLog()
         createInfoLog(pid: pid)
@@ -47,7 +47,7 @@ class EmbraceStorageLoggingTests: XCTestCase {
         let result = sut.fetchAll(excludingProcessIdentifier: pid)
 
         XCTAssertEqual(result.count, 2)
-        XCTAssertTrue(!result.contains(where: { $0.processIdRaw == pid.hex }))
+        XCTAssertTrue(!result.contains(where: { $0.processIdRaw == pid.value }))
     }
 
     // MARK: - RemoveAllLogs

--- a/Tests/EmbraceStorageInternalTests/MetadataRecordTests.swift
+++ b/Tests/EmbraceStorageInternalTests/MetadataRecordTests.swift
@@ -93,7 +93,7 @@ class MetadataRecordTests: XCTestCase {
                 value: "test",
                 type: .resource,
                 lifespan: .process,
-                lifespanId: i % 2 == 0 ? TestConstants.processId.hex : "test"
+                lifespanId: i % 2 == 0 ? TestConstants.processId.value : "test"
             )
         }
 
@@ -110,7 +110,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
 
         // then they should be inserted
@@ -141,7 +141,7 @@ class MetadataRecordTests: XCTestCase {
                 value: "test",
                 type: .customProperty,
                 lifespan: .process,
-                lifespanId: i % 2 == 0 ? TestConstants.processId.hex : "test"
+                lifespanId: i % 2 == 0 ? TestConstants.processId.value : "test"
             )
         }
 
@@ -158,7 +158,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
 
         // then they should be inserted
@@ -229,7 +229,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test4",
@@ -242,7 +242,7 @@ class MetadataRecordTests: XCTestCase {
         // when cleaning old metadata
         storage.cleanMetadata(
             currentSessionId: TestConstants.sessionId.toString,
-            currentProcessId: TestConstants.processId.hex
+            currentProcessId: TestConstants.processId.value
         )
 
         // then only the correct records should be removed
@@ -462,7 +462,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -496,7 +496,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test7",
@@ -508,7 +508,7 @@ class MetadataRecordTests: XCTestCase {
 
         // when fetching all resources by session id and process id
         let resources = storage.fetchResources(
-            sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.hex)
+            sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.value)
 
         // then the correct records are fetched
         XCTAssertEqual(resources.count, 3)
@@ -538,7 +538,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -572,7 +572,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test7",
@@ -613,7 +613,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -647,7 +647,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test7",
@@ -688,7 +688,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -722,7 +722,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test7",
@@ -734,7 +734,7 @@ class MetadataRecordTests: XCTestCase {
 
         // when fetching all resources by session id and process id
         let resources = storage.fetchCustomProperties(
-            sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.hex)
+            sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.value)
 
         // then the correct records are fetched
         XCTAssertEqual(resources.count, 3)
@@ -764,7 +764,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -798,7 +798,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .resource,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test7",
@@ -839,7 +839,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -879,12 +879,12 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .personaTag,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
 
         // when fetching all persona tags by session id and process id
         let resources = storage.fetchPersonaTags(
-            sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.hex)
+            sessionId: TestConstants.sessionId.toString, processId: TestConstants.processId.value)
 
         // then the correct records are fetched
         XCTAssertEqual(resources.count, 3)
@@ -914,7 +914,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -954,7 +954,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .personaTag,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
 
         // when fetching all persona tags by session
@@ -988,7 +988,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .customProperty,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
         storage.addMetadata(
             key: "test2",
@@ -1028,7 +1028,7 @@ class MetadataRecordTests: XCTestCase {
             value: "test",
             type: .personaTag,
             lifespan: .process,
-            lifespanId: TestConstants.processId.hex
+            lifespanId: TestConstants.processId.value
         )
 
         // when fetching all persona tags by session

--- a/Tests/TestSupport/Extensions/EmbraceStorage+Extension.swift
+++ b/Tests/TestSupport/Extensions/EmbraceStorage+Extension.swift
@@ -19,7 +19,9 @@ extension EmbraceStorage {
     public static func createInDiskDb(fileName: String) throws -> EmbraceStorage {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
         let storage = try EmbraceStorage(
-            options: .init(storageMechanism: .onDisk(name: fileName, baseURL: url, journalMode: .delete), enableBackgroundTasks: false),
+            options: .init(
+                storageMechanism: .onDisk(name: fileName, baseURL: url, journalMode: .delete),
+                enableBackgroundTasks: false),
             logger: MockLogger()
         )
 

--- a/Tests/TestSupport/Mocks/Model/MockLog.swift
+++ b/Tests/TestSupport/Mocks/Model/MockLog.swift
@@ -23,7 +23,7 @@ public class MockLog: EmbraceLog {
         attributes: [String: AttributeValue] = [:]
     ) {
         self.idRaw = id.toString
-        self.processIdRaw = processId.hex
+        self.processIdRaw = processId.value
         self.severityRaw = severity.rawValue
         self.body = body
         self.timestamp = timestamp

--- a/Tests/TestSupport/Mocks/Model/MockSession.swift
+++ b/Tests/TestSupport/Mocks/Model/MockSession.swift
@@ -34,7 +34,7 @@ public class MockSession: EmbraceSession {
         appTerminated: Bool = false
     ) {
         self.idRaw = id.toString
-        self.processIdRaw = processId.hex
+        self.processIdRaw = processId.value
         self.state = state.rawValue
         self.traceId = traceId
         self.spanId = spanId

--- a/Tests/TestSupport/TestConstants.swift
+++ b/Tests/TestSupport/TestConstants.swift
@@ -14,7 +14,7 @@ public struct TestConstants {
     public static let date = Date(timeIntervalSince1970: 0)
 
     public static let sessionId = SessionIdentifier(string: "18EDB6CE-90C2-456B-97CB-91E0F5941CCA")!
-    public static let processId = ProcessIdentifier(hex: "12345678")!
+    public static let processId = ProcessIdentifier(string: "12345678")
     public static let traceId = "traceId"
     public static let spanId = "spanId"
 


### PR DESCRIPTION
The process identifier was a UInt32 which will lead to collisions. This PR changes that to a UUID. The value also used to be used as a base 16 encoded hex string. This lead to the decision to keep the internals of the id as a string.  This in the end streamlines the struct and make it more efficient when getting access to to the string.