### PR TITLE
Fix backtrace bug

### DIFF
--- a/Sources/EmbraceCore/Internal/Tracing/StorageSpanExporter.swift
+++ b/Sources/EmbraceCore/Internal/Tracing/StorageSpanExporter.swift
@@ -59,7 +59,7 @@ class StorageSpanExporter: SpanExporter {
                     attributes[SpanSemantics.keySessionId] = .string(sessionId)
                     spanData = spanData.settingAttributes(attributes)
                 }
-                
+
                 let data = try spanData.toJSON()
 
                 storage.upsertSpan(

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -179,19 +179,18 @@ extension Embrace: EmbraceOpenTelemetry {
         attributes: [String: String] = [:],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
-        processingQueue.async {
-            self.logController.createLog(
-                message,
-                severity: severity,
-                type: type,
-                timestamp: timestamp,
-                attachment: nil,
-                attachmentId: nil,
-                attachmentUrl: nil,
-                attributes: attributes,
-                stackTraceBehavior: stackTraceBehavior
-            )
-        }
+        self.logController.createLog(
+            message,
+            severity: severity,
+            type: type,
+            timestamp: timestamp,
+            attachment: nil,
+            attachmentId: nil,
+            attachmentUrl: nil,
+            attributes: attributes,
+            stackTraceBehavior: stackTraceBehavior,
+            queue: processingQueue
+        )
     }
 
     /// Creates and adds a log with the given data as an attachment for the current session span.
@@ -214,20 +213,18 @@ extension Embrace: EmbraceOpenTelemetry {
         attributes: [String: String] = [:],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
-        processingQueue.async {
-            self.logController.createLog(
-                message,
-                severity: severity,
-                type: type,
-                timestamp: timestamp,
-                attachment: attachment,
-                attachmentId: nil,
-                attachmentUrl: nil,
-                attributes: attributes,
-                stackTraceBehavior: stackTraceBehavior
-            )
-
-        }
+        self.logController.createLog(
+            message,
+            severity: severity,
+            type: type,
+            timestamp: timestamp,
+            attachment: attachment,
+            attachmentId: nil,
+            attachmentUrl: nil,
+            attributes: attributes,
+            stackTraceBehavior: stackTraceBehavior,
+            queue: processingQueue
+        )
     }
 
     /// Creates and adds a log with the given attachment info for the current session span.
@@ -252,19 +249,18 @@ extension Embrace: EmbraceOpenTelemetry {
         attributes: [String: String],
         stackTraceBehavior: StackTraceBehavior = .default
     ) {
-        processingQueue.async {
-            self.logController.createLog(
-                message,
-                severity: severity,
-                type: type,
-                timestamp: timestamp,
-                attachment: nil,
-                attachmentId: attachmentId,
-                attachmentUrl: attachmentUrl,
-                attributes: attributes,
-                stackTraceBehavior: stackTraceBehavior
-            )
-        }
+        self.logController.createLog(
+            message,
+            severity: severity,
+            type: type,
+            timestamp: timestamp,
+            attachment: nil,
+            attachmentId: attachmentId,
+            attachmentUrl: attachmentUrl,
+            attributes: attributes,
+            stackTraceBehavior: stackTraceBehavior,
+            queue: processingQueue
+        )
     }
 }
 

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -373,7 +373,10 @@ extension LogControllerTests {
         loggingQueue.async {
             sem.signal()
         }
-        sem.wait()
+        let timeout: DispatchTime = .now() + 1.0
+        if sem.wait(timeout: timeout) != .success {
+            XCTFail("waitForLoggingQueue timed out waiting for loggingQueue to complete.")
+        }
     }
 
     fileprivate func whenCreatingLog(

--- a/Tests/TestSupport/Mocks/DummyLogControllable.swift
+++ b/Tests/TestSupport/Mocks/DummyLogControllable.swift
@@ -24,7 +24,8 @@ public class DummyLogControllable: LogControllable {
         attachmentId: String?,
         attachmentUrl: URL?,
         attributes: [String: String],
-        stackTraceBehavior: StackTraceBehavior
+        stackTraceBehavior: StackTraceBehavior,
+        queue: DispatchQueue
     ) {}
 
     public func batchFinished(withLogs logs: [EmbraceLog]) {}


### PR DESCRIPTION
This PR ensures logs that use backtraces are taken on the same thread as the call, then moves all the processing to a background thread.