### PR TITLE
[EASY][UI_TESTS_APP] Allow "emb-thread-blockage" to be missing from session payload tests

### DIFF
--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/UploadedPayloads/Tests/UploadedSessionPayloadTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/UploadedPayloads/Tests/UploadedSessionPayloadTest.swift
@@ -106,6 +106,7 @@ class UploadedSessionPayloadTest: PayloadTest {
     private func missingSpanTestResult(_ name: String) -> TestResult {
         switch name {
         case "emb-setup",
+            "emb-thread-blockage",
             "POST /api/v2/spans":
             return .warning
         default:


### PR DESCRIPTION
There is one span exported during the payload creation for the span that triggers the test to see if it's included in the current payload and it's not, so it fails, but it's not a big deal if it's missing so this PR tags it as "allowed to be missing" and triggers a warning without failing the test.

<img width="568" height="1084" alt="Screenshot 2025-09-04 at 19 07 03" src="https://github.com/user-attachments/assets/af222ca8-990c-4655-9c99-adec4449a738" />
