### PR TITLE
Migrate NanosecondClock to EmbraceClock

### DIFF
--- a/Sources/EmbraceCommonInternal/Clock/EmbraceClock.swift
+++ b/Sources/EmbraceCommonInternal/Clock/EmbraceClock.swift
@@ -4,105 +4,417 @@
 
 import Foundation
 
-/// A clock that works in nanoseconds
-/// and contains the 3 basic times needed to
-/// work with performance and interact with the outside world.
+// MARK: - EmbraceClock
+
+/// A high-resolution clock abstraction that captures three core time domains:
+/// - **Uptime:** Time since boot, excluding sleep (`CLOCK_UPTIME_RAW`)
+/// - **Monotonic:** Time since boot, including sleep (`CLOCK_MONOTONIC_RAW`)
+/// - **Realtime:** Wall time since the Unix epoch (`CLOCK_REALTIME`)
+///
+/// `EmbraceClock` is used for performance measurement, event correlation,
+/// and mapping between system-relative and wall-clock times.
+///
+/// - Example: Capture a timestamp snapshot and convert to `Date`
+/// ```swift
+/// let clock = EmbraceClock.current
+/// print("Wall Date:", clock.date)          // From `realtime`
+/// print("Uptime ns:", clock.uptime.nanosecondsValue)
+/// print("Monotonic ns:", clock.monotonic.nanosecondsValue)
+/// ```
+///
+/// - Example: Latency measurement with monotonic time
+/// ```swift
+/// let start = EmbraceClock.current
+/// performWork()
+/// let end = EmbraceClock.current
+/// let delta = end - start
+/// let elapsedNs = delta.monotonic.nanosecondsValue
+/// ```
 public struct EmbraceClock: Sendable {
 
-    public typealias Nanoseconds = UInt64
+    // MARK: - Instant
 
-    /// The clock for the current time.
+    /// Represents a single timestamp with unit flexibility (`seconds`, `milliseconds`, or `nanoseconds`).
+    ///
+    /// Provides safe arithmetic, unit conversion, and value accessors across time scales.
+    ///
+    /// - Note:
+    ///   Use `nanosecondsValue`/`millisecondsValue`/`secondsValue` when you need a concrete numeric value.
+    public struct Instant: Sendable {
+
+        /// The time unit used to represent an `Instant`.
+        public enum Unit: Sendable {
+            /// A value expressed in seconds.
+            case seconds(Double)
+            /// A value expressed in milliseconds.
+            case milliseconds(UInt64)
+            /// A value expressed in nanoseconds.
+            case nanoseconds(UInt64)
+        }
+
+        /// The underlying representation of this instant.
+        public let unit: Unit
+
+        // MARK: - Initialization
+
+        /// Creates a new instant in seconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let t = EmbraceClock.Instant(seconds: 1.25)
+        /// print(t.nanosecondsValue) // 1_250_000_000
+        /// ```
+        public init(seconds value: Double) {
+            self.unit = .seconds(value)
+        }
+
+        /// Creates a new instant in milliseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let t = EmbraceClock.Instant(milliseconds: 250)
+        /// print(t.secondsValue) // 0.25
+        /// ```
+        public init(milliseconds value: UInt64) {
+            self.unit = .milliseconds(value)
+        }
+
+        /// Creates a new instant in nanoseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let t = EmbraceClock.Instant(nanoseconds: 5_000_000)
+        /// print(t.millisecondsValue) // 5
+        /// ```
+        public init(nanoseconds value: UInt64) {
+            self.unit = .nanoseconds(value)
+        }
+
+        // MARK: - Factory Methods
+
+        /// Creates an instant from a value in seconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let s = EmbraceClock.Instant.seconds(2.5)
+        /// ```
+        public static func seconds(_ value: Double) -> Instant {
+            Instant(seconds: value)
+        }
+
+        /// Creates an instant from a value in milliseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let ms = EmbraceClock.Instant.milliseconds(1500)
+        /// print(ms.secondsValue) // 1.5
+        /// ```
+        public static func milliseconds(_ value: UInt64) -> Instant {
+            Instant(milliseconds: value)
+        }
+
+        /// Creates an instant from a value in nanoseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let ns = EmbraceClock.Instant.nanoseconds(750_000)
+        /// print(ns.millisecondsValue) // 0
+        /// ```
+        public static func nanoseconds(_ value: UInt64) -> Instant {
+            Instant(nanoseconds: value)
+        }
+
+        // MARK: - Arithmetic Operators
+
+        /// Subtracts one instant from another using standard integer subtraction.
+        ///
+        /// - Important: Uses **saturating integer semantics** of `UInt64` when accessing `nanosecondsValue`
+        ///   before conversion. Prefer `&-` if you explicitly want wrapping behavior.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let a = EmbraceClock.Instant.milliseconds(1200)
+        /// let b = EmbraceClock.Instant.milliseconds(200)
+        /// let c = a - b
+        /// print(c.millisecondsValue) // 1000
+        /// ```
+        public static func - (lhs: Instant, rhs: Instant) -> Instant {
+            .nanoseconds(lhs.nanosecondsValue - rhs.nanosecondsValue)
+        }
+
+        /// Subtracts one instant from another using wrapping subtraction (`&-`).
+        ///
+        /// - Example:
+        /// ```swift
+        /// let a = EmbraceClock.Instant.nanoseconds(10)
+        /// let b = EmbraceClock.Instant.nanoseconds(20)
+        /// let wrap = a &- b
+        /// // `wrap` will wrap around UInt64
+        /// ```
+        public static func &- (lhs: Instant, rhs: Instant) -> Instant {
+            .nanoseconds(lhs.nanosecondsValue &- rhs.nanosecondsValue)
+        }
+
+        /// Adds two instants using standard integer addition.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let a = EmbraceClock.Instant.seconds(1)
+        /// let b = EmbraceClock.Instant.milliseconds(250)
+        /// print((a + b).secondsValue) // 1.25
+        /// ```
+        public static func + (lhs: Instant, rhs: Instant) -> Instant {
+            .nanoseconds(lhs.nanosecondsValue + rhs.nanosecondsValue)
+        }
+
+        /// Adds two instants using wrapping addition (`&+`).
+        ///
+        /// - Example:
+        /// ```swift
+        /// let big = EmbraceClock.Instant.nanoseconds(.max)
+        /// let one = EmbraceClock.Instant.nanoseconds(1)
+        /// let wrap = big &+ one // wraps UInt64
+        /// ```
+        public static func &+ (lhs: Instant, rhs: Instant) -> Instant {
+            .nanoseconds(lhs.nanosecondsValue &+ rhs.nanosecondsValue)
+        }
+
+        // MARK: - Unit Conversion
+
+        /// Returns this instant expressed in seconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let ns = EmbraceClock.Instant.nanoseconds(2_000_000_000)
+        /// print(ns.seconds().secondsValue) // 2.0
+        /// ```
+        public func seconds() -> Instant {
+            switch unit {
+            case .seconds:
+                return self
+            case .milliseconds(let value):
+                return .seconds(Double(value) / 1_000.0)
+            case .nanoseconds(let value):
+                return .seconds(Double(value) / 1_000_000_000.0)
+            }
+        }
+
+        /// Returns this instant expressed in milliseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let s = EmbraceClock.Instant.seconds(0.75)
+        /// print(s.milliseconds().millisecondsValue) // 750
+        /// ```
+        public func milliseconds() -> Instant {
+            switch unit {
+            case .seconds(let value):
+                return .milliseconds(UInt64(value * 1_000.0))
+            case .milliseconds:
+                return self
+            case .nanoseconds(let value):
+                return .milliseconds(value / 1_000_000)
+            }
+        }
+
+        /// Returns this instant expressed in nanoseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let ms = EmbraceClock.Instant.milliseconds(3)
+        /// print(ms.nanoseconds().nanosecondsValue) // 3_000_000
+        /// ```
+        public func nanoseconds() -> Instant {
+            switch unit {
+            case .seconds(let value):
+                return .nanoseconds(UInt64(value * 1_000_000_000.0))
+            case .milliseconds(let value):
+                return .nanoseconds(value * 1_000_000)
+            case .nanoseconds:
+                return self
+            }
+        }
+
+        // MARK: - Value Accessors
+
+        /// Returns the numeric value of the instant in seconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let t = EmbraceClock.Instant.milliseconds(1500)
+        /// print(t.secondsValue) // 1.5
+        /// ```
+        public var secondsValue: Double {
+            switch unit {
+            case .seconds(let value):
+                return value
+            case .milliseconds(let value):
+                return Double(value) / 1_000.0
+            case .nanoseconds(let value):
+                return Double(value) / 1_000_000_000.0
+            }
+        }
+
+        /// Returns the numeric value of the instant in milliseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let t = EmbraceClock.Instant.seconds(2.0)
+        /// print(t.millisecondsValue) // 2000
+        /// ```
+        public var millisecondsValue: UInt64 {
+            switch unit {
+            case .seconds(let value):
+                return UInt64(value * 1_000.0)
+            case .milliseconds(let value):
+                return value
+            case .nanoseconds(let value):
+                return value / 1_000_000
+            }
+        }
+
+        /// Returns the numeric value of the instant in nanoseconds.
+        ///
+        /// - Example:
+        /// ```swift
+        /// let t = EmbraceClock.Instant.milliseconds(3)
+        /// print(t.nanosecondsValue) // 3_000_000
+        /// ```
+        public var nanosecondsValue: UInt64 {
+            switch unit {
+            case .seconds(let value):
+                return UInt64(value * 1_000_000_000.0)
+            case .milliseconds(let value):
+                return value * 1_000_000
+            case .nanoseconds(let value):
+                return value
+            }
+        }
+    }
+
+    // MARK: - Preset Clocks
+
+    /// Returns a snapshot of the current system clock across uptime, monotonic, and realtime domains.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let snapshot = EmbraceClock.current
+    /// print(snapshot.realtime.secondsValue) // seconds since 1970
+    /// ```
     public static var current: EmbraceClock { EmbraceClock() }
 
-    /// The clock for a ver far distant future.
-    public static var never: EmbraceClock { EmbraceClock(0) }
+    /// Returns a clock set to an infinitely distant future value (used as a sentinel).
+    ///
+    /// - Example:
+    /// ```swift
+    /// let deadline = EmbraceClock.never
+    /// // Useful as a "no deadline" / "disabled" marker.
+    /// ```
+    public static let never: EmbraceClock = { EmbraceClock(.nanoseconds(.max)) }()
 
-    /// Uptime in nanoseconds, not incrementing during sleep.
-    /// CLOCK_UPTIME_RAW
-    public let uptime: Nanoseconds
+    // MARK: - Clock Components
 
-    /// Monotonic time in nanoseconds, increments during sleep.
-    /// using CLOCK_MONOTONIC_RAW.
-    public let monotonic: Nanoseconds
+    /// Uptime in nanoseconds (does **not** advance during system sleep).
+    /// Backed by `CLOCK_UPTIME_RAW`.
+    public let uptime: Instant
 
-    /// Walltime (real time, unix epoch) in nanoseconds.
-    /// using CLOCK_REALTIME.
-    public let realtime: Nanoseconds
+    /// Monotonic time in nanoseconds (advances during system sleep).
+    /// Backed by `CLOCK_MONOTONIC_RAW`.
+    public let monotonic: Instant
 
-    /// Private intializers
+    /// Wall-clock time in nanoseconds since the Unix epoch.
+    /// Backed by `CLOCK_REALTIME`.
+    public let realtime: Instant
+
+    // MARK: - Initialization
+
+    /// Creates a new clock snapshot capturing the three time sources (`uptime`, `monotonic`, and `realtime`).
+    ///
+    /// The timestamps are sampled individually, so a small skew is expected but insignificant for
+    /// most measurement or correlation use cases.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let c = EmbraceClock.current
+    /// ```
     private init() {
-        // There will always be a very small skew,
-        // but it's unimportant for our use case.
         self.init(
-            uptime: clock_gettime_nsec_np(CLOCK_UPTIME_RAW),
-            monotonic: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW),
-            realtime: clock_gettime_nsec_np(CLOCK_REALTIME)
+            uptime: .nanoseconds(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)),
+            monotonic: .nanoseconds(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)),
+            realtime: .nanoseconds(clock_gettime_nsec_np(CLOCK_REALTIME))
         )
     }
 
-    private init(_ value: Nanoseconds) {
+    /// Creates a clock using a single `Instant` for all time sources.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let zero = EmbraceClock(EmbraceClock.Instant.nanoseconds(0)) // private ctor
+    /// ```
+    private init(_ value: Instant) {
         self.uptime = value
         self.monotonic = value
         self.realtime = value
     }
 
-    private init(uptime: Nanoseconds, monotonic: Nanoseconds, realtime: Nanoseconds) {
+    /// Creates a clock from explicit time sources.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let c = EmbraceClock(
+    ///     uptime: .nanoseconds(1),
+    ///     monotonic: .nanoseconds(2),
+    ///     realtime: .nanoseconds(3)
+    /// )
+    /// ```
+    private init(uptime: Instant, monotonic: Instant, realtime: Instant) {
         self.uptime = uptime
         self.monotonic = monotonic
         self.realtime = realtime
     }
 }
 
+// MARK: - Arithmetic
+
 extension EmbraceClock {
 
-    /// Substract one clock from another
+    /// Subtracts one clock snapshot from another.
+    ///
+    /// Each component (`uptime`, `monotonic`, `realtime`) is subtracted independently using wrapping subtraction.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let start = EmbraceClock.current
+    /// work()
+    /// let end = EmbraceClock.current
+    /// let diff = end - start
+    /// print(diff.monotonic.nanosecondsValue)
+    /// ```
     public static func - (lhs: EmbraceClock, rhs: EmbraceClock) -> EmbraceClock {
-        return EmbraceClock(
-            uptime: lhs.uptime &- rhs.uptime,
-            monotonic: lhs.monotonic &- rhs.monotonic,
-            realtime: lhs.realtime &- rhs.realtime
-        )
-    }
-
-    /// Substract a duration from the clock.
-    public static func - (lhs: EmbraceClock, rhs: Nanoseconds) -> EmbraceClock {
-        return EmbraceClock(
-            uptime: lhs.uptime &- rhs,
-            monotonic: lhs.monotonic &- rhs,
-            realtime: lhs.realtime &- rhs
-        )
-    }
-
-    /// Add a duration from the clock.
-    public static func + (lhs: EmbraceClock, rhs: Nanoseconds) -> EmbraceClock {
-        return EmbraceClock(
-            uptime: lhs.uptime &+ rhs,
-            monotonic: lhs.monotonic &+ rhs,
-            realtime: lhs.realtime &+ rhs
+        EmbraceClock(
+            uptime: .nanoseconds(lhs.uptime.nanosecondsValue &- rhs.uptime.nanosecondsValue),
+            monotonic: .nanoseconds(lhs.monotonic.nanosecondsValue &- rhs.monotonic.nanosecondsValue),
+            realtime: .nanoseconds(lhs.realtime.nanosecondsValue &- rhs.realtime.nanosecondsValue)
         )
     }
 }
 
+// MARK: - Date Conversion
+
 extension EmbraceClock {
 
-    /// Get a `Date` from the clock.
+    /// Converts the `realtime` value to a `Date` instance.
+    ///
+    /// This enables easy interoperability with standard Foundation APIs.
+    ///
+    /// - Example:
+    /// ```swift
+    /// let now = EmbraceClock.current
+    /// let date = now.date
+    /// formatter.string(from: date)
+    /// ```
     @inlinable
     public var date: Date {
-        Date(timeIntervalSince1970: realtime.seconds)
-    }
-}
-
-extension EmbraceClock.Nanoseconds {
-
-    /// Convert nanoseconds to milliseconds
-    @inlinable
-    public var milliseconds: UInt64 {
-        self / 1_000_000
-    }
-
-    /// Convert nanoseconds to seconds
-    @inlinable
-    public var seconds: Double {
-        Double(self) / 1_000_000_000.0
+        Date(timeIntervalSince1970: realtime.secondsValue)
     }
 }

--- a/Sources/EmbraceCommonInternal/Clock/EmbraceClock.swift
+++ b/Sources/EmbraceCommonInternal/Clock/EmbraceClock.swift
@@ -337,7 +337,7 @@ public struct EmbraceClock: Sendable {
     /// ```swift
     /// let c = EmbraceClock.current
     /// ```
-    private init() {
+    internal init() {
         self.init(
             uptime: .nanoseconds(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)),
             monotonic: .nanoseconds(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)),
@@ -351,7 +351,7 @@ public struct EmbraceClock: Sendable {
     /// ```swift
     /// let zero = EmbraceClock(EmbraceClock.Instant.nanoseconds(0)) // private ctor
     /// ```
-    private init(_ value: Instant) {
+    internal init(_ value: Instant) {
         self.uptime = value
         self.monotonic = value
         self.realtime = value
@@ -367,7 +367,7 @@ public struct EmbraceClock: Sendable {
     ///     realtime: .nanoseconds(3)
     /// )
     /// ```
-    private init(uptime: Instant, monotonic: Instant, realtime: Instant) {
+    internal init(uptime: Instant, monotonic: Instant, realtime: Instant) {
         self.uptime = uptime
         self.monotonic = monotonic
         self.realtime = realtime

--- a/Sources/EmbraceCommonInternal/Clock/EmbraceClock.swift
+++ b/Sources/EmbraceCommonInternal/Clock/EmbraceClock.swift
@@ -7,12 +7,15 @@ import Foundation
 /// A clock that works in nanoseconds
 /// and contains the 3 basic times needed to
 /// work with performance and interact with the outside world.
-public struct NanosecondClock: Sendable {
+public struct EmbraceClock: Sendable {
 
     public typealias Nanoseconds = UInt64
 
     /// The clock for the current time.
-    public static var current: NanosecondClock { NanosecondClock() }
+    public static var current: EmbraceClock { EmbraceClock() }
+
+    /// The clock for a ver far distant future.
+    public static var never: EmbraceClock { EmbraceClock(0) }
 
     /// Uptime in nanoseconds, not incrementing during sleep.
     /// CLOCK_UPTIME_RAW
@@ -50,19 +53,37 @@ public struct NanosecondClock: Sendable {
     }
 }
 
-extension NanosecondClock {
+extension EmbraceClock {
 
     /// Substract one clock from another
-    static func - (lhs: NanosecondClock, rhs: NanosecondClock) -> NanosecondClock {
-        return NanosecondClock(
+    public static func - (lhs: EmbraceClock, rhs: EmbraceClock) -> EmbraceClock {
+        return EmbraceClock(
             uptime: lhs.uptime &- rhs.uptime,
             monotonic: lhs.monotonic &- rhs.monotonic,
             realtime: lhs.realtime &- rhs.realtime
         )
     }
+
+    /// Substract a duration from the clock.
+    public static func - (lhs: EmbraceClock, rhs: Nanoseconds) -> EmbraceClock {
+        return EmbraceClock(
+            uptime: lhs.uptime &- rhs,
+            monotonic: lhs.monotonic &- rhs,
+            realtime: lhs.realtime &- rhs
+        )
+    }
+
+    /// Add a duration from the clock.
+    public static func + (lhs: EmbraceClock, rhs: Nanoseconds) -> EmbraceClock {
+        return EmbraceClock(
+            uptime: lhs.uptime &+ rhs,
+            monotonic: lhs.monotonic &+ rhs,
+            realtime: lhs.realtime &+ rhs
+        )
+    }
 }
 
-extension NanosecondClock {
+extension EmbraceClock {
 
     /// Get a `Date` from the clock.
     @inlinable
@@ -71,7 +92,7 @@ extension NanosecondClock {
     }
 }
 
-extension NanosecondClock.Nanoseconds {
+extension EmbraceClock.Nanoseconds {
 
     /// Convert nanoseconds to milliseconds
     @inlinable

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -76,7 +76,7 @@ extension HangCaptureService: HangObserver {
     // Hang span documented here:
     // https://www.notion.so/embraceio/ANRs-1d77e3c9985281c58765d8c622443e2c
 
-    public func hangStarted(at: NanosecondClock, duration: NanosecondClock) {
+    public func hangStarted(at: EmbraceClock, duration: EmbraceClock) {
 
         logger?.debug("[Watchdog] Hang started, at \(at.date) after waiting \(duration.uptime.milliseconds) ms")
 
@@ -110,9 +110,9 @@ extension HangCaptureService: HangObserver {
         }
 
         // Capture the stack now
-        let pre = NanosecondClock.current
+        let pre = EmbraceClock.current
         let backtrace = EmbraceBacktrace.backtrace(of: mainThread, suspendingThreads: true)
-        let post = NanosecondClock.current
+        let post = EmbraceClock.current
 
         spanQueue.async { [self] in
             span =
@@ -125,7 +125,7 @@ extension HangCaptureService: HangObserver {
         }
     }
 
-    public func hangUpdated(at: NanosecondClock, duration: NanosecondClock) {
+    public func hangUpdated(at: EmbraceClock, duration: EmbraceClock) {
         logger?.debug("[Watchdog] Hang for \(duration.uptime.milliseconds) ms")
 
         guard
@@ -138,9 +138,9 @@ extension HangCaptureService: HangObserver {
         }
 
         // Capture the stack now
-        let pre = NanosecondClock.current
+        let pre = EmbraceClock.current
         let backtrace = EmbraceBacktrace.backtrace(of: mainThread, suspendingThreads: true)
-        let post = NanosecondClock.current
+        let post = EmbraceClock.current
 
         // process it later
         spanQueue.async { [self] in
@@ -148,7 +148,7 @@ extension HangCaptureService: HangObserver {
         }
     }
 
-    public func hangEnded(at: NanosecondClock, duration: NanosecondClock) {
+    public func hangEnded(at: EmbraceClock, duration: EmbraceClock) {
         logger?.debug("[Watchdog] Hang ended at \(at.date) after \(duration.uptime.milliseconds) ms")
 
         spanQueue.async { [self] in

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -78,7 +78,7 @@ extension HangCaptureService: HangObserver {
 
     public func hangStarted(at: EmbraceClock, duration: EmbraceClock) {
 
-        logger?.debug("[Watchdog] Hang started, at \(at.date) after waiting \(duration.uptime.milliseconds) ms")
+        logger?.debug("[Watchdog] Hang started, at \(at.date) after waiting \(duration.uptime.millisecondsValue) ms")
 
         // Keep tabs on how many hang spans we've created
         let sampleInfo = limitData.withLock {
@@ -120,13 +120,17 @@ extension HangCaptureService: HangObserver {
                 .setStartTime(time: at.date)
                 .startSpan()
             if sampleInfo.canSample {
-                addSamplingSpanEvent(time: at.date, backtrace: backtrace, overhead: Int(post.monotonic - pre.monotonic))
+                addSamplingSpanEvent(
+                    time: at.date,
+                    backtrace: backtrace,
+                    overhead: Int((post.monotonic - pre.monotonic).nanosecondsValue)
+                )
             }
         }
     }
 
     public func hangUpdated(at: EmbraceClock, duration: EmbraceClock) {
-        logger?.debug("[Watchdog] Hang for \(duration.uptime.milliseconds) ms")
+        logger?.debug("[Watchdog] Hang for \(duration.uptime.millisecondsValue) ms")
 
         guard
             limitData.withLock({
@@ -144,12 +148,16 @@ extension HangCaptureService: HangObserver {
 
         // process it later
         spanQueue.async { [self] in
-            addSamplingSpanEvent(time: at.date, backtrace: backtrace, overhead: Int(post.monotonic - pre.monotonic))
+            addSamplingSpanEvent(
+                time: at.date,
+                backtrace: backtrace,
+                overhead: Int((post.monotonic - pre.monotonic).nanosecondsValue)
+            )
         }
     }
 
     public func hangEnded(at: EmbraceClock, duration: EmbraceClock) {
-        logger?.debug("[Watchdog] Hang ended at \(at.date) after \(duration.uptime.milliseconds) ms")
+        logger?.debug("[Watchdog] Hang ended at \(at.date) after \(duration.uptime.millisecondsValue) ms")
 
         spanQueue.async { [self] in
             span?.end(time: at.date)

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/HangWatchdog.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/HangWatchdog.swift
@@ -276,7 +276,7 @@ extension HangWatchdog {
                 let hangTime = now - enterTime
 
                 // Hangtime is based on uptime, we don't count the time the app is suspended.
-                let isHang = hangTime.uptime >= threasholdInNs
+                let isHang = hangTime.uptime.nanosecondsValue >= threasholdInNs
 
                 let startHang = isHang && $0.hanging == false
                 if startHang { $0.hanging = true }

--- a/Tests/EmbraceCommonInternalTests/Clock/EmbraceClockTests.swift
+++ b/Tests/EmbraceCommonInternalTests/Clock/EmbraceClockTests.swift
@@ -1,0 +1,237 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import EmbraceCommonInternal
+
+// MARK: - Helpers
+
+private func assertApproximatelyEqual(
+    _ a: Double,
+    _ b: Double,
+    tolerance: Double = 1e-9,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    XCTAssertLessThanOrEqual(abs(a - b), tolerance, "Expected \(a) ≈ \(b) (±\(tolerance))", file: file, line: line)
+}
+
+/// For UInt64 divisions/rounding semantics, conversion is truncating toward zero by design.
+private func assertEqualU64(
+    _ a: UInt64,
+    _ b: UInt64,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    XCTAssertEqual(a, b, file: file, line: line)
+}
+
+// MARK: - Instant Construction & Conversions
+
+final class EmbraceClockInstantConstructionTests: XCTestCase {
+
+    func testInitSeconds() {
+        let t = EmbraceClock.Instant(seconds: 1.25)
+        assertApproximatelyEqual(t.secondsValue, 1.25)
+        assertEqualU64(t.millisecondsValue, 1_250)
+        assertEqualU64(t.nanosecondsValue, 1_250_000_000)
+    }
+
+    func testInitMilliseconds() {
+        let t = EmbraceClock.Instant(milliseconds: 250)
+        assertApproximatelyEqual(t.secondsValue, 0.25)
+        assertEqualU64(t.millisecondsValue, 250)
+        assertEqualU64(t.nanosecondsValue, 250_000_000)
+    }
+
+    func testInitNanoseconds() {
+        let t = EmbraceClock.Instant(nanoseconds: 5_000_000)
+        assertApproximatelyEqual(t.secondsValue, 0.005)
+        assertEqualU64(t.millisecondsValue, 5)
+        assertEqualU64(t.nanosecondsValue, 5_000_000)
+    }
+
+    func testFactoryMethods() {
+        XCTAssertEqual(EmbraceClock.Instant.seconds(2).nanosecondsValue, 2_000_000_000)
+        XCTAssertEqual(EmbraceClock.Instant.milliseconds(1500).secondsValue, 1.5)
+        XCTAssertEqual(EmbraceClock.Instant.nanoseconds(750_000).millisecondsValue, 0)  // truncates
+    }
+}
+
+final class EmbraceClockInstantConversionAPITests: XCTestCase {
+
+    func testSecondsConversionMethodPreservesUnitOrConverts() {
+        let a = EmbraceClock.Instant.seconds(2.0).seconds()
+        assertApproximatelyEqual(a.secondsValue, 2.0)
+
+        let b = EmbraceClock.Instant.milliseconds(500).seconds()
+        assertApproximatelyEqual(b.secondsValue, 0.5)
+
+        let c = EmbraceClock.Instant.nanoseconds(2_000_000_000).seconds()
+        assertApproximatelyEqual(c.secondsValue, 2.0)
+    }
+
+    func testMillisecondsConversionMethod() {
+        let a = EmbraceClock.Instant.seconds(0.75).milliseconds()
+        assertEqualU64(a.millisecondsValue, 750)
+
+        let b = EmbraceClock.Instant.nanoseconds(3_499_999).milliseconds()  // trunc
+        assertEqualU64(b.millisecondsValue, 3)
+
+        let c = EmbraceClock.Instant.milliseconds(42).milliseconds()
+        assertEqualU64(c.millisecondsValue, 42)
+    }
+
+    func testNanosecondsConversionMethod() {
+        let a = EmbraceClock.Instant.seconds(1.0).nanoseconds()
+        assertEqualU64(a.nanosecondsValue, 1_000_000_000)
+
+        let b = EmbraceClock.Instant.milliseconds(3).nanoseconds()
+        assertEqualU64(b.nanosecondsValue, 3_000_000)
+
+        let c = EmbraceClock.Instant.nanoseconds(7).nanoseconds()
+        assertEqualU64(c.nanosecondsValue, 7)
+    }
+}
+
+// MARK: - Instant Arithmetic
+
+final class EmbraceClockInstantArithmeticTests: XCTestCase {
+
+    func testAddition() {
+        let a = EmbraceClock.Instant.seconds(1.0)
+        let b = EmbraceClock.Instant.milliseconds(250)
+        let sum = a + b
+        assertApproximatelyEqual(sum.secondsValue, 1.25)
+        assertEqualU64(sum.nanosecondsValue, 1_250_000_000)
+    }
+
+    func testSubtractionNonWrapping() {
+        let a = EmbraceClock.Instant.milliseconds(1200)
+        let b = EmbraceClock.Instant.milliseconds(200)
+        let diff = a - b
+        assertEqualU64(diff.millisecondsValue, 1_000)
+    }
+
+    func testWrappingAddition() {
+        let big = EmbraceClock.Instant.nanoseconds(.max)
+        let one = EmbraceClock.Instant.nanoseconds(1)
+        let wrap = big &+ one
+        // UInt64.max &+ 1 wraps to 0
+        assertEqualU64(wrap.nanosecondsValue, 0)
+    }
+
+    func testWrappingSubtraction() {
+        let small = EmbraceClock.Instant.nanoseconds(1)
+        let big = EmbraceClock.Instant.nanoseconds(2)
+        let wrap = small &- big
+        // 1 &- 2 wraps to UInt64.max
+        assertEqualU64(wrap.nanosecondsValue, .max)
+    }
+
+    func testCrossUnitArithmetic() {
+        let a = EmbraceClock.Instant.seconds(2.5)  // 2_500_000_000 ns
+        let b = EmbraceClock.Instant.nanoseconds(250_000)  // 0.00025 s
+        let c = EmbraceClock.Instant.milliseconds(125)  // 0.125 s
+        let sum = a + b + c
+        assertApproximatelyEqual(sum.secondsValue, 2.5 + 0.00025 + 0.125, tolerance: 1e-12)
+        assertEqualU64(sum.millisecondsValue, 2_625)  // truncation in ms
+    }
+}
+
+// MARK: - EmbraceClock Behavior
+
+final class EmbraceClockSnapshotTests: XCTestCase {
+
+    func testCurrentProducesReasonableRealtimeDate() {
+        let now = Date().timeIntervalSince1970
+        let snapshot = EmbraceClock.current
+        let rt = snapshot.realtime.secondsValue
+
+        // Allow a small skew between sampling the Date() and the clock.
+        assertApproximatelyEqual(rt, now, tolerance: 1.0)  // 1s is generous for CI
+        XCTAssertGreaterThan(snapshot.uptime.nanosecondsValue, 0)
+        XCTAssertGreaterThan(snapshot.monotonic.nanosecondsValue, 0)
+    }
+
+    func testNeverIsMax() {
+        let never = EmbraceClock.never
+        XCTAssertEqual(never.uptime.nanosecondsValue, .max)
+        XCTAssertEqual(never.monotonic.nanosecondsValue, .max)
+        XCTAssertEqual(never.realtime.nanosecondsValue, .max)
+    }
+
+    func testDateAccessorMatchesRealtime() {
+        let s = EmbraceClock.current
+        let derived = s.date.timeIntervalSince1970
+        assertApproximatelyEqual(derived, s.realtime.secondsValue, tolerance: 1e-6)
+    }
+
+    func testClockSubtractionComponentWise() {
+        // Construct deterministic clocks
+        let a = makeClock(u: 2_000, m: 5_000, r: 10_000)  // ns
+        let b = makeClock(u: 1_000, m: 4_000, r: 9_000)
+        let d = a - b
+
+        XCTAssertEqual(d.uptime.nanosecondsValue, 1_000)
+        XCTAssertEqual(d.monotonic.nanosecondsValue, 1_000)
+        XCTAssertEqual(d.realtime.nanosecondsValue, 1_000)
+    }
+
+    func testClockSubtractionWrapping() {
+        let a = makeClock(u: 0, m: 0, r: 0)
+        let b = makeClock(u: 1, m: 2, r: 3)
+        let d = a - b
+        XCTAssertEqual(d.uptime.nanosecondsValue, .max)  // 0 &- 1
+        XCTAssertEqual(d.monotonic.nanosecondsValue, .max &- 1)  // 0 &- 2
+        XCTAssertEqual(d.realtime.nanosecondsValue, .max &- 2)  // 0 &- 3
+    }
+
+    func testTwoSnapshotsAreNonNegativeDiffs() {
+        // Not asserting monotonicity across different domains, only that self - self == 0
+        let s1 = EmbraceClock.current
+        let s2 = EmbraceClock.current
+        let diff = s2 - s1
+        // Wrapping subtraction should not wrap when s2 >= s1 in practice (very likely).
+        // We'll just assert "not nonsensical": values won't be astronomically large if close in time.
+        XCTAssertLessThan(diff.uptime.secondsValue, 10)  // <10s
+        XCTAssertLessThan(diff.monotonic.secondsValue, 10)
+        XCTAssertLessThan(diff.realtime.secondsValue, 10)
+    }
+
+    // MARK: - Private
+
+    private func makeClock(u: UInt64, m: UInt64, r: UInt64) -> EmbraceClock {
+        // Use the private initializer pattern via a small test-only extension below.
+        EmbraceClock(
+            uptime: .nanoseconds(u),
+            monotonic: .nanoseconds(m),
+            realtime: .nanoseconds(r)
+        )
+    }
+}
+
+// MARK: - Performance
+
+final class EmbraceClockPerformanceTests: XCTestCase {
+
+    func testSnapshotPerformance() {
+        measure {
+            _ = EmbraceClock.current
+        }
+    }
+
+    func testInstantArithmeticPerformance() {
+        let a = EmbraceClock.Instant.nanoseconds(1_234_567_890)
+        let b = EmbraceClock.Instant.milliseconds(987)
+        measure {
+            var acc = EmbraceClock.Instant.nanoseconds(0)
+            for _ in 0..<100_000 {
+                acc = (acc &+ a) &- b
+            }
+            _ = acc
+        }
+    }
+}

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -183,24 +183,24 @@ class MockHangObserver: HangObserver {
     func hangStarted(at: EmbraceClock, duration: EmbraceClock) {
         hangStartedCalled = true
         hangStartedCallCount += 1
-        lastStartTime = at.monotonic
-        lastHangDuration = duration.monotonic
-        onHangStarted?(at.monotonic, duration.monotonic)
+        lastStartTime = at.monotonic.nanosecondsValue
+        lastHangDuration = duration.monotonic.nanosecondsValue
+        onHangStarted?(at.monotonic.nanosecondsValue, duration.monotonic.nanosecondsValue)
     }
 
     func hangUpdated(at: EmbraceClock, duration: EmbraceClock) {
         hangUpdatedCalled = true
         hangUpdatedCallCount += 1
-        lastUpdateTime = at.monotonic
-        lastHangDuration = duration.monotonic
-        onHangUpdated?(at.monotonic, duration.monotonic)
+        lastUpdateTime = at.monotonic.nanosecondsValue
+        lastHangDuration = duration.monotonic.nanosecondsValue
+        onHangUpdated?(at.monotonic.nanosecondsValue, duration.monotonic.nanosecondsValue)
     }
 
-    func hangEnded(at: EmbraceCore.EmbraceClock, duration: EmbraceCore.EmbraceClock) {
+    func hangEnded(at: EmbraceClock, duration: EmbraceClock) {
         hangEndedCalled = true
         hangEndedCallCount += 1
-        lastEndTime = at.monotonic
-        lastHangDuration = duration.monotonic
-        onHangEnded?(at.monotonic, duration.monotonic)
+        lastEndTime = at.monotonic.nanosecondsValue
+        lastHangDuration = duration.monotonic.nanosecondsValue
+        onHangEnded?(at.monotonic.nanosecondsValue, duration.monotonic.nanosecondsValue)
     }
 }

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -180,7 +180,7 @@ class MockHangObserver: HangObserver {
     var lastEndTime: UInt64 = 0
     var lastHangDuration: UInt64 = 0
 
-    func hangStarted(at: NanosecondClock, duration: NanosecondClock) {
+    func hangStarted(at: EmbraceClock, duration: EmbraceClock) {
         hangStartedCalled = true
         hangStartedCallCount += 1
         lastStartTime = at.monotonic
@@ -188,7 +188,7 @@ class MockHangObserver: HangObserver {
         onHangStarted?(at.monotonic, duration.monotonic)
     }
 
-    func hangUpdated(at: NanosecondClock, duration: NanosecondClock) {
+    func hangUpdated(at: EmbraceClock, duration: EmbraceClock) {
         hangUpdatedCalled = true
         hangUpdatedCallCount += 1
         lastUpdateTime = at.monotonic
@@ -196,7 +196,7 @@ class MockHangObserver: HangObserver {
         onHangUpdated?(at.monotonic, duration.monotonic)
     }
 
-    func hangEnded(at: EmbraceCore.NanosecondClock, duration: EmbraceCore.NanosecondClock) {
+    func hangEnded(at: EmbraceCore.EmbraceClock, duration: EmbraceCore.EmbraceClock) {
         hangEndedCalled = true
         hangEndedCallCount += 1
         lastEndTime = at.monotonic


### PR DESCRIPTION
Replaces NanosecondClock with a more robust EmbraceClock implementation that provides enhanced time measurement capabilities.

### Changes

  - Removed NanosecondClock.swift and replaced with EmbraceClock.swift
  - Enhanced time abstraction with flexible unit support (seconds/milliseconds/nanoseconds)
  - Added comprehensive arithmetic operators including wrapping variants (&+, &-)
  - Updated all usage sites in hang detection components
  - Added extensive test coverage with 237 lines of unit tests

### Key Improvements

  - More flexible Instant type with multiple unit representations
  - Rich API with conversion methods and value accessors
  - Better documentation with inline examples
  - Sentinel value EmbraceClock.never for timeout handling
  - Performance benchmarks included

### Test Plan

  - All existing functionality preserved
  - Comprehensive unit tests added
  - Build passes successfully
  - No remaining references to old NanosecondClock