### PR TITLE
[EMBR-7724][UI_TESTS_APP] Add tests to measure performance impact of exporting Spans and Logs on an app.

### DIFF
--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj/project.pbxproj
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj/project.pbxproj
@@ -9,6 +9,14 @@
 /* Begin PBXBuildFile section */
 		4D03F6E02DF2545600475383 /* UploadedSessionPayloadTestUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D03F6DF2DF2544600475383 /* UploadedSessionPayloadTestUserInfoView.swift */; };
 		4D03F6E32DF36F6F00475383 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D03F6E22DF36F5A00475383 /* UserInfo.swift */; };
+		4D1E16AE2E678CF7001295A1 /* PerformanceTestScreenDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16AD2E678CEC001295A1 /* PerformanceTestScreenDataModel.swift */; };
+		4D1E16B62E67AFE9001295A1 /* PerformanceTestSpansUIComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16B52E67AFE0001295A1 /* PerformanceTestSpansUIComponent.swift */; };
+		4D1E16B82E67AFF2001295A1 /* PerformanceTestLogsUIComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16B72E67AFED001295A1 /* PerformanceTestLogsUIComponent.swift */; };
+		4D1E16BA2E67B0D3001295A1 /* PerformanceTestSpansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16B92E67B0C6001295A1 /* PerformanceTestSpansViewModel.swift */; };
+		4D1E16BC2E67B21F001295A1 /* PerformanceTestLogsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16BB2E67B21A001295A1 /* PerformanceTestLogsViewModel.swift */; };
+		4D1E16BE2E688E3F001295A1 /* PerformanceSpanTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16BD2E688E39001295A1 /* PerformanceSpanTest.swift */; };
+		4D1E16C02E68F027001295A1 /* PerformanceLogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16BF2E68F01F001295A1 /* PerformanceLogTest.swift */; };
+		4D1E16C22E690834001295A1 /* PerformanceTestSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16C12E69082E001295A1 /* PerformanceTestSliderView.swift */; };
 		4D3334C42DFB893200C699B4 /* StartupStateSpanTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3334C32DFB892300C699B4 /* StartupStateSpanTest.swift */; };
 		4D3334C72DFCC77D00C699B4 /* StartupStateTestUIComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3334C62DFCC77400C699B4 /* StartupStateTestUIComponent.swift */; };
 		4D3334CD2DFCC8B100C699B4 /* StartupStateTestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3334CC2DFCC8AC00C699B4 /* StartupStateTestViewModel.swift */; };
@@ -152,6 +160,14 @@
 /* Begin PBXFileReference section */
 		4D03F6DF2DF2544600475383 /* UploadedSessionPayloadTestUserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadedSessionPayloadTestUserInfoView.swift; sourceTree = "<group>"; };
 		4D03F6E22DF36F5A00475383 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		4D1E16AD2E678CEC001295A1 /* PerformanceTestScreenDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestScreenDataModel.swift; sourceTree = "<group>"; };
+		4D1E16B52E67AFE0001295A1 /* PerformanceTestSpansUIComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestSpansUIComponent.swift; sourceTree = "<group>"; };
+		4D1E16B72E67AFED001295A1 /* PerformanceTestLogsUIComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestLogsUIComponent.swift; sourceTree = "<group>"; };
+		4D1E16B92E67B0C6001295A1 /* PerformanceTestSpansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestSpansViewModel.swift; sourceTree = "<group>"; };
+		4D1E16BB2E67B21A001295A1 /* PerformanceTestLogsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestLogsViewModel.swift; sourceTree = "<group>"; };
+		4D1E16BD2E688E39001295A1 /* PerformanceSpanTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceSpanTest.swift; sourceTree = "<group>"; };
+		4D1E16BF2E68F01F001295A1 /* PerformanceLogTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceLogTest.swift; sourceTree = "<group>"; };
+		4D1E16C12E69082E001295A1 /* PerformanceTestSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTestSliderView.swift; sourceTree = "<group>"; };
 		4D3334C32DFB892300C699B4 /* StartupStateSpanTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupStateSpanTest.swift; sourceTree = "<group>"; };
 		4D3334C62DFCC77400C699B4 /* StartupStateTestUIComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupStateTestUIComponent.swift; sourceTree = "<group>"; };
 		4D3334CC2DFCC8AC00C699B4 /* StartupStateTestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupStateTestViewModel.swift; sourceTree = "<group>"; };
@@ -308,6 +324,45 @@
 				4D03F6E22DF36F5A00475383 /* UserInfo.swift */,
 			);
 			path = Supporting;
+			sourceTree = "<group>";
+		};
+		4D1E16AC2E678CDE001295A1 /* Performance */ = {
+			isa = PBXGroup;
+			children = (
+				4D1E16B42E67AFC3001295A1 /* Views */,
+				4D1E16B32E67AFBA001295A1 /* ViewModels */,
+				4D1E16B12E67AF64001295A1 /* Tests */,
+				4D1E16AD2E678CEC001295A1 /* PerformanceTestScreenDataModel.swift */,
+			);
+			path = Performance;
+			sourceTree = "<group>";
+		};
+		4D1E16B12E67AF64001295A1 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				4D1E16BF2E68F01F001295A1 /* PerformanceLogTest.swift */,
+				4D1E16BD2E688E39001295A1 /* PerformanceSpanTest.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		4D1E16B32E67AFBA001295A1 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				4D1E16BB2E67B21A001295A1 /* PerformanceTestLogsViewModel.swift */,
+				4D1E16B92E67B0C6001295A1 /* PerformanceTestSpansViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		4D1E16B42E67AFC3001295A1 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				4D1E16C12E69082E001295A1 /* PerformanceTestSliderView.swift */,
+				4D1E16B72E67AFED001295A1 /* PerformanceTestLogsUIComponent.swift */,
+				4D1E16B52E67AFE0001295A1 /* PerformanceTestSpansUIComponent.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		4D3334C52DFCC72900C699B4 /* Views */ = {
@@ -806,6 +861,7 @@
 		4D6338222DE1157700557BDC /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				4D1E16AC2E678CDE001295A1 /* Performance */,
 				4D686FB52E1D747800483C72 /* SwiftUI */,
 				4D5E45FC2E0B07D900FA6E0E /* OTel Semantics */,
 				4D6337E82DE1157700557BDC /* Crashes */,
@@ -1048,6 +1104,7 @@
 				4DF440832E3C4C3700708D6A /* SwiftUITestViewEmbraceViewCapture.swift in Sources */,
 				4D63382C2DE1157700557BDC /* Font+Extensions.swift in Sources */,
 				4D63382D2DE1157700557BDC /* String+Extensions.swift in Sources */,
+				4D1E16C02E68F027001295A1 /* PerformanceLogTest.swift in Sources */,
 				4D63382E2DE1157700557BDC /* View+Extensions.swift in Sources */,
 				4D63382F2DE1157700557BDC /* DataCollector.swift in Sources */,
 				4D6338302DE1157700557BDC /* TestLogRecordExporter.swift in Sources */,
@@ -1062,6 +1119,7 @@
 				4D6338342DE1157700557BDC /* UIComponentViewModelType.swift in Sources */,
 				4D6338352DE1157700557BDC /* TestScreen.swift in Sources */,
 				4D6338362DE1157700557BDC /* TextFieldRoundedStyle.swift in Sources */,
+				4D1E16BA2E67B0D3001295A1 /* PerformanceTestSpansViewModel.swift in Sources */,
 				4D6338372DE1157700557BDC /* MockData.swift in Sources */,
 				4D4CE8022E031A6200740AC3 /* EmbraceInitForceState.swift in Sources */,
 				4D6338382DE1157700557BDC /* MockDataTask.swift in Sources */,
@@ -1084,6 +1142,7 @@
 				4D6338472DE1157700557BDC /* TestReportCardSectionsView.swift in Sources */,
 				4D6338482DE1157700557BDC /* TestReportCard.swift in Sources */,
 				4D03F6E02DF2545600475383 /* UploadedSessionPayloadTestUserInfoView.swift in Sources */,
+				4D1E16BE2E688E3F001295A1 /* PerformanceSpanTest.swift in Sources */,
 				4D6338492DE1157700557BDC /* TestMenuHeaderView.swift in Sources */,
 				4DF4408D2E3D518B00708D6A /* SwiftUITestsAttributesView.swift in Sources */,
 				4D63384A2DE1157700557BDC /* TestSideMenuListItem.swift in Sources */,
@@ -1094,10 +1153,12 @@
 				4D63384F2DE1157700557BDC /* EmbraceInitScreenViewModel.swift in Sources */,
 				4D6338502DE1157700557BDC /* EmbraceInitScreen.swift in Sources */,
 				4D6338512DE1157700557BDC /* LoggingErrorMessageTest.swift in Sources */,
+				4D1E16B62E67AFE9001295A1 /* PerformanceTestSpansUIComponent.swift in Sources */,
 				4DF440892E3D502A00708D6A /* SwiftUIEmbraceTraceViewCaptureTestUIComponent.swift in Sources */,
 				4D6338522DE1157700557BDC /* LoggingTestMessageViewModel.swift in Sources */,
 				4D4CE7FA2DFCF9A400740AC3 /* StartupProcessLaunchSpanTest.swift in Sources */,
 				4D6338532DE1157700557BDC /* LoggingTestLogMessageUIComponent.swift in Sources */,
+				4D1E16AE2E678CF7001295A1 /* PerformanceTestScreenDataModel.swift in Sources */,
 				4D6338542DE1157700557BDC /* LoggingTestsAttachmentView.swift in Sources */,
 				4D6338552DE1157700557BDC /* LoggingTestsLogAttributesView.swift in Sources */,
 				4DF440852E3D4FFB00708D6A /* SwiftUIManualCaptureTestUIComponent.swift in Sources */,
@@ -1120,11 +1181,13 @@
 				4D6338602DE1157700557BDC /* NetworkingTestViewModel.swift in Sources */,
 				4D4CE7FF2E0319F500740AC3 /* EmbraceInitScreenForceStateView.swift in Sources */,
 				4D6338612DE1157700557BDC /* NetworkingTestBodyPropertyView.swift in Sources */,
+				4D1E16C22E690834001295A1 /* PerformanceTestSliderView.swift in Sources */,
 				4D6338622DE1157700557BDC /* NetworkingTestMethodTypeView.swift in Sources */,
 				4D6338632DE1157700557BDC /* NetworkingTestUIComponent.swift in Sources */,
 				4D6338642DE1157700557BDC /* NetworkingTestsDataModel.swift in Sources */,
 				4D6338652DE1157700557BDC /* FinishedSessionTest.swift in Sources */,
 				4D6338662DE1157700557BDC /* SessionTestFinishedSessionTestViewModel.swift in Sources */,
+				4D1E16B82E67AFF2001295A1 /* PerformanceTestLogsUIComponent.swift in Sources */,
 				4D6338672DE1157700557BDC /* SessionTestFinishedSessionUIComponent.swift in Sources */,
 				4D6338682DE1157700557BDC /* SessionTestsDataModel.swift in Sources */,
 				4D6338692DE1157700557BDC /* UploadedSessionPayloadTest.swift in Sources */,
@@ -1136,6 +1199,7 @@
 				4D4CE7FC2DFCFA5C00740AC3 /* StartupAppStartupInitSpanTest.swift in Sources */,
 				4D63386E2DE1157700557BDC /* ViewControllerViewDidLoadTest.swift in Sources */,
 				4D63386F2DE1157700557BDC /* ViewControllerTestsDataModel.swift in Sources */,
+				4D1E16BC2E67B21F001295A1 /* PerformanceTestLogsViewModel.swift in Sources */,
 				4D6338702DE1157700557BDC /* ContentView.swift in Sources */,
 				4D03F6E32DF36F6F00475383 /* UserInfo.swift in Sources */,
 				4D6338712DE1157700557BDC /* EmbraceIOTestAppApp.swift in Sources */,

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Screens/TestSideMenuScreen/TestMenuOptionDataModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Screens/TestSideMenuScreen/TestMenuOptionDataModel.swift
@@ -16,6 +16,7 @@ enum TestMenuOptionDataModel: Int, CaseIterable {
     case crashes
     case session
     case uploadedPayloads
+    case performance
 
     var title: String {
         switch self {
@@ -37,6 +38,8 @@ enum TestMenuOptionDataModel: Int, CaseIterable {
             "Session Payload Tests"
         case .uploadedPayloads:
             "Uploaded Payload Tests"
+        case .performance:
+            "Performance Tests"
         }
     }
 
@@ -60,6 +63,8 @@ enum TestMenuOptionDataModel: Int, CaseIterable {
             "session"
         case .uploadedPayloads:
             "uploadedPayloads"
+        case .performance:
+            "performance"
         }
     }
 
@@ -83,6 +88,8 @@ enum TestMenuOptionDataModel: Int, CaseIterable {
             TestScreen<SessionTestsDataModel>()
         case .uploadedPayloads:
             TestScreen<UploadedPayloadsTestsDataModel>()
+        case .performance:
+            TestScreen<PerformanceTestScreenDataModel>()
         }
     }
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/PerformanceTestScreenDataModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/PerformanceTestScreenDataModel.swift
@@ -1,0 +1,39 @@
+//
+//  PerformanceTestScreenDataModel.swift
+//  EmbraceIOTestApp
+//
+//
+
+import SwiftUI
+
+enum PerformanceTestScreenDataModel: Int, TestScreenDataModel, CaseIterable {
+    case logsPerformance = 0
+    case spansPerformance
+
+    var title: String {
+        switch self {
+        case .logsPerformance:
+            "Log Performance Impact"
+        case .spansPerformance:
+            "Span Performance Impact"
+        }
+    }
+
+    var identifier: String {
+        switch self {
+        case .logsPerformance:
+            "logMessageCaptureTestButton"
+        case .spansPerformance:
+            "spanMessageCaptureTestButton"
+        }
+    }
+
+    @ViewBuilder var uiComponent: some View {
+        switch self {
+        case .logsPerformance:
+            PerformanceTestLogsUIComponent(dataModel: self)
+        case .spansPerformance:
+            PerformanceTestSpansUIComponent(dataModel: self)
+        }
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Tests/PerformanceLogTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Tests/PerformanceLogTest.swift
@@ -83,7 +83,7 @@ class PerformanceLogTest: PayloadTest {
         let nonSpansTime = String(format: "%.4f Seconds",nonLogsTotalTime / Double(numberOfLoops))
         let spansTime = String(format: "%.4f Seconds",withLogsTotalTime / Double(numberOfLoops))
         testItems.append(.init(target: "Control", expected: "", recorded: nonSpansTime, result: .unknown))
-        testItems.append(.init(target: "Exporting Spans", expected: "", recorded: spansTime, result: .unknown))
+        testItems.append(.init(target: "Exporting Logs", expected: "", recorded: spansTime, result: .unknown))
         testGroup.leave()
 
         testGroup.wait()

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Tests/PerformanceLogTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Tests/PerformanceLogTest.swift
@@ -1,0 +1,93 @@
+//
+//  PerformanceLogTest.swift
+//  EmbraceIOTestApp
+//
+//
+
+import EmbraceIO
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SwiftUI
+
+class PerformanceLogTest: PayloadTest {
+    var testRelevantPayloadNames: [String] { ["LoggingTestStart"] }
+    var runImmediatelyIfSpansFound: Bool { true }
+    var numberOfLoops: Int = 0
+    var calculationsPerLoop: Int = 0
+    var maxNumberOfLogs: Int = 0
+
+    func runTestPreparations() {
+        Embrace.client?.buildSpan(name: "LoggingTestStart").startSpan().end()
+    }
+
+    func test(spans: [SpanData]) -> TestReport {
+        var testItems = [TestReportItem]()
+
+        let nonLogsGroup = DispatchGroup()
+        let logsGroup = DispatchGroup()
+        let testGroup = DispatchGroup()
+
+        let lock = NSLock()
+
+        var nonLogsTotalTime: TimeInterval = 0
+        var withLogsTotalTime: TimeInterval = 0
+        testGroup.enter()
+
+        for _ in 0..<numberOfLoops {
+            lock.lock()
+            nonLogsGroup.enter()
+            lock.unlock()
+            DispatchQueue.global().async { [weak self] in
+                let start = Date()
+                let numberOfCalculations = UInt32(self?.calculationsPerLoop ?? 0)
+                for _ in 0..<numberOfCalculations {
+                    var hasher = Hasher()
+                    hasher.combine(UUID())
+                    let _ = hasher.finalize()
+                }
+                lock.lock()
+                nonLogsTotalTime += start.distance(to: Date())
+                nonLogsGroup.leave()
+                lock.unlock()
+            }
+        }
+
+        nonLogsGroup.wait()
+
+        for _ in 0..<numberOfLoops {
+            lock.lock()
+            logsGroup.enter()
+            lock.unlock()
+            DispatchQueue.global().async { [weak self] in
+                let start = Date()
+                var totalLogs = 0
+                let numberOfCalculations = self?.calculationsPerLoop ?? 0
+                let limitNumberOfLogsPerLoop = self?.maxNumberOfLogs ?? 0
+                for _ in 0..<numberOfCalculations {
+                    var hasher = Hasher()
+                    hasher.combine(UUID())
+                    let hash = hasher.finalize()
+                    if totalLogs <= limitNumberOfLogsPerLoop {
+                        Embrace.client?.log("hashed: \(hash)", severity: .info)
+                        totalLogs += 1
+                    }
+                }
+                lock.lock()
+                withLogsTotalTime += start.distance(to: Date())
+                logsGroup.leave()
+                lock.unlock()
+            }
+        }
+        logsGroup.wait()
+
+        let nonSpansTime = String(format: "%.4f Seconds",nonLogsTotalTime / Double(numberOfLoops))
+        let spansTime = String(format: "%.4f Seconds",withLogsTotalTime / Double(numberOfLoops))
+        testItems.append(.init(target: "Control", expected: "", recorded: nonSpansTime, result: .unknown))
+        testItems.append(.init(target: "Exporting Spans", expected: "", recorded: spansTime, result: .unknown))
+        testGroup.leave()
+
+        testGroup.wait()
+
+        return .init(items: testItems)
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Tests/PerformanceSpanTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Tests/PerformanceSpanTest.swift
@@ -1,0 +1,98 @@
+//
+//  PerformanceSpanTest.swift
+//  EmbraceIOTestApp
+//
+//
+
+import EmbraceIO
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import SwiftUI
+
+class PerformanceSpanTest: PayloadTest {
+    var testRelevantPayloadNames: [String] { ["HashingTestStart"] }
+    var runImmediatelyIfSpansFound: Bool { true }
+    var numberOfLoops: Int = 0
+    var calculationsPerLoop: Int = 0
+    var maxNumberOfSpans: Int = 0
+
+    func runTestPreparations() {
+        Embrace.client?.buildSpan(name: "HashingTestStart").startSpan().end()
+    }
+
+    func test(spans: [SpanData]) -> TestReport {
+        var testItems = [TestReportItem]()
+
+        let nonSpansGroup = DispatchGroup()
+        let spansGroup = DispatchGroup()
+        let testGroup = DispatchGroup()
+
+        let lock = NSLock()
+
+        var nonSpansTotalTime: TimeInterval = 0
+        var withSpansTotalTime: TimeInterval = 0
+        testGroup.enter()
+
+        for _ in 0..<numberOfLoops {
+            lock.lock()
+            nonSpansGroup.enter()
+            lock.unlock()
+            DispatchQueue.global().async { [weak self] in
+                let start = Date()
+                let numberOfCalculations = UInt32(self?.calculationsPerLoop ?? 0)
+                for _ in 0..<numberOfCalculations {
+                    var hasher = Hasher()
+                    hasher.combine(UUID())
+                    let _ = hasher.finalize()
+                }
+                lock.lock()
+                nonSpansTotalTime += start.distance(to: Date())
+                nonSpansGroup.leave()
+                lock.unlock()
+            }
+        }
+
+        nonSpansGroup.wait()
+
+        for _ in 0..<numberOfLoops {
+            lock.lock()
+            spansGroup.enter()
+            lock.unlock()
+            DispatchQueue.global().async { [weak self] in
+                let start = Date()
+                var totalSpans = 0
+                let numberOfCalculations = self?.calculationsPerLoop ?? 0
+                let limitNumberOfSpansPerLoop = self?.maxNumberOfSpans ?? 0
+                for _ in 0..<numberOfCalculations {
+                    var span: (any Span)?
+                    lock.lock()
+                    if totalSpans < limitNumberOfSpansPerLoop {
+                        span = Embrace.client?.buildSpan(name: "HashingSpan").startSpan()
+                        totalSpans += 1
+                    }
+                    lock.unlock()
+                    var hasher = Hasher()
+                    hasher.combine(UUID())
+                    let hash = hasher.finalize()
+                    span?.setAttribute(key: "hashed_number", value: hash)
+                    span?.end()
+                }
+                lock.lock()
+                withSpansTotalTime += start.distance(to: Date())
+                spansGroup.leave()
+                lock.unlock()
+            }
+        }
+        spansGroup.wait()
+
+        let nonSpansTime = String(format: "%.4f Seconds",nonSpansTotalTime / Double(numberOfLoops))
+        let spansTime = String(format: "%.4f Seconds",withSpansTotalTime / Double(numberOfLoops))
+        testItems.append(.init(target: "Control", expected: "", recorded: nonSpansTime, result: .unknown))
+        testItems.append(.init(target: "Exporting Spans", expected: "", recorded: spansTime, result: .unknown))
+        testGroup.leave()
+
+        testGroup.wait()
+
+        return .init(items: testItems)
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/ViewModels/PerformanceTestLogsViewModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/ViewModels/PerformanceTestLogsViewModel.swift
@@ -43,8 +43,6 @@ class PerformanceTestLogsViewModel: SpanTestUIComponentViewModel {
         testObject.numberOfLoops = Int(min(max(1, numberOfConcurrentLoops), maxConcurrentLoops))
         testObject.calculationsPerLoop = Int(min(max(1, numberOfCalculationsPerLoop), maxCalculationsPerLoop))
         testObject.maxNumberOfLogs = Int(min(max(1, limitNumberOfLogsPerLoop), maxNumberOfLogsPerLoop))
-
-        print("\(numberOfConcurrentLoops) - \(numberOfCalculationsPerLoop) - \(limitNumberOfLogsPerLoop)")
     }
     override func testButtonPressed() {
         updateTestObject()

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/ViewModels/PerformanceTestLogsViewModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/ViewModels/PerformanceTestLogsViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  PerformanceTestLogsViewModel.swift
+//  EmbraceIOTestApp
+//
+//
+
+import SwiftUI
+
+@Observable
+class PerformanceTestLogsViewModel: SpanTestUIComponentViewModel {
+    private var testObject: PerformanceLogTest
+    var numberOfConcurrentLoops: Double {
+        didSet {
+            updateTestObject()
+        }
+    }
+
+    var numberOfCalculationsPerLoop: Double {
+        didSet {
+            updateTestObject()
+        }
+    }
+
+    var limitNumberOfLogsPerLoop: Double {
+        didSet {
+            updateTestObject()
+        }
+    }
+
+    let maxConcurrentLoops: Double = 30
+    let maxCalculationsPerLoop: Double = 10000
+    let maxNumberOfLogsPerLoop: Double = 3000
+
+    init(dataModel: any TestScreenDataModel) {
+        let testObject = PerformanceLogTest()
+        self.testObject = testObject
+        numberOfConcurrentLoops = 10
+        numberOfCalculationsPerLoop = 5000
+        limitNumberOfLogsPerLoop = 100
+        super.init(dataModel: dataModel, payloadTestObject: testObject)
+    }
+    private func updateTestObject() {
+        testObject.numberOfLoops = Int(min(max(1, numberOfConcurrentLoops), maxConcurrentLoops))
+        testObject.calculationsPerLoop = Int(min(max(1, numberOfCalculationsPerLoop), maxCalculationsPerLoop))
+        testObject.maxNumberOfLogs = Int(min(max(1, limitNumberOfLogsPerLoop), maxNumberOfLogsPerLoop))
+
+        print("\(numberOfConcurrentLoops) - \(numberOfCalculationsPerLoop) - \(limitNumberOfLogsPerLoop)")
+    }
+    override func testButtonPressed() {
+        updateTestObject()
+        super.testButtonPressed()
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/ViewModels/PerformanceTestSpansViewModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/ViewModels/PerformanceTestSpansViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  PerformanceTestSpansViewModel.swift
+//  EmbraceIOTestApp
+//
+//
+
+import SwiftUI
+import EmbraceCore
+import OpenTelemetryApi
+
+@Observable
+class PerformanceTestSpansViewModel: SpanTestUIComponentViewModel {
+    private var testObject: PerformanceSpanTest
+    var numberOfConcurrentLoops: Double {
+        didSet {
+            updateTestObject()
+        }
+    }
+
+    var numberOfCalculationsPerLoop: Double {
+        didSet {
+            updateTestObject()
+        }
+    }
+
+    var limitNumberOfSpansPerLoop: Double {
+        didSet {
+            updateTestObject()
+        }
+    }
+    
+    let maxConcurrentLoops: Double = 30
+    let maxCalculationsPerLoop: Double = 10000
+    let maxNumberOfSpansPerLoop: Double = 3000
+
+    init(dataModel: any TestScreenDataModel) {
+        let testObject = PerformanceSpanTest()
+        self.testObject = testObject
+        numberOfConcurrentLoops = 10
+        numberOfCalculationsPerLoop = 5000
+        limitNumberOfSpansPerLoop = 100
+        super.init(dataModel: dataModel, payloadTestObject: testObject)
+    }
+    private func updateTestObject() {
+        testObject.numberOfLoops = Int(min(max(1, numberOfConcurrentLoops), maxConcurrentLoops))
+        testObject.calculationsPerLoop = Int(min(max(1, numberOfCalculationsPerLoop), maxCalculationsPerLoop))
+        testObject.maxNumberOfSpans = Int(min(max(1, limitNumberOfSpansPerLoop), maxNumberOfSpansPerLoop))
+    }
+    override func testButtonPressed() {
+        updateTestObject()
+        super.testButtonPressed()
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestLogsUIComponent.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestLogsUIComponent.swift
@@ -1,0 +1,44 @@
+//
+//  PerformanceTestLogsUIComponent.swift
+//  EmbraceIOTestApp
+//
+//
+
+import SwiftUI
+
+struct PerformanceTestLogsUIComponent: View {
+    @Environment(DataCollector.self) private var dataCollector
+    private var spanExporter: TestSpanExporter {
+        dataCollector.spanExporter
+    }
+    @State var dataModel: any TestScreenDataModel
+
+    @State private var viewModel: PerformanceTestLogsViewModel
+
+    init(dataModel: any TestScreenDataModel) {
+        self.dataModel = dataModel
+        self.viewModel = PerformanceTestLogsViewModel(dataModel: dataModel)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Section {
+                VStack {
+                    PerformanceTestSliderView(title: "Number of concurrent loops", maxValue: viewModel.maxConcurrentLoops, value: $viewModel.numberOfConcurrentLoops)
+                    PerformanceTestSliderView(title: "Number of calculations loops", maxValue: viewModel.maxCalculationsPerLoop, value: $viewModel.numberOfCalculationsPerLoop)
+                    PerformanceTestSliderView(title: "Limit Number of Logs per loop", maxValue: viewModel.maxNumberOfLogsPerLoop, value: $viewModel.limitNumberOfLogsPerLoop)
+                    TestScreenButtonView(viewModel: viewModel)
+                        .onAppear {
+                            viewModel.spanExporter = spanExporter
+                        }
+                }
+            } header: {
+                Text("Logs Stress Test")
+                    .textCase(nil)
+                    .font(.embraceFont(size: 18))
+                    .foregroundStyle(.embraceSilver)
+            }
+            .padding(.top, 15)
+        }
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestSliderView.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestSliderView.swift
@@ -1,0 +1,28 @@
+//
+//  PerformanceTestSliderView.swift
+//  EmbraceIOTestApp
+//
+//
+
+import SwiftUI
+
+struct PerformanceTestSliderView: View {
+    @State var title: String
+    @State var maxValue: Double
+    @Binding var value: Double
+    var body: some View {
+        VStack {
+            Text("\(title): \(UInt32(value))")
+                .textCase(nil)
+                .font(.embraceFont(size: 15))
+                .foregroundStyle(.embraceSilver)
+            Slider(value: $value, in: 1...maxValue, step: 1) { }
+            minimumValueLabel: {
+                Text("1")
+            } maximumValueLabel: {
+                Text("\(UInt32(maxValue))")
+            }
+            .tint(.embracePurple)
+        }
+    }
+}

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestSliderView.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestSliderView.swift
@@ -19,10 +19,17 @@ struct PerformanceTestSliderView: View {
             Slider(value: $value, in: 1...maxValue, step: 1) { }
             minimumValueLabel: {
                 Text("1")
+                    .textCase(nil)
+                    .font(.embraceFont(size: 12))
+                    .foregroundStyle(.embraceSilver)
             } maximumValueLabel: {
                 Text("\(UInt32(maxValue))")
+                    .textCase(nil)
+                    .font(.embraceFont(size: 12))
+                    .foregroundStyle(.embraceSilver)
             }
             .tint(.embracePurple)
         }
+        .padding([.leading, .trailing], 20)
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestSpansUIComponent.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Performance/Views/PerformanceTestSpansUIComponent.swift
@@ -1,0 +1,44 @@
+//
+//  PerformanceTestSpansView.swift
+//  EmbraceIOTestApp
+//
+//
+
+import SwiftUI
+
+struct PerformanceTestSpansUIComponent: View {
+    @Environment(DataCollector.self) private var dataCollector
+    private var spanExporter: TestSpanExporter {
+        dataCollector.spanExporter
+    }
+    @State var dataModel: any TestScreenDataModel
+
+    @State private var viewModel: PerformanceTestSpansViewModel
+
+    init(dataModel: any TestScreenDataModel) {
+        self.dataModel = dataModel
+        self.viewModel = PerformanceTestSpansViewModel(dataModel: dataModel)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Section {
+                VStack {
+                    PerformanceTestSliderView(title: "Number of concurrent loops", maxValue: viewModel.maxConcurrentLoops, value: $viewModel.numberOfConcurrentLoops)
+                    PerformanceTestSliderView(title: "Number of calculations loops", maxValue: viewModel.maxCalculationsPerLoop, value: $viewModel.numberOfCalculationsPerLoop)
+                    PerformanceTestSliderView(title: "Limit Number of Spans per loop", maxValue: viewModel.maxNumberOfSpansPerLoop, value: $viewModel.limitNumberOfSpansPerLoop)
+                    TestScreenButtonView(viewModel: viewModel)
+                        .onAppear {
+                            viewModel.spanExporter = spanExporter
+                        }
+                }
+            } header: {
+                Text("Spans Stress Test")
+                    .textCase(nil)
+                    .font(.embraceFont(size: 18))
+                    .foregroundStyle(.embraceSilver)
+            }
+            .padding(.top, 15)
+        }
+    }
+}


### PR DESCRIPTION
Adds a screen that stress tests the sdk running hashing operations while exporting spans or logs and measures how long it takes vs running the same operations without exporting anything.
