### PR TITLE
[EMBR-11117] Fix: Fix attempt for GZip crash

### DIFF
--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -320,18 +320,22 @@ extension LogController {
     }
 
     static func adaptiveMaxLogsPerBatch() -> Int {
-        let availableMemory = os_proc_available_memory()
-
-        switch availableMemory {
-        case 0..<(15 * 1024 * 1024):
-            return 1
-        case ..<(30 * 1024 * 1024):
-            return 5
-        case ..<(50 * 1024 * 1024):
-            return 10
-        default:
+        #if os(macOS)
             return maxLogsPerBatch
-        }
+        #else
+            let availableMemory = os_proc_available_memory()
+
+            switch availableMemory {
+            case 0..<(15 * 1024 * 1024):
+                return 1
+            case ..<(30 * 1024 * 1024):
+                return 5
+            case ..<(50 * 1024 * 1024):
+                return 10
+            default:
+                return maxLogsPerBatch
+            }
+        #endif
     }
 
     fileprivate func divideInBatches(_ logs: [EmbraceLog], maxLogsPerBatch: Int = LogController.maxLogsPerBatch) -> [LogsBatch] {

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -45,6 +45,11 @@ class LogController: LogControllable {
     /// For consistency, I created a constant
     static let maxLogsPerBatch: Int = 20
 
+    /// Returns the batch size to use for unsent log uploads.
+    /// Defaults to adaptive sizing based on available memory.
+    /// Can be overridden in tests to use a fixed value.
+    var maxLogsPerBatchProvider: () -> Int = { LogController.adaptiveMaxLogsPerBatch() }
+
     struct MutableState {
         var limits: LogsLimits = LogsLimits()
     }
@@ -76,7 +81,7 @@ class LogController: LogControllable {
 
         let logs: [EmbraceLog] = storage.fetchAll(excludingProcessIdentifier: ProcessIdentifier.current)
         if logs.isEmpty == false {
-            let batchSize = Self.adaptiveMaxLogsPerBatch()
+            let batchSize = maxLogsPerBatchProvider()
             send(batches: divideInBatches(logs, maxLogsPerBatch: batchSize)) {
                 completion?()
             }

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import os
 
 #if !EMBRACE_COCOAPOD_BUILDING_SDK
     import EmbraceStorageInternal
@@ -75,7 +76,8 @@ class LogController: LogControllable {
 
         let logs: [EmbraceLog] = storage.fetchAll(excludingProcessIdentifier: ProcessIdentifier.current)
         if logs.isEmpty == false {
-            send(batches: divideInBatches(logs)) {
+            let batchSize = Self.adaptiveMaxLogsPerBatch()
+            send(batches: divideInBatches(logs, maxLogsPerBatch: batchSize)) {
                 completion?()
             }
         } else {
@@ -219,26 +221,18 @@ extension LogController {
 
 extension LogController {
     fileprivate func send(batches: [LogsBatch], completion: (() -> Void)? = nil) {
-        guard sdkStateProvider?.isEnabled == true else {
+        guard sdkStateProvider?.isEnabled == true, !batches.isEmpty else {
             completion?()
             return
         }
 
-        guard batches.isEmpty == false else {
-            completion?()
-            return
-        }
-
-        let group = DispatchGroup()
-        group.enter()
+        // Process batches sequentially so each compressed payload
+        // is released before the next one is allocated.
+        let semaphore = DispatchSemaphore(value: 0)
 
         for batch in batches {
-            do {
-                guard batch.logs.isEmpty == false else {
-                    continue
-                }
-
-                guard let processId = batch.logs[0].processId else {
+            autoreleasepool {
+                guard !batch.logs.isEmpty, let processId = batch.logs[0].processId else {
                     return
                 }
 
@@ -251,35 +245,33 @@ extension LogController {
                 //
                 // If we can't find a sessionId, we use the processId instead
 
-                var sessionId: EmbraceIdentifier?
-                if let log = batch.logs.first(where: { $0.attribute(forKey: LogSemantics.keySessionId) != nil }) {
-                    if let id = log.attribute(forKey: LogSemantics.keySessionId)?.valueRaw {
-                        sessionId = EmbraceIdentifier(stringValue: id)
+                do {
+                    var sessionId: EmbraceIdentifier?
+                    if let log = batch.logs.first(where: { $0.attribute(forKey: LogSemantics.keySessionId) != nil }) {
+                        if let id = log.attribute(forKey: LogSemantics.keySessionId)?.valueRaw {
+                            sessionId = EmbraceIdentifier(stringValue: id)
+                        }
                     }
+
+                    let resourcePayload = try createResourcePayload(sessionId: sessionId, processId: processId)
+                    let metadataPayload = try createMetadataPayload(sessionId: sessionId, processId: processId)
+
+                    send(
+                        logs: batch.logs,
+                        resourcePayload: resourcePayload,
+                        metadataPayload: metadataPayload,
+                        completion: { semaphore.signal() }
+                    )
+
+                    semaphore.wait()
+
+                } catch let exception {
+                    Error.couldntCreatePayload(reason: exception.localizedDescription).log()
                 }
-
-                let resourcePayload = try createResourcePayload(sessionId: sessionId, processId: processId)
-                let metadataPayload = try createMetadataPayload(sessionId: sessionId, processId: processId)
-
-                group.enter()
-
-                send(
-                    logs: batch.logs,
-                    resourcePayload: resourcePayload,
-                    metadataPayload: metadataPayload,
-                    completion: {
-                        group.leave()
-                    }
-                )
-            } catch let exception {
-                Error.couldntCreatePayload(reason: exception.localizedDescription).log()
             }
         }
 
-        group.leave()
-        group.notify(queue: .global(qos: .default)) {
-            completion?()
-        }
+        completion?()
     }
 
     fileprivate func send(
@@ -322,16 +314,31 @@ extension LogController {
         }
     }
 
-    fileprivate func divideInBatches(_ logs: [EmbraceLog]) -> [LogsBatch] {
+    static func adaptiveMaxLogsPerBatch() -> Int {
+        let availableMemory = os_proc_available_memory()
+
+        switch availableMemory {
+        case 0..<(15 * 1024 * 1024):
+            return 1
+        case ..<(30 * 1024 * 1024):
+            return 5
+        case ..<(50 * 1024 * 1024):
+            return 10
+        default:
+            return maxLogsPerBatch
+        }
+    }
+
+    fileprivate func divideInBatches(_ logs: [EmbraceLog], maxLogsPerBatch: Int = LogController.maxLogsPerBatch) -> [LogsBatch] {
         var batches: [LogsBatch] = []
-        var batch: LogsBatch = .init(limits: .init(maxBatchAge: .infinity, maxLogsPerBatch: Self.maxLogsPerBatch))
+        var batch: LogsBatch = .init(limits: .init(maxBatchAge: .infinity, maxLogsPerBatch: maxLogsPerBatch))
         for log in logs {
             let result = batch.add(log: log)
             switch result {
             case .success(let batchState):
                 if batchState == .closed {
                     batches.append(batch)
-                    batch = LogsBatch(limits: .init(maxLogsPerBatch: Self.maxLogsPerBatch))
+                    batch = LogsBatch(limits: .init(maxLogsPerBatch: maxLogsPerBatch))
                 }
             case .failure:
                 // This shouldn't happen.

--- a/Sources/EmbraceCore/Utils/Data+Gzip.swift
+++ b/Sources/EmbraceCore/Utils/Data+Gzip.swift
@@ -138,11 +138,16 @@ extension Data {
     /// - Throws: `GzipError`
     func gzipped(
         level: CompressionLevel = .defaultCompression,
-        wBits: Int32 = Gzip.maxWindowBits + 16
+        wBits: Int32 = Gzip.maxWindowBits + 16,
+        maxInputSize: Int = 50 * 1024 * 1024
     ) throws -> Data {
 
         guard !self.isEmpty else {
             return Data()
+        }
+
+        guard self.count <= maxInputSize else {
+            throw GzipError(code: Z_MEM_ERROR, msg: nil)
         }
 
         var stream = z_stream()
@@ -196,6 +201,13 @@ extension Data {
                 }
 
                 stream.next_in = nil
+            }
+
+            // Break early on fatal deflate errors instead of
+            // continuing to allocate memory.
+            if status != Z_OK && status != Z_STREAM_END && status != Z_BUF_ERROR {
+                deflateEnd(&stream)
+                throw GzipError(code: status, msg: stream.msg)
             }
 
         } while stream.avail_out == 0 && status != Z_STREAM_END

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerTests.swift
@@ -311,6 +311,7 @@ extension LogControllerTests {
 
         sut.sdkStateProvider = sdkStateProvider
         sut.otel = otelBridge
+        sut.maxLogsPerBatchProvider = { LogController.maxLogsPerBatch }
     }
 
     fileprivate func givenLogController() {
@@ -322,6 +323,7 @@ extension LogControllerTests {
 
         sut.sdkStateProvider = sdkStateProvider
         sut.otel = otelBridge
+        sut.maxLogsPerBatchProvider = { LogController.maxLogsPerBatch }
     }
 
     fileprivate func givenEmbraceLogUploader() {

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -690,6 +690,7 @@ class UnsentDataHandlerTests: XCTestCase {
             controller: MockSessionController()
         )
         logController.sdkStateProvider = sdkStateProvider
+        logController.maxLogsPerBatchProvider = { LogController.maxLogsPerBatch }
         let otel = MockEmbraceOpenTelemetry()
 
         // given logs in storage

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/SpyEmbraceLogUploader.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/SpyEmbraceLogUploader.swift
@@ -14,9 +14,7 @@ class SpyEmbraceLogUploader: EmbraceLogUploader {
         didCallUploadLogCount += 1
         didCallUploadLog = true
         logPayloadTypes = payloadTypes
-        if let result = stubbedLogCompletion {
-            completion?(result)
-        }
+        completion?(stubbedLogCompletion ?? .success(()))
     }
 
     var didCallUploadAttachment = false


### PR DESCRIPTION
This PR attempts to fix a crash that occurs when we compress payload data with GZip on memory pressure situations.

There are 4 layers:
1. **Adaptive batches for logs:** Log batch size changes depending on available memory.
2. **Sequential processing:** Process log batches sequentially so no more than 1 compressed payload lives in memory at the same time.
3. **GZip deflate error check:** this just adds an early error check inside the GZip code so the buffer doesn't keep growing unnecessarily.
4. **Input size guard in GZip:** Added a hard cap of 50mb in the GZip code. Any data larger than this gets dropped.