### PR TITLE
Enable library evolution for xcframework builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-# We're using a specific commit of xccache that has a fix because latest version (1.0.4) is not working. 
-# See issue: https://github.com/trinhngocthuyen/xccache/issues/100 (when solved, we can use a normal gem version)
-gem 'xccache', git: 'https://github.com/trinhngocthuyen/xccache.git', ref: '6e3fe288127c529a0b88c653eb02b01ad16af205'
+gem 'xccache', git: 'https://github.com/embrace-io/xccache.git', ref: '0919370'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/trinhngocthuyen/xccache.git
-  revision: 6e3fe288127c529a0b88c653eb02b01ad16af205
-  ref: 6e3fe288127c529a0b88c653eb02b01ad16af205
+  remote: https://github.com/embrace-io/xccache.git
+  revision: 0919370044e58b32fb19d9ff6465cad8950bc507
+  ref: 0919370
   specs:
     xccache (1.0.5)
       claide

--- a/bin/build_xcframeworks.sh
+++ b/bin/build_xcframeworks.sh
@@ -95,7 +95,7 @@ echo "=========================================="
 echo "Building all XCFrameworks..."
 echo "=========================================="
 
-bundle exec xccache pkg build "${PRODUCTS[@]}" --sdk="${SDKS}" --out="binaries"
+bundle exec xccache pkg build "${PRODUCTS[@]}" --sdk="${SDKS}" --library-evolution --out="binaries"
 
 if [ $? -eq 0 ]; then
     echo ""


### PR DESCRIPTION
# Overview
Added the `--library-evolution` flag to `xccache` so `.xcframeworks` are built with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`, making them compatible across Xcode versions.

Also switched `xccache` to our fork ([embrace-io/xccache](https://github.com/embrace-io/xccache)) which fixes a problem on newer xcode versions.