### PR TITLE
[EASY] Converts targets meant as test to TestTarget

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -316,7 +316,7 @@ let package = Package(
         ),
 
         // test support --------------------------------------------------------------
-        .target(
+        .testTarget(
             name: "TestSupport",
             dependencies: [
                 "EmbraceCore",
@@ -327,7 +327,7 @@ let package = Package(
             path: "Tests/TestSupport",
             exclude: ["Objc"]
         ),
-        .target(
+        .testTarget(
             name: "TestSupportObjc",
             path: "Tests/TestSupport/Objc"
         )

--- a/Package.swift
+++ b/Package.swift
@@ -327,7 +327,7 @@ let package = Package(
             path: "Tests/TestSupport",
             exclude: ["Objc"]
         ),
-        .testTarget(
+        .target(
             name: "TestSupportObjc",
             path: "Tests/TestSupport/Objc"
         )


### PR DESCRIPTION
This fixes some blips spit out by `swift build -c release`