### PR TITLE
Fix handling config updates

### DIFF
--- a/Sources/EmbraceConfigInternal/EmbraceConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfig.swift
@@ -77,7 +77,7 @@ public class EmbraceConfig {
                 self?.lastUpdateTime = Date().timeIntervalSince1970
 
                 if didChange {
-                    self?.notificationCenter.post(name: .embraceConfigUpdated, object: self)
+                    self?.notificationCenter.post(name: .embraceConfigUpdated, object: self?.configurable)
                 }
             }
         }

--- a/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/NetworkPayloadCapture/NetworkPayloadCaptureHandler.swift
@@ -88,7 +88,7 @@ class DefaultNetworkPayloadCaptureHandler: NetworkPayloadCaptureHandler {
     }
 
     @objc private func onConfigUpdated(_ notification: Notification) {
-        let config = notification.object as? EmbraceConfig
+        let config = notification.object as? EmbraceConfigurable
         updateRules(config?.networkPayloadCaptureRules)
     }
 

--- a/Sources/EmbraceCore/Capture/UX/View/ViewCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/UX/View/ViewCaptureService.swift
@@ -77,10 +77,11 @@
         }
 
         private func updateBlockList(config: EmbraceConfigurable?) {
-            if let list = config?.viewControllerClassNameBlocklist {
-                let blockHostingControllers = config?.uiInstrumentationCaptureHostingControllers ?? true
+            if let config {
                 blockList.safeValue = ViewControllerBlockList(
-                    names: list, blockHostingControllers: blockHostingControllers)
+                    names: config.viewControllerClassNameBlocklist,
+                    blockHostingControllers: !config.uiInstrumentationCaptureHostingControllers
+                )
             } else {
                 blockList.safeValue = options.viewControllerBlockList
             }

--- a/Tests/EmbraceCoreTests/Capture/UX/View/ViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/View/ViewCaptureServiceTests.swift
@@ -94,9 +94,15 @@
         func test_blockList_remoteConfig() {
             // given a capture service with a block list
             let blockList = ViewControllerBlockList(
-                types: [MockViewController.self], names: ["Test"], blockHostingControllers: true)
+                types: [MockViewController.self],
+                names: ["Test"],
+                blockHostingControllers: true
+            )
             let options = ViewCaptureService.Options(
-                instrumentVisibility: true, instrumentFirstRender: true, viewControllerBlockList: blockList)
+                instrumentVisibility: true,
+                instrumentFirstRender: true,
+                viewControllerBlockList: blockList
+            )
             service = ViewCaptureService(options: options, handler: handler, lock: NSLock())
 
             // then it has the correct block list
@@ -107,7 +113,8 @@
             // when the remote config changes
             let config = EditableConfig()
             config.viewControllerClassNameBlocklist = ["MyCustomViewController", "MySpecialViewController"]
-            config.uiInstrumentationCaptureHostingControllers = false
+            // Is config says it should capture, then it capture service shouldn't block
+            config.uiInstrumentationCaptureHostingControllers = true
             Embrace.notificationCenter.post(name: .embraceConfigUpdated, object: config)
 
             // then the blocklist is updated


### PR DESCRIPTION
# Overview
Some configurations were not being updated because the notification wasn't posting the correct object.
Also, fixed the handling of the config to turn on/off capturing `UIHostingController`s.