### PR TITLE
Remove unintended `public` access modifier from method

### DIFF
--- a/Sources/EmbraceCore/Public/Metadata/MetadataHandler.swift
+++ b/Sources/EmbraceCore/Public/Metadata/MetadataHandler.swift
@@ -83,7 +83,7 @@ public class MetadataHandler: NSObject {
         try addMetadata(key: key, value: value, type: .resource, lifespan: lifespan)
     }
 
-    public func addCriticalResource(key: String, value: String) {
+    func addCriticalResource(key: String, value: String) {
         storage?.addCriticalResources([key: value], processId: .current)
     }
 


### PR DESCRIPTION
This method was never intended to be public.