### PR TITLE
Fix crashes related to not being able to load the persistent store

### DIFF
--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -168,7 +168,7 @@ import Foundation
         self.config = Embrace.createConfig(options: options, deviceId: deviceId)
 
         // initialize upload module
-        self.upload = Embrace.createUpload(options: options, deviceId: deviceId.hex, configuration: config.configurable)
+        self.upload = try Embrace.createUpload(options: options, deviceId: deviceId.hex, configuration: config.configurable)
 
         // send critical logs from previous session
         UnsentDataHandler.sendCriticalLogs(fileUrl: EmbraceFileSystem.criticalLogsURL, upload: upload)

--- a/Sources/EmbraceCore/ErrorManagement/EmbraceSetupError.swift
+++ b/Sources/EmbraceCore/ErrorManagement/EmbraceSetupError.swift
@@ -10,6 +10,7 @@ public enum EmbraceSetupError: Error, Equatable {
     case invalidThread(_ description: String)
     case invalidOptions(_ description: String)
     case failedStorageCreation(partitionId: String, appGroupId: String?)
+    case failedUploadModuleCreation(_ description: String)
     case unableToInitialize(_ description: String)
     case initializationNotAllowed(_ description: String)
 }
@@ -37,6 +38,8 @@ extension EmbraceSetupError: LocalizedError, CustomNSError {
             return -6
         case .initializationNotAllowed:
             return -7
+        case .failedUploadModuleCreation:
+            return -8
         }
     }
 
@@ -55,6 +58,8 @@ extension EmbraceSetupError: LocalizedError, CustomNSError {
         case .failedStorageCreation(let partitionId, let appGroupId):
             return "Failed to create Storage Directory. partitionId: '\(partitionId)' appGroupId: '\(appGroupId ?? "")'"
         case .initializationNotAllowed(let description):
+            return description
+        case .failedUploadModuleCreation(let description):
             return description
         }
     }

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -36,8 +36,11 @@ extension Embrace {
         }
     }
 
-    static func createUpload(options: Embrace.Options, deviceId: String, configuration: EmbraceConfigurable)
-        -> EmbraceUpload? {
+    static func createUpload(
+        options: Embrace.Options,
+        deviceId: String,
+        configuration: EmbraceConfigurable
+    ) throws -> EmbraceUpload? {
         guard let appId = options.appId else {
             return nil
         }
@@ -95,9 +98,8 @@ extension Embrace {
             return try EmbraceUpload(options: options, logger: Embrace.logger, queue: queue)
         } catch {
             Embrace.logger.critical("Error initializing Embrace Upload: " + error.localizedDescription)
+            throw EmbraceSetupError.failedUploadModuleCreation(error.localizedDescription)
         }
-
-        return nil
     }
     #if os(iOS)
         static func createSessionLifecycle(controller: SessionControllable) -> SessionLifecycle {


### PR DESCRIPTION
# Overview
This PR prevents crashes that could be caused whenever we're unable to load the persistent store (e.g. `container.loadPersistentStores(completionHandler:)` ). 

## Context
Currently, if an error occurs while loading the persistent store, we simply create a critical log and move on. However, later on, when an operation such as `save()` is executed, a crash will occur.

To address this, this PR introduces a fail-fast approach during SDK initialization. If the persistent store cannot be loaded, we now `throw` an error in `Embrace.setup`. The possible errors are:
- `EmbraceSetupError.failedStorageCreation`
- `EmbraceSetupError.failedUploadModuleCreation`
