### PR TITLE
Enforce code style with pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,73 +1,122 @@
-#!/bin/bash
-export PATH=/usr/local/bin:$PATH
+#!/usr/bin/env bash
+# POSIX/Bash 3.2 compatible pre-commit hook (macOS-safe)
+set -o pipefail
 
-# SETTINGS  ########################################################################################
+# Prefer Homebrew paths (Apple Silicon + Intel)
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-# depending on your local environment and tools you're using
-# you might need to specify the path where swiftlint is installed
-SWIFT_LINT=swiftlint
+# ---- config toggles ---------------------------------------------------------
+# Set PRECOMMIT_AUTOFIX=0 to disable auto-fixing (formatters + autocorrect)
+: "${PRECOMMIT_AUTOFIX:=1}"
+# xargs parallelism for per-file operations (used by SwiftLint autocorrect)
+: "${XARGS_JOBS:=4}"
 
-# homebrew path example
-# SWIFT_LINT=/opt/homebrew/bin/swiftlint
+# ---- repo root --------------------------------------------------------------
+REPO_ROOT="$(git rev-parse --show-toplevel)" || exit 1
+cd "$REPO_ROOT" || exit 1
 
-# attempt to fix files when possible
-AUTO_CORRECT=1
+# ---- tool checks ------------------------------------------------------------
+need_tool() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "pre-commit: missing required tool: $1"
+    echo "Hint: brew install $1"
+    exit 1
+  fi
+}
 
-# stage fixed files automatically
-AUTO_STAGE=0
+SWIFT_LINT="${SWIFT_LINT:-swiftlint}"
+SWIFT_FORMAT="${SWIFT_FORMAT:-swift-format}"
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
 
-####################################################################################################
+need_tool "$SWIFT_LINT"
+need_tool "$SWIFT_FORMAT"
+need_tool "$CLANG_FORMAT"
 
-# non-staged changes
-FILE_COUNT=0
-for file_path in $(git diff --diff-filter=d --name-only | grep ".swift$"); do
-    export SCRIPT_INPUT_FILE_$FILE_COUNT=$file_path
-    FILE_COUNT=$((FILE_COUNT + 1))
-done
+# ---- temp files for NUL-safe lists ------------------------------------------
+SWIFT_LIST="$(mktemp -t precommit_swift.XXXXXX)"
+C_LIST="$(mktemp -t precommit_c.XXXXXX)"
+cleanup() { rm -f "$SWIFT_LIST" "$C_LIST"; }
+trap cleanup EXIT INT TERM HUP
 
-# staged changes
-for file_path in $(git diff --diff-filter=d --name-only --cached | grep ".swift$"); do
-    export SCRIPT_INPUT_FILE_$FILE_COUNT=$file_path
-    FILE_COUNT=$((FILE_COUNT + 1))
-done
+# ---- collect staged files (NUL-separated; pathspecs) ------------------------
+git diff --cached --name-only -z --diff-filter=d -- '*.swift' \
+  | while IFS= read -r -d '' f; do printf '%s\0' "$f" >>"$SWIFT_LIST"; done
 
-# newly added untracked files
-for file_path in $(git ls-files --others --exclude-standard | grep ".swift$"); do
-    export SCRIPT_INPUT_FILE_$FILE_COUNT=$file_path
-    FILE_COUNT=$((FILE_COUNT + 1))
-done
+git diff --cached --name-only -z --diff-filter=d -- '*.c' '*.cpp' '*.hpp' '*.h' '*.m' '*.mm' \
+  | while IFS= read -r -d '' f; do printf '%s\0' "$f" >>"$C_LIST"; done
 
+swift_empty=1; c_empty=1
+[ -s "$SWIFT_LIST" ] && swift_empty=0
+[ -s "$C_LIST" ] && c_empty=0
+[ "$swift_empty" -eq 1 ] && [ "$c_empty" -eq 1 ] && exit 0
 
-if [ "$FILE_COUNT" -eq 0 ]; then
-    echo "No files to lint!"
-    exit 0
-fi
+EXIT_CODE=0
+blocked() { printf "\n❌ Commit blocked: %s\n\n" "$1"; }
 
-export SCRIPT_INPUT_FILE_COUNT=$FILE_COUNT
-
-# autocorrect modified files
-if [ "$AUTO_CORRECT" -eq 1 ]; then
-    FIX_RESULT=$($SWIFT_LINT lint --fix --strict --use-script-input-files --force-exclude)
-
-    if [ "$FIX_RESULT" != "" ]; then
-        # stage corrected files
-        if [ "$AUTO_STAGE" -eq 1 ]; then
-            for ((i=0;i<FILE_COUNT;i++)); do
-                var=SCRIPT_INPUT_FILE_$i
-                git stage ${!var}
-            done
-        fi
+# ---- AUTOFIX: format & autocorrect, then re-add -----------------------------
+if [ "$PRECOMMIT_AUTOFIX" -eq 1 ]; then
+  # swift-format (in-place)
+  if [ "$swift_empty" -eq 0 ]; then
+    if ! xargs -0 -n 64 -- "$SWIFT_FORMAT" --in-place --configuration .swift-format <"$SWIFT_LIST"; then
+      echo "pre-commit: swift-format auto-fix encountered errors."
+      EXIT_CODE=1
     fi
+  fi
+
+  # clang-format (in-place)
+  if [ "$c_empty" -eq 0 ]; then
+    if ! xargs -0 -n 64 -- "$CLANG_FORMAT" -i <"$C_LIST"; then
+      echo "pre-commit: clang-format auto-fix encountered errors."
+      EXIT_CODE=1
+    fi
+  fi
+
+  # SwiftLint autocorrect + format (per-file)
+  if [ "$swift_empty" -eq 0 ]; then
+    # Note: per-file invocation; parallelized to speed things up.
+    if ! xargs -0 -I{} -P "$XARGS_JOBS" -- "$SWIFT_LINT" autocorrect --quiet --format --force-exclude --config .swiftlint.yml --path "{}" <"$SWIFT_LIST"; then
+      echo "pre-commit: SwiftLint autocorrect encountered errors."
+      # Don't fail commit yet — we'll lint next and decide there.
+    fi
+  fi
+
+  # Re-add updated files to the index so the commit includes the fixes
+  if [ "$swift_empty" -eq 0 ]; then
+    xargs -0 -n 128 git add -- <"$SWIFT_LIST"
+  fi
+  if [ "$c_empty" -eq 0 ]; then
+    xargs -0 -n 128 git add -- <"$C_LIST"
+  fi
 fi
 
-# lint modified files
-LINT_RESULT=$($SWIFT_LINT lint --strict --use-script-input-files --force-exclude)
-
-echo $LINT_RESULT
-
-if [ "$LINT_RESULT" == "" ]; then
-    exit 0
+# ---- LINT / VERIFY (block on any remaining issues) --------------------------
+# swift-format in "lint" mode: fail on remaining diffs
+if [ "$swift_empty" -eq 0 ]; then
+  if ! xargs -0 -n 64 -- "$SWIFT_FORMAT" lint --configuration .swift-format <"$SWIFT_LIST"; then
+    blocked "swift-format issues detected."
+    EXIT_CODE=1
+  fi
 fi
 
-exit 1
+# SwiftLint strict lint
+if [ "$swift_empty" -eq 0 ]; then
+  if ! xargs -0 -n 64 -- "$SWIFT_LINT" lint --quiet --strict --force-exclude --config .swiftlint.yml <"$SWIFT_LIST"; then
+    blocked "SwiftLint violations detected."
+    EXIT_CODE=1
+  fi
+fi
 
+# clang-format dry run (error on diff)
+if [ "$c_empty" -eq 0 ]; then
+  if ! xargs -0 -n 64 -- "$CLANG_FORMAT" --dry-run -Werror <"$C_LIST" >/dev/null 2>&1; then
+    blocked "clang-format issues detected."
+    EXIT_CODE=1
+  fi
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo 'Some issues remain. Run `make all` to auto-fix where possible.'
+  echo 'Tip: set PRECOMMIT_AUTOFIX=0 to skip auto-fixing in this hook.'
+fi
+
+exit "$EXIT_CODE"

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ CLANG_FORMAT := $(shell command -v clang-format-18 2> /dev/null || command -v cl
 SWIFT_FORMAT_CMD = swift format
 SWIFT_LINT_CMD=swiftlint
 
+HOOKS_DIR := $(shell git rev-parse --show-toplevel)/.githooks
+GIT_HOOKS_DIR := $(shell git rev-parse --git-path hooks)
+
 # Define the default target
 .PHONY: format check-format swift-format check-swift-format lint check-lint
 
@@ -64,3 +67,16 @@ check-lint:
 lint:
 	@echo "Running lint with swift-lint..."
 	$(SWIFT_LINT_CMD) lint --fix --quiet --config .swiftlint.yml --force-exclude
+
+.PHONY: install-hooks
+install-hooks:
+	@echo "Installing Git hooks..."
+	@for hook in $(HOOKS_DIR)/*; do \
+		hook_name=$$(basename $$hook); \
+		target="$(GIT_HOOKS_DIR)/$$hook_name"; \
+		rm -f $$target; \
+		ln -s $$hook $$target; \
+		chmod +x $$hook; \
+		echo " → Installed $$hook_name"; \
+	done
+	@echo "Done!"


### PR DESCRIPTION
This adds a **POSIX-compatible pre-commit hook** (Bash 3.2 / macOS safe) that enforces consistent formatting and linting for Swift and C/ObjC/C++ code.

- Runs swift-format, clang-format, and swiftlint on staged files.
- Supports auto-fixing (enabled by default, disable with PRECOMMIT_AUTOFIX=0).
- Re-adds corrected files to the index so fixes are included in the commit.
- Fails the commit if any remaining lint/formatting issues are detected.
- Parallelizes SwiftLint autocorrect for speed (XARGS_JOBS configurable).
- Provides clear commit-block messages with hints for remediation.

This ensures commits always pass style/lint checks without manual intervention.

---

Also adds a make target `make install-hooks` to install the pre-commit hook.