### PR TITLE
[EASY] Fixed autotermination attribute not being added to Span

### DIFF
--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -33,8 +33,8 @@ extension Embrace: EmbraceOpenTelemetry {
     /// - Parameters:
     ///    - name: The name of the span.
     ///    - type: The type of the span. Will be set as the `emb.type` attribute.
-    ///    - autoTerminationCode: `SpanErrorCode` to be used to automatically close this span if the current session ends while the span is open.
     ///    - attributes: A dictionary of attributes to set on the span.
+    ///    - autoTerminationCode: `SpanErrorCode` to be used to automatically close this span if the current session ends while the span is open.
     /// - Returns: An OpenTelemetry `SpanBuilder`.
     public func buildSpan(
         name: String,
@@ -42,14 +42,14 @@ extension Embrace: EmbraceOpenTelemetry {
         attributes: [String: String] = [:],
         autoTerminationCode: SpanErrorCode? = nil
     ) -> SpanBuilder {
-        var extraAttributes = [String: String]()
-
-        if let autoTerminationCode = autoTerminationCode {
-            extraAttributes[SpanSemantics.keyAutoTerminationCode] = autoTerminationCode.rawValue
+        guard let autoTerminationCode = autoTerminationCode else {
+            return otel.buildSpan(name: name, type: type, attributes: attributes)
         }
 
-        extraAttributes.merge(attributes) { left, _ in left }
-        return otel.buildSpan(name: name, type: type, attributes: extraAttributes)
+        var attributes = attributes
+        attributes[SpanSemantics.keyAutoTerminationCode] = autoTerminationCode.rawValue
+
+        return otel.buildSpan(name: name, type: type, attributes: attributes)
     }
 
     /// Record a span after the fact

--- a/Sources/EmbraceCore/Public/Embrace+OTel.swift
+++ b/Sources/EmbraceCore/Public/Embrace+OTel.swift
@@ -42,12 +42,14 @@ extension Embrace: EmbraceOpenTelemetry {
         attributes: [String: String] = [:],
         autoTerminationCode: SpanErrorCode? = nil
     ) -> SpanBuilder {
+        var extraAttributes = [String: String]()
+
         if let autoTerminationCode = autoTerminationCode {
-            var attributes = attributes
-            attributes[SpanSemantics.keyAutoTerminationCode] = autoTerminationCode.rawValue
+            extraAttributes[SpanSemantics.keyAutoTerminationCode] = autoTerminationCode.rawValue
         }
 
-        return otel.buildSpan(name: name, type: type, attributes: attributes)
+        extraAttributes.merge(attributes) { left, _ in left }
+        return otel.buildSpan(name: name, type: type, attributes: extraAttributes)
     }
 
     /// Record a span after the fact

--- a/Tests/EmbraceCoreTests/Public/EmbraceCoreTests.swift
+++ b/Tests/EmbraceCoreTests/Public/EmbraceCoreTests.swift
@@ -265,6 +265,34 @@ final class EmbraceCoreTests: XCTestCase {
         XCTAssertFalse(spanData.hasEnded)
     }
 
+    func test_buildSpan_withAttributes_withErrorCode() throws {
+        let storage = try EmbraceStorage.createInMemoryDb()
+
+        guard let embrace = try getLocalEmbrace(storage: storage) else {
+            XCTFail("\(#function): failed to get embrace instance")
+            return
+        }
+
+        let builder = embrace.buildSpan(
+            name: "testSpan",
+            type: .performance,
+            attributes: ["foo": "bar"],
+            autoTerminationCode: .userAbandon)
+
+        if let span = builder.startSpan() as? ReadableSpan {
+            XCTAssertEqual(
+                span.toSpanData().attributes,
+                [
+                    "emb.auto_termination.code": .string("user_abandon"),
+                    "foo": .string("bar"),
+                    "emb.type": .string("perf")
+                ])
+
+        } else {
+            XCTFail("Failed to get Span from Builder")
+        }
+    }
+
     // MARK: - Crash+CrashRecorder tests
     func test_appendCrashInfo_throwsOnNotHavingCrashReporter() throws {
         let embrace = try getLocalEmbrace(crashReporter: nil)
@@ -318,8 +346,8 @@ final class EmbraceCoreTests: XCTestCase {
     }
 
     func randomString(length: Int) -> String {
-      let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-      return String((0..<length).map { _ in letters.randomElement()! })
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        return String((0..<length).map { _ in letters.randomElement()! })
     }
 }
 */


### PR DESCRIPTION
Fixed a silly mistake that would prevent Auto Termination code from being added to the span attributes.

Also added a Unit Test for it although the whole section where it belongs is currently commented out due to it being unstable on CI. Tested it locally and it passes though.
