### PR TITLE
Rename EmbraceKSCrashSupport Module EmbraceCrash

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/EmbraceIO-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/EmbraceIO-Package.xcscheme
@@ -462,9 +462,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EmbraceKSCrashSupport"
-               BuildableName = "EmbraceKSCrashSupport"
-               BlueprintName = "EmbraceKSCrashSupport"
+               BlueprintIdentifier = "EmbraceCrash"
+               BuildableName = "EmbraceCrash"
+               BlueprintName = "EmbraceCrash"
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>

--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCaptureService"
     subs.dependency "EmbraceIO/EmbraceCore"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
-    subs.dependency "EmbraceIO/EmbraceKSCrashSupport"
+    subs.dependency "EmbraceIO/EmbraceCrash"
     subs.dependency "EmbraceIO/EmbraceSemantics"
   end
 
@@ -101,8 +101,8 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
   end
 
-  spec.subspec 'EmbraceKSCrashSupport' do |subs|
-    subs.source_files = "Sources/ThirdParty/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
+  spec.subspec 'EmbraceCrash' do |subs|
+    subs.source_files = "Sources/ThirdParty/EmbraceKSCrashSupport/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceSemantics"
     subs.dependency "EmbraceIO/EmbraceKSCrash"

--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCore"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceCrash"
+    subs.dependency "EmbraceIO/EmbraceKSCrashBacktraceSupport"
     subs.dependency "EmbraceIO/EmbraceSemantics"
   end
 
@@ -58,6 +59,7 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceOTelInternal"
     subs.dependency "EmbraceIO/OpenTelemetrySdk"
+    subs.dependency "EmbraceIO/EmbraceConfiguration"
   end
 
   spec.subspec 'EmbraceConfigInternal' do |subs|
@@ -105,6 +107,12 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/ThirdParty/EmbraceKSCrashSupport/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceSemantics"
+    subs.dependency "EmbraceIO/EmbraceKSCrash"
+  end
+
+  spec.subspec 'EmbraceKSCrashBacktraceSupport' do |subs|
+    subs.source_files = "Sources/ThirdParty/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
+    subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceKSCrash"
   end
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj/project.pbxproj
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2AFD347F2E7C6C7500047D03 /* EmbraceCrash in Frameworks */ = {isa = PBXBuildFile; productRef = 2AFD347E2E7C6C7500047D03 /* EmbraceCrash */; };
 		4D03F6E02DF2545600475383 /* UploadedSessionPayloadTestUserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D03F6DF2DF2544600475383 /* UploadedSessionPayloadTestUserInfoView.swift */; };
 		4D03F6E32DF36F6F00475383 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D03F6E22DF36F5A00475383 /* UserInfo.swift */; };
 		4D1E16AE2E678CF7001295A1 /* PerformanceTestScreenDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1E16AD2E678CEC001295A1 /* PerformanceTestScreenDataModel.swift */; };
@@ -145,7 +146,6 @@
 		4DF4408B2E3D517F00708D6A /* SwiftUITestsLoadedPropertyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF4408A2E3D517400708D6A /* SwiftUITestsLoadedPropertyView.swift */; };
 		4DF4408D2E3D518B00708D6A /* SwiftUITestsAttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF4408C2E3D518400708D6A /* SwiftUITestsAttributesView.swift */; };
 		FADD99932E3961590076712E /* EmbraceKSCrashSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FADD99922E3961590076712E /* EmbraceKSCrashSupport */; };
-		FADD99952E3961600076712E /* EmbraceKSCrashSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FADD99942E3961600076712E /* EmbraceKSCrashSupport */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -306,12 +306,12 @@
 				4D54F2872E3AB89D00E38132 /* EmbraceIO in Frameworks */,
 				4D54F28B2E3AB89D00E38132 /* EmbraceSemantics in Frameworks */,
 				4D54F2892E3AB89D00E38132 /* EmbraceMacros in Frameworks */,
+				2AFD347F2E7C6C7500047D03 /* EmbraceCrash in Frameworks */,
 				4D61D1BD2DE0BA750048B5E2 /* EmbraceIO in Frameworks */,
 				4D61D1BF2DE0BA750048B5E2 /* EmbraceSemantics in Frameworks */,
 				4DF12A372D302CBE00C93E62 /* EmbraceCrashlyticsSupport in Frameworks */,
 				4D54F2852E3AB89D00E38132 /* EmbraceCrashlyticsSupport in Frameworks */,
 				4DF12A3B2D302CBE00C93E62 /* EmbraceSemantics in Frameworks */,
-				FADD99952E3961600076712E /* EmbraceKSCrashSupport in Frameworks */,
 				4D61D1B72DE0BA750048B5E2 /* EmbraceCore in Frameworks */,
 				4D61D1BB2DE0BA750048B5E2 /* EmbraceCrashlyticsSupport in Frameworks */,
 			);
@@ -1010,7 +1010,7 @@
 				4D61D1BA2DE0BA750048B5E2 /* EmbraceCrashlyticsSupport */,
 				4D61D1BC2DE0BA750048B5E2 /* EmbraceIO */,
 				4D61D1BE2DE0BA750048B5E2 /* EmbraceSemantics */,
-				FADD99942E3961600076712E /* EmbraceKSCrashSupport */,
+				2AFD347E2E7C6C7500047D03 /* EmbraceCrash */,
 			);
 			productName = EmbraceIOTestApp;
 			productReference = 4DF12A202D302C3200C93E62 /* EmbraceIOTestApp.app */;
@@ -1480,6 +1480,11 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2AFD347E2E7C6C7500047D03 /* EmbraceCrash */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4D54F27F2E3AB89D00E38132 /* XCLocalSwiftPackageReference "../../../embrace-apple-sdk" */;
+			productName = EmbraceCrash;
+		};
 		4D54F2802E3AB89D00E38132 /* EmbraceCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceCore;
@@ -1549,10 +1554,6 @@
 			productName = EmbraceSemantics;
 		};
 		FADD99922E3961590076712E /* EmbraceKSCrashSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = EmbraceKSCrashSupport;
-		};
-		FADD99942E3961600076712E /* EmbraceKSCrashSupport */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceKSCrashSupport;
 		};

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/EmbraceInit/EmbraceInitScreen.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/EmbraceInit/EmbraceInitScreen.swift
@@ -5,9 +5,9 @@
 //
 
 import EmbraceCommonInternal
+import EmbraceCrash
 import EmbraceIO
 import EmbraceKSCrashBacktraceSupport
-import EmbraceKSCrashSupport
 import EmbraceObjCUtilsInternal
 import SwiftUI
 

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .library(name: "EmbraceCore", targets: ["EmbraceCore", "EmbraceConfiguration"]),
         .library(name: "EmbraceSemantics", targets: ["EmbraceSemantics"]),
         .library(name: "EmbraceMacros", targets: ["EmbraceMacros", "EmbraceCore"]),
-        .library(name: "EmbraceKSCrashSupport", targets: ["EmbraceKSCrashSupport"]),
+        .library(name: "EmbraceCrash", targets: ["EmbraceCrash"]),
         .library(name: "EmbraceKSCrashBacktraceSupport", targets: ["EmbraceKSCrashBacktraceSupport"]),
         .library(name: "EmbraceCrashlyticsSupport", targets: ["EmbraceCrashlyticsSupport"])
     ],
@@ -64,7 +64,7 @@ let package = Package(
                 "EmbraceCore",
                 "EmbraceCommonInternal",
                 "EmbraceSemantics",
-                "EmbraceKSCrashSupport",
+                "EmbraceCrash",
                 "EmbraceKSCrashBacktraceSupport"
             ],
             linkerSettings: linkerSettings
@@ -280,7 +280,7 @@ let package = Package(
 
         // kscrash support  -------------------------------------------------------
         .target(
-            name: "EmbraceKSCrashSupport",
+            name: "EmbraceCrash",
             dependencies: [
                 "EmbraceCommonInternal",
                 .product(name: "Recording", package: "KSCrash")
@@ -298,7 +298,7 @@ let package = Package(
         ),
         .testTarget(
             name: "EmbraceCrashTests",
-            dependencies: ["EmbraceCore", "EmbraceKSCrashSupport", "EmbraceCommonInternal", "TestSupport"],
+            dependencies: ["EmbraceCore", "EmbraceCrash", "EmbraceCommonInternal", "TestSupport"],
             resources: [
                 .copy("Mocks/")
             ]

--- a/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
+++ b/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
@@ -191,5 +191,5 @@ public typealias FrameAddress = UInt
     ///                      consider normalizing (e.g., `addr - 1`) before calling.
     /// - Returns: A `SymbolicatedFrame` on success, or `nil` if the address could not be resolved
     ///            (e.g., missing symbols/dSYMs, unknown image).
-    @objc func symbolicate(address: FrameAddress) -> SymbolicatedFrame?
+    @objc func resolve(address: FrameAddress) -> SymbolicatedFrame?
 }

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -88,7 +88,7 @@ public class RemoteConfig {
 }
 
 extension RemoteConfig: EmbraceConfigurable {
-    public var hangLimits: EmbraceConfiguration.HangLimits {
+    public var hangLimits: HangLimits {
         HangLimits(
             hangPerSession: payload.hangLimitsHangPerSession,
             samplesPerHang: payload.hangLimitsSamplesPerHang

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
@@ -160,7 +160,7 @@ extension EmbraceBacktraceFrame {
             return cached
         }
 
-        guard let result = Embrace.client?.options.symbolicator?.symbolicate(address: UInt(address)) else {
+        guard let result = Embrace.client?.options.symbolicator?.resolve(address: UInt(address)) else {
             return self
         }
 

--- a/Sources/EmbraceIO/Options/Options+CaptureService.swift
+++ b/Sources/EmbraceIO/Options/Options+CaptureService.swift
@@ -8,7 +8,7 @@ import Foundation
     import EmbraceCaptureService
     import EmbraceCore
     import EmbraceCommonInternal
-    import EmbraceKSCrashSupport
+    import EmbraceCrash
     import EmbraceOTelInternal
     import EmbraceKSCrashBacktraceSupport
     import KSCrashDemangleFilter

--- a/Sources/ThirdParty/EmbraceKSCrashBacktraceSupport/EmbraceKSCrashBacktraceSupport.swift
+++ b/Sources/ThirdParty/EmbraceKSCrashBacktraceSupport/EmbraceKSCrashBacktraceSupport.swift
@@ -33,10 +33,10 @@ public class KSCrashBacktracing: Backtracer, Symbolicator {
         return addresses
     }
 
-    public func symbolicate(address: UInt) -> SymbolicatedFrame? {
+    public func resolve(address: UInt) -> SymbolicatedFrame? {
 
         var result = SymbolInformation()
-        guard KSCrashRecordingCore.symbolicate(address: UInt(address), result: &result) else {
+        guard symbolicate(address: UInt(address), result: &result) else {
             return nil
         }
 

--- a/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
+++ b/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
@@ -11,7 +11,7 @@
     import XCTest
 
     @testable import EmbraceCore
-    @testable import EmbraceKSCrashSupport
+    @testable import EmbraceCrash
 
     class EmbraceCrashReporterTests: XCTestCase {
 

--- a/Tests/EmbraceIOTests/PerformanceTests.swift
+++ b/Tests/EmbraceIOTests/PerformanceTests.swift
@@ -3,7 +3,7 @@
 //
 
 import EmbraceCore
-import EmbraceKSCrashSupport
+import EmbraceCrash
 import XCTest
 
 @testable import EmbraceCore

--- a/bin/templates/EmbraceIO.podspec.tpl
+++ b/bin/templates/EmbraceIO.podspec.tpl
@@ -26,7 +26,7 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCaptureService"
     subs.dependency "EmbraceIO/EmbraceCore"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
-    subs.dependency "EmbraceIO/EmbraceKSCrashSupport"
+    subs.dependency "EmbraceIO/EmbraceCrash"
     subs.dependency "EmbraceIO/EmbraceSemantics"
   end
 
@@ -101,8 +101,8 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
   end
 
-  spec.subspec 'EmbraceKSCrashSupport' do |subs|
-    subs.source_files = "Sources/ThirdParty/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
+  spec.subspec 'EmbraceCrash' do |subs|
+    subs.source_files = "Sources/ThirdParty/EmbraceKSCrashSupport/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceSemantics"
     subs.dependency "EmbraceIO/EmbraceKSCrash"

--- a/bin/templates/EmbraceIO.podspec.tpl
+++ b/bin/templates/EmbraceIO.podspec.tpl
@@ -27,6 +27,7 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCore"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceCrash"
+    subs.dependency "EmbraceIO/EmbraceKSCrashBacktraceSupport"
     subs.dependency "EmbraceIO/EmbraceSemantics"
   end
 
@@ -58,6 +59,7 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceOTelInternal"
     subs.dependency "EmbraceIO/OpenTelemetrySdk"
+    subs.dependency "EmbraceIO/EmbraceConfiguration"
   end
 
   spec.subspec 'EmbraceConfigInternal' do |subs|
@@ -105,6 +107,12 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/ThirdParty/EmbraceKSCrashSupport/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceSemantics"
+    subs.dependency "EmbraceIO/EmbraceKSCrash"
+  end
+
+  spec.subspec 'EmbraceKSCrashBacktraceSupport' do |subs|
+    subs.source_files = "Sources/ThirdParty/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
+    subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceKSCrash"
   end
 


### PR DESCRIPTION
This was a breaking change which I'm simply moving the naming back to the original.