### PR TITLE
Added fix to allow pushing other variants of the OS to the backend

### DIFF
--- a/Sources/EmbraceCore/Payload/ResourcePayload.swift
+++ b/Sources/EmbraceCore/Payload/ResourcePayload.swift
@@ -30,6 +30,7 @@ struct ResourcePayload: Codable {
     var environmentDetail: String?
     var appFramework: Int?
     var launchCount: Int?
+    var sdkPlatform: String?
     var sdkVersion: String?
     var appVersion: String?
     var appBundleId: String?
@@ -64,6 +65,7 @@ struct ResourcePayload: Codable {
         case appFramework = "app_framework"
         case launchCount = "launch_count"
         case sdkVersion = "sdk_version"
+        case sdkPlatform = "sdk_platform"
         case appVersion = "app_version"
         case appBundleId = "app_bundle_id"
         case processIdentifier = "process_identifier"
@@ -92,6 +94,7 @@ struct ResourcePayload: Codable {
         try container.encode(appFramework, forKey: .appFramework)
         try container.encode(launchCount, forKey: .launchCount)
         try container.encode(sdkVersion, forKey: .sdkVersion)
+        try container.encode(sdkPlatform, forKey: .sdkPlatform)
         try container.encode(appVersion, forKey: .appVersion)
         try container.encode(appBundleId, forKey: .appBundleId)
         try container.encode(processIdentifier, forKey: .processIdentifier)
@@ -110,7 +113,10 @@ struct ResourcePayload: Codable {
 
         // bundle_id is constant and won't change over app install lifetime
         self.appBundleId = Bundle.main.bundleIdentifier
-        self.osName = EMBDevice.operatingSystemType
+        // The backend uses this values to identify the platform through out all the system
+        // The specific OS is going to be reported in the `osAlternateType` field
+        self.osName = "ios"
+        self.sdkPlatform = "ios"
 
         // use the current sdk version as a fallback in case the resource is missing
         // (this happens when sending critical logs while the sdk is not totally initialized)

--- a/Tests/EmbraceCoreTests/Payload/ResourcePayloadTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/ResourcePayloadTests.swift
@@ -77,7 +77,8 @@ class ResourcePayloadTests: XCTestCase {
         XCTAssertEqual(json["os_build"] as? String, "23D60")
         XCTAssertEqual(json["os_type"] as? String, "darwin")
         XCTAssertEqual(json["os_alternate_type"] as? String, "iOS_variant")
-        XCTAssertEqual(json["os_name"] as? String, EMBDevice.operatingSystemType)
+        XCTAssertEqual(json["os_name"] as? String, "ios")
+        XCTAssertEqual(json["sdk_platform"] as? String, "ios")
 
         let jsonKeys = Set(json.keys)
         let expectedKeys = Set(ResourcePayload.CodingKeys.allCases.map { $0.rawValue })
@@ -93,5 +94,7 @@ class ResourcePayloadTests: XCTestCase {
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any])
 
         XCTAssertEqual(json["app_bundle_id"] as? String, Bundle.main.bundleIdentifier!)
+        XCTAssertEqual(json["os_name"] as? String, "ios")
+        XCTAssertEqual(json["sdk_platform"] as? String, "ios")
     }
 }


### PR DESCRIPTION
# Overview 
We were incorrectly sending the OS variant (aka. the `systemName`) in the `os_name` field when sending traces/logs to the backend. This caused payloads from other platforms (such as tvOS) to be dropped at ingestion time.

This PR fixes that.
