### PR TITLE
Implement frame-pointer stack walker and profiling test infrastructure.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/EmbraceIO-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/EmbraceIO-Package.xcscheme
@@ -482,6 +482,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ProfilingBenchmarkRunner"
+               BuildableName = "ProfilingBenchmarkRunner"
+               BlueprintName = "ProfilingBenchmarkRunner"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -716,6 +730,16 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EmbraceProfilingSamplerTests"
+               BuildableName = "EmbraceProfilingSamplerTests"
+               BlueprintName = "EmbraceProfilingSamplerTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -728,6 +752,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ProfilingBenchmarkRunner"
+            BuildableName = "ProfilingBenchmarkRunner"
+            BlueprintName = "ProfilingBenchmarkRunner"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -735,15 +769,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EmbraceCore"
-            BuildableName = "EmbraceCore"
-            BlueprintName = "EmbraceCore"
+            BlueprintIdentifier = "ProfilingBenchmarkRunner"
+            BuildableName = "ProfilingBenchmarkRunner"
+            BlueprintName = "ProfilingBenchmarkRunner"
             ReferencedContainer = "container:">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Package.swift
+++ b/Package.swift
@@ -344,11 +344,41 @@ let package = Package(
         ),
         .target(
             name: "EmbraceProfiling",
-            dependencies: ["EmbraceProfilingSampler"]
+            dependencies: [
+                "EmbraceProfilingSampler",
+                .product(name: "Recording", package: "KSCrash")
+            ]
         ),
         .testTarget(
             name: "EmbraceProfilingTests",
-            dependencies: ["EmbraceProfiling"]
+            dependencies: [
+                "EmbraceProfiling",
+                "EmbraceProfilingTestSupport",
+                "EmbraceProfilingTestSupportNoFP"
+            ]
+        ),
+        .target(
+            name: "EmbraceProfilingTestSupport",
+            path: "Tests/EmbraceProfilingTestSupport"
+        ),
+        .target(
+            name: "EmbraceProfilingTestSupportNoFP",
+            path: "Tests/EmbraceProfilingTestSupportNoFP",
+            cSettings: [.unsafeFlags(["-fomit-frame-pointer"])]
+        ),
+        .testTarget(
+            name: "EmbraceProfilingSamplerTests",
+            dependencies: ["EmbraceProfilingSampler", "EmbraceProfilingTestSupport"]
+        ),
+        .executableTarget(
+            name: "ProfilingBenchmarkRunner",
+            dependencies: [
+                "EmbraceProfilingSampler",
+                "EmbraceProfilingTestSupport",
+                "EmbraceProfilingTestSupportNoFP",
+                .product(name: "Recording", package: "KSCrash")
+            ],
+            path: "Tests/ProfilingBenchmarkRunner"
         ),
 
         // test support --------------------------------------------------------------

--- a/Sources/EmbraceProfiling/ProfilingEngine.swift
+++ b/Sources/EmbraceProfiling/ProfilingEngine.swift
@@ -125,11 +125,11 @@ public final class ProfilingEngine {
             return samples
         }
 
-        private func fakeSampleFrames(seed: UInt64) -> [UInt64] {
+        private func fakeSampleFrames(seed: UInt64) -> [UInt] {
             // Simulate main thread call stacks with realistic arm64 addresses.
 
             // Usually the base will look like this:
-            let runLoopBase: [UInt64] = [
+            let runLoopBase: [UInt] = [
                 0x00000001_8B6E6000,  // CoreFoundation: CFRunLoopRunSpecific
                 0x00000001_8B6E5800,  // CoreFoundation: __CFRunLoopRun
                 0x00000001_8B6E2400,  // CoreFoundation: __CFRunLoopDoSources0
@@ -144,7 +144,7 @@ public final class ProfilingEngine {
             ]
 
             // Varying stack tops
-            var top: [UInt64]
+            var top: [UInt]
             switch seed % 5 {
             case 0:
                 top = [

--- a/Sources/EmbraceProfiling/ProfilingEngine.swift
+++ b/Sources/EmbraceProfiling/ProfilingEngine.swift
@@ -116,7 +116,8 @@ public final class ProfilingEngine {
                     samples.append(
                         ProfilingSample(
                             timestamp: tick,
-                            frames: fakeSampleFrames(seed: tick)
+                            frames: fakeSampleFrames(seed: tick),
+                            unwindMethod: .framePointer  // Fake samples use FP method
                         ))
                 }
                 tick += intervalNs

--- a/Sources/EmbraceProfiling/ProfilingEngine.swift
+++ b/Sources/EmbraceProfiling/ProfilingEngine.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -8,7 +8,7 @@ public enum StackUnwindMethod {
     case framePointer
     /// KSCrash's DWARF-based unwinder (slower, more robust fallback)
     case kscrash
-    /// Partial frame-pointer walk (below minFPFrames threshold, returned as last resort)
+    /// Partial frame-pointer walk (below minFPFrames threshold, returned as last resort if kscrash returned nothing)
     case framePointerPartial
     /// Stack capture failed entirely — no frames were obtained.
     case failed

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -2,6 +2,16 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
+/// How a stack trace was captured.
+public enum StackUnwindMethod {
+    /// Frame-pointer based stack walking (fast, works when FP is available)
+    case framePointer
+    /// KSCrash's DWARF-based unwinder (slower, more robust fallback)
+    case kscrash
+    /// Partial frame-pointer walk (below minFPFrames threshold, returned as last resort)
+    case framePointerPartial
+}
+
 /// A single profiling sample containing a stack trace captured at a point in time.
 public struct ProfilingSample {
     /// `CLOCK_MONOTONIC_RAW` timestamp in nanoseconds when this sample was captured.
@@ -10,8 +20,12 @@ public struct ProfilingSample {
     /// Raw return addresses from the captured stack trace.
     public let frames: [UInt]
 
-    public init(timestamp: UInt64, frames: [UInt]) {
+    /// The method used to capture this stack trace.
+    public let unwindMethod: StackUnwindMethod
+
+    public init(timestamp: UInt64, frames: [UInt], unwindMethod: StackUnwindMethod) {
         self.timestamp = timestamp
         self.frames = frames
+        self.unwindMethod = unwindMethod
     }
 }

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -10,6 +10,8 @@ public enum StackUnwindMethod {
     case kscrash
     /// Partial frame-pointer walk (below minFPFrames threshold, returned as last resort)
     case framePointerPartial
+    /// Stack capture failed entirely — no frames were obtained.
+    case failed
 }
 
 /// A single profiling sample containing a stack trace captured at a point in time.

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -8,9 +8,9 @@ public struct ProfilingSample {
     public let timestamp: UInt64
 
     /// Raw return addresses from the captured stack trace.
-    public let frames: [UInt64]
+    public let frames: [UInt]
 
-    public init(timestamp: UInt64, frames: [UInt64]) {
+    public init(timestamp: UInt64, frames: [UInt]) {
         self.timestamp = timestamp
         self.frames = frames
     }

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -3,7 +3,7 @@
 //
 
 /// How a stack trace was captured.
-public enum StackUnwindMethod {
+public enum StackUnwindMethod: Equatable, Hashable, CaseIterable, Sendable {
     /// Frame-pointer based stack walking (fast, works when FP is available)
     case framePointer
     /// KSCrash's DWARF-based unwinder (slower, more robust fallback)

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 /// How a stack trace was captured.
@@ -15,7 +15,7 @@ public enum StackUnwindMethod {
 }
 
 /// A single profiling sample containing a stack trace captured at a point in time.
-public struct ProfilingSample {
+public struct ProfilingSample: Equatable, Hashable, Sendable {
     /// `CLOCK_MONOTONIC_RAW` timestamp in nanoseconds when this sample was captured.
     public let timestamp: UInt64
 

--- a/Sources/EmbraceProfiling/StackCapture.swift
+++ b/Sources/EmbraceProfiling/StackCapture.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)
@@ -35,15 +35,29 @@ func captureStack(thread: thread_t, maxFrames: Int = 512) -> (frames: [UInt], me
     var ksFrames = [UInt](repeating: 0, count: maxFrames)
     let pthread = pthread_from_mach_thread_np(thread)
 
+    // Resolve stack bounds before suspending — pthread APIs are not async-safe.
+    var stackBottom: UnsafeRawPointer? = nil
+    var stackTop: UnsafeRawPointer? = nil
+    if let pth = pthread {
+        let top = pthread_get_stackaddr_np(pth)
+        let size = pthread_get_stacksize_np(pth)
+        stackTop = UnsafeRawPointer(top)
+        stackBottom = UnsafeRawPointer(top - size)
+    }
+
     guard thread_suspend(thread) == KERN_SUCCESS else {
         return ([], .failed)
     }
 
-    // Only asyn-safe things allowed between suspend and resume.
+    // Only async-safe things allowed between suspend and resume.
 
     var fpCount = 0
-    // Common case: Frame pointer is available, so we can fast-walk the stack.
-    let fpSuccess = emb_stack_walk(thread, &fpFrames, maxFrames, &fpCount)
+    let fpSuccess: Bool
+    if let bottom = stackBottom, let top = stackTop {
+        fpSuccess = emb_stack_walk(thread, bottom, top, &fpFrames, maxFrames, &fpCount)
+    } else {
+        fpSuccess = false
+    }
 
     // Fall back to KSCrash's unwinder if FP walking didn't produce enough
     // frames.

--- a/Sources/EmbraceProfiling/StackCapture.swift
+++ b/Sources/EmbraceProfiling/StackCapture.swift
@@ -17,45 +17,60 @@ import EmbraceProfilingSampler
 /// successful. Below this threshold we fall back to KSCrash's unwinder.
 private let minFPFrames = 3
 
-/// Captures a stack trace from a suspended thread.
+/// Captures a stack trace from a running thread.
 ///
-/// Uses fast frame-pointer walking first. If that yields fewer than
-/// ``minFPFrames`` frames, falls back to KSCrash's `captureBacktrace`
-/// unwinder.
+/// Suspends the target thread, walks its stack, then resumes the thread.
+///
+/// Tries fast frame-pointer walking first. If that yields fewer than ``minFPFrames``
+/// frames, falls back to KSCrash's `captureBacktrace` unwinder.
 ///
 /// Note: KSCrash will support walking a stack without a FP in the next release.
 ///
-/// The thread **must** already be suspended before calling this function.
-///
 /// - Parameters:
-///   - thread: The Mach thread port of the suspended thread.
+///   - thread: The Mach thread port of the thread to capture.
 ///   - maxFrames: Maximum number of frames to capture.
 /// - Returns: A tuple containing the array of return addresses and the method used to capture them.
 func captureStack(thread: thread_t, maxFrames: Int = 512) -> (frames: [UInt], method: StackUnwindMethod) {
-    // Try fast frame-pointer walking first.
-    var frames = [UInt](repeating: 0, count: maxFrames)
-    var count = 0
-    let success = emb_stack_walk(thread, &frames, maxFrames, &count)
+    var fpFrames = [UInt](repeating: 0, count: maxFrames)
+    var ksFrames = [UInt](repeating: 0, count: maxFrames)
+    let pthread = pthread_from_mach_thread_np(thread)
 
-    if success && count >= minFPFrames {
-        return (Array(frames[0..<count]), .framePointer)
+    guard thread_suspend(thread) == KERN_SUCCESS else {
+        return ([], .framePointerPartial)
     }
 
-    // Fall back to KSCrash's unwinder.
-    if let pthread = pthread_from_mach_thread_np(thread) {
-        var ksFrames = [UInt](repeating: 0, count: maxFrames)
-        let ksCount = captureBacktrace(thread: pthread, addresses: &ksFrames, count: Int32(maxFrames))
+    // Only asyn-safe things allowed between suspend and resume.
 
-        if ksCount > 0 {
-            return (Array(ksFrames[0..<Int(ksCount)]), .kscrash)
-        }
+    var fpCount = 0
+    // Common case: Frame pointer is available, so we can fast-walk the stack.
+    let fpSuccess = emb_stack_walk(thread, &fpFrames, maxFrames, &fpCount)
+
+    // Fall back to KSCrash's unwinder if FP walking didn't produce enough
+    // frames.
+    //
+    // `captureBacktrace` currently does its own suspend/resume of the
+    // target thread, but since Mach uses a suspend count, the nested
+    // suspend/resume just bumps the count to 2 and back to 1,
+    // and then our outer resume below takes it to 0. A future KSCrash
+    // release will expose a variant that skips the extra dance.
+    // (see kstenerud/KSCrash#816).
+    var ksCount: Int32 = 0
+    if (!fpSuccess || fpCount < minFPFrames), let pthread = pthread {
+        ksCount = captureBacktrace(thread: pthread, addresses: &ksFrames, count: Int32(maxFrames))
     }
 
-    // Just return whatever FP walking got us.
-    if success && count > 0 {
-        return (Array(frames[0..<count]), .framePointerPartial)
-    }
+    thread_resume(thread)
 
+    // Safe to allocate again.
+    if fpSuccess && fpCount >= minFPFrames {
+        return (Array(fpFrames[0..<fpCount]), .framePointer)
+    }
+    if ksCount > 0 {
+        return (Array(ksFrames[0..<Int(ksCount)]), .kscrash)
+    }
+    if fpSuccess && fpCount > 0 {
+        return (Array(fpFrames[0..<fpCount]), .framePointerPartial)
+    }
     return ([], .framePointerPartial)
 }
 

--- a/Sources/EmbraceProfiling/StackCapture.swift
+++ b/Sources/EmbraceProfiling/StackCapture.swift
@@ -36,7 +36,7 @@ func captureStack(thread: thread_t, maxFrames: Int = 512) -> (frames: [UInt], me
     let pthread = pthread_from_mach_thread_np(thread)
 
     guard thread_suspend(thread) == KERN_SUCCESS else {
-        return ([], .framePointerPartial)
+        return ([], .failed)
     }
 
     // Only asyn-safe things allowed between suspend and resume.
@@ -71,7 +71,7 @@ func captureStack(thread: thread_t, maxFrames: Int = 512) -> (frames: [UInt], me
     if fpSuccess && fpCount > 0 {
         return (Array(fpFrames[0..<fpCount]), .framePointerPartial)
     }
-    return ([], .framePointerPartial)
+    return ([], .failed)
 }
 
 #endif

--- a/Sources/EmbraceProfiling/StackCapture.swift
+++ b/Sources/EmbraceProfiling/StackCapture.swift
@@ -1,0 +1,58 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+import Darwin
+import EmbraceProfilingSampler
+
+#if canImport(KSCrash)
+    import KSCrash
+#else
+    import KSCrashRecording
+#endif
+
+/// Minimum number of frames from frame-pointer walking to consider the walk
+/// successful. Below this threshold we fall back to KSCrash's unwinder.
+private let minFPFrames = 3
+
+/// Captures a stack trace from a suspended thread.
+///
+/// Uses fast frame-pointer walking first. If that yields fewer than
+/// ``minFPFrames`` frames, falls back to KSCrash's `captureBacktrace`
+/// unwinder.
+///
+/// Note: KSCrash will support walking a stack without a FP in the next release.
+///
+/// The thread **must** already be suspended before calling this function.
+///
+/// - Parameters:
+///   - thread: The Mach thread port of the suspended thread.
+///   - maxFrames: Maximum number of frames to capture.
+/// - Returns: An array of return addresses, or an empty array on failure.
+func captureStack(thread: thread_t, maxFrames: Int = 512) -> [UInt] {
+    // Try fast frame-pointer walking first.
+    var frames = [UInt](repeating: 0, count: maxFrames)
+    var count = 0
+    let success = emb_stack_walk(thread, &frames, maxFrames, &count)
+
+    if success && count >= minFPFrames {
+        return Array(frames[0..<count])
+    }
+
+    // Fall back to KSCrash's unwinder.
+    if let pthread = pthread_from_mach_thread_np(thread) {
+        var ksFrames = [UInt](repeating: 0, count: maxFrames)
+        let ksCount = captureBacktrace(thread: pthread, addresses: &ksFrames, count: Int32(maxFrames))
+
+        if ksCount > 0 {
+            return Array(ksFrames[0..<Int(ksCount)])
+        }
+    }
+    
+    // Just return whatever FP walking got us.
+    return success && count > 0 ? Array(frames[0..<count]) : []
+}
+
+#endif

--- a/Sources/EmbraceProfiling/StackCapture.swift
+++ b/Sources/EmbraceProfiling/StackCapture.swift
@@ -30,15 +30,15 @@ private let minFPFrames = 3
 /// - Parameters:
 ///   - thread: The Mach thread port of the suspended thread.
 ///   - maxFrames: Maximum number of frames to capture.
-/// - Returns: An array of return addresses, or an empty array on failure.
-func captureStack(thread: thread_t, maxFrames: Int = 512) -> [UInt] {
+/// - Returns: A tuple containing the array of return addresses and the method used to capture them.
+func captureStack(thread: thread_t, maxFrames: Int = 512) -> (frames: [UInt], method: StackUnwindMethod) {
     // Try fast frame-pointer walking first.
     var frames = [UInt](repeating: 0, count: maxFrames)
     var count = 0
     let success = emb_stack_walk(thread, &frames, maxFrames, &count)
 
     if success && count >= minFPFrames {
-        return Array(frames[0..<count])
+        return (Array(frames[0..<count]), .framePointer)
     }
 
     // Fall back to KSCrash's unwinder.
@@ -47,12 +47,16 @@ func captureStack(thread: thread_t, maxFrames: Int = 512) -> [UInt] {
         let ksCount = captureBacktrace(thread: pthread, addresses: &ksFrames, count: Int32(maxFrames))
 
         if ksCount > 0 {
-            return Array(ksFrames[0..<Int(ksCount)])
+            return (Array(ksFrames[0..<Int(ksCount)]), .kscrash)
         }
     }
-    
+
     // Just return whatever FP walking got us.
-    return success && count > 0 ? Array(frames[0..<count]) : []
+    if success && count > 0 {
+        return (Array(frames[0..<count]), .framePointerPartial)
+    }
+
+    return ([], .framePointerPartial)
 }
 
 #endif

--- a/Sources/EmbraceProfiling/StackCapture.swift
+++ b/Sources/EmbraceProfiling/StackCapture.swift
@@ -24,7 +24,7 @@ private let minFPFrames = 3
 /// Tries fast frame-pointer walking first. If that yields fewer than ``minFPFrames``
 /// frames, falls back to KSCrash's `captureBacktrace` unwinder.
 ///
-/// Note: KSCrash will support walking a stack without a FP in the next release.
+/// Note: KSCrash 2.6.0 will support walking a stack without a FP.
 ///
 /// - Parameters:
 ///   - thread: The Mach thread port of the thread to capture.

--- a/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
@@ -2,6 +2,30 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
+/// Async-safe frame-pointer stack walker for suspended Mach threads.
+///
+/// Principles of operation:
+///
+/// - Calls thread_get_state (a Mach trap) to read the target thread's PC
+///   and frame pointer (FP). The PC becomes the first captured frame.
+/// - Walks the FP chain: each stack frame is a [saved_FP, return_address]
+///   pair. The return address is captured (after stripping ARM64 PAC via
+///   ptrauth_strip), then the walker advances to the saved FP.
+/// - Stops when: max_frames reached, FP leaves the provided stack bounds,
+///   FP is misaligned, return address is NULL, or FP stops ascending
+///   (cycle guard).
+///
+/// Async-safety:
+///
+/// - The only kernel interaction is thread_get_state (a Mach trap, never
+///   blocks). Everything else is pointer arithmetic within caller-provided
+///   stack bounds.
+/// - This is essential because the target thread is suspended and may hold
+///   any userspace lock; the walker must never attempt to acquire one.
+/// - Callers must resolve stack bounds (pthread_get_stackaddr_np /
+///   pthread_get_stacksize_np) *before* suspending the thread, since those
+///   pthread APIs are not async-safe.
+
 #ifndef emb_stack_walker_h
 #define emb_stack_walker_h
 
@@ -22,8 +46,20 @@ extern "C" {
 /// into `frames_out`. At most `max_frames` will be captured. The actual count
 /// is written to `count_out`.
 ///
-/// Returns true on success, false on failure.
+/// Async-safe: only calls `thread_get_state` (a Mach trap) and walks memory
+/// within the provided stack bounds. Callers must resolve stack bounds before
+/// the target thread is suspended (pthread APIs are not async-safe).
+///
+/// @param thread       Mach thread port (must be suspended).
+/// @param stack_bottom Lowest valid stack address.
+/// @param stack_top    Highest valid stack address (pthread_get_stackaddr_np).
+/// @param frames_out   Output buffer for frame addresses.
+/// @param max_frames   Capacity of frames_out.
+/// @param count_out    On return, the number of frames captured.
+/// @return true on success, false on failure.
 bool emb_stack_walk(thread_t thread,
+                    const void *stack_bottom,
+                    const void *stack_top,
                     uintptr_t *frames_out,
                     size_t max_frames,
                     size_t *count_out);

--- a/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
@@ -10,6 +10,8 @@
 #if !TARGET_OS_WATCH
 
 #include <mach/mach_types.h>
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -20,11 +22,11 @@ extern "C" {
 /// into `frames_out`. At most `max_frames` will be captured. The actual count
 /// is written to `count_out`.
 ///
-/// Returns 0 on success, -1 on failure.
-int emb_stack_walk(thread_t thread,
-                   uint64_t *frames_out,
-                   uint32_t max_frames,
-                   uint32_t *count_out);
+/// Returns true on success, false on failure.
+bool emb_stack_walk(thread_t thread,
+                    uintptr_t *frames_out,
+                    size_t max_frames,
+                    size_t *count_out);
 
 #ifdef __cplusplus
 }

--- a/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 /// Async-safe frame-pointer stack walker for suspended Mach threads.

--- a/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
@@ -52,7 +52,7 @@ extern "C" {
 ///
 /// @param thread       Mach thread port (must be suspended).
 /// @param stack_bottom Lowest valid stack address.
-/// @param stack_top    Highest valid stack address (pthread_get_stackaddr_np).
+/// @param stack_top    First address past the top of the stack (treated exclusively); typically the value returned by `pthread_get_stackaddr_np`.
 /// @param frames_out   Output buffer for frame addresses.
 /// @param max_frames   Capacity of frames_out.
 /// @param count_out    On return, the number of frames captured.

--- a/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
@@ -6,16 +6,83 @@
 
 #if !TARGET_OS_WATCH
 
-int emb_stack_walk(thread_t thread,
-                   uint64_t *frames_out,
-                   uint32_t max_frames,
-                   uint32_t *count_out)
+#include <mach/mach.h>
+#include <pthread.h>
+#include <ptrauth.h>
+
+// Architecture-specific thread state access.
+#if defined(__arm64__) || defined(__aarch64__)
+  #define EMB_THREAD_STATE_FLAVOR  ARM_THREAD_STATE64
+  #define EMB_THREAD_STATE_COUNT   ARM_THREAD_STATE64_COUNT
+  typedef arm_thread_state64_t     emb_thread_state_t;
+  #define EMB_GET_PC(s) ((void *)arm_thread_state64_get_pc(s))
+  #define EMB_GET_FP(s) ((void *)arm_thread_state64_get_fp(s))
+#elif defined(__x86_64__)
+  #define EMB_THREAD_STATE_FLAVOR  x86_THREAD_STATE64
+  #define EMB_THREAD_STATE_COUNT   x86_THREAD_STATE64_COUNT
+  typedef x86_thread_state64_t     emb_thread_state_t;
+  #define EMB_GET_PC(s) ((void *)(s).__rip)
+  #define EMB_GET_FP(s) ((void *)(s).__rbp)
+#endif
+
+bool emb_stack_walk(thread_t thread,
+                    uintptr_t *frames_out,
+                    size_t max_frames,
+                    size_t *count_out)
 {
-    (void)thread;
-    (void)frames_out;
-    (void)max_frames;
-    (void)count_out;
-    return -1;
+    if (frames_out == NULL || count_out == NULL || max_frames == 0) {
+        return false;
+    }
+    *count_out = 0;
+
+    emb_thread_state_t state;
+    mach_msg_type_number_t state_count = EMB_THREAD_STATE_COUNT;
+    kern_return_t kr = thread_get_state(thread,
+                                        EMB_THREAD_STATE_FLAVOR,
+                                        (thread_state_t)&state,
+                                        &state_count);
+    if (kr != KERN_SUCCESS) {
+        return false;
+    }
+
+    // Determine the target thread's stack bounds for safe direct dereference.
+    pthread_t target_pthread = pthread_from_mach_thread_np(thread);
+    if (target_pthread == NULL) {
+        return false;
+    }
+    void *stack_top = pthread_get_stackaddr_np(target_pthread);
+    size_t stack_size = pthread_get_stacksize_np(target_pthread);
+    void *stack_bottom = (char *)stack_top - stack_size;
+
+    void *pc = EMB_GET_PC(state);
+    void *fp = EMB_GET_FP(state);
+    size_t count = 0;
+
+    if (pc != NULL) {
+        frames_out[count++] = (uintptr_t)pc;
+    }
+
+    // Walk the frame pointer chain.
+    // Each frame record is: [saved_fp, return_address]
+    while (count < max_frames && fp >= stack_bottom && fp < stack_top) {
+        void **record = (void **)fp;
+        void *next_fp = record[0];
+        void *ret_addr = ptrauth_strip(record[1], ptrauth_key_return_address);
+
+        if (ret_addr == NULL) {
+            break;
+        }
+
+        frames_out[count++] = (uintptr_t)ret_addr;
+
+        if (next_fp == NULL || (uintptr_t)next_fp <= (uintptr_t)fp) {
+            break;
+        }
+        fp = next_fp;
+    }
+
+    *count_out = count;
+    return true;
 }
 
 #endif /* !TARGET_OS_WATCH */

--- a/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #include "emb_stack_walker.h"

--- a/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
@@ -7,7 +7,6 @@
 #if !TARGET_OS_WATCH
 
 #include <mach/mach.h>
-#include <pthread.h>
 #include <ptrauth.h>
 
 // Architecture-specific thread state access.
@@ -26,11 +25,15 @@
 #endif
 
 bool emb_stack_walk(thread_t thread,
+                    const void *stack_bottom,
+                    const void *stack_top,
                     uintptr_t *frames_out,
                     size_t max_frames,
                     size_t *count_out)
 {
-    if (frames_out == NULL || count_out == NULL || max_frames == 0) {
+    if (frames_out == NULL || count_out == NULL || max_frames == 0
+        || stack_bottom == NULL || stack_top == NULL
+        || stack_bottom >= stack_top) {
         return false;
     }
     *count_out = 0;
@@ -45,15 +48,6 @@ bool emb_stack_walk(thread_t thread,
         return false;
     }
 
-    // Determine the target thread's stack bounds for safe direct dereference.
-    pthread_t target_pthread = pthread_from_mach_thread_np(thread);
-    if (target_pthread == NULL) {
-        return false;
-    }
-    void *stack_top = pthread_get_stackaddr_np(target_pthread);
-    size_t stack_size = pthread_get_stacksize_np(target_pthread);
-    void *stack_bottom = (char *)stack_top - stack_size;
-
     void *pc = EMB_GET_PC(state);
     void *fp = EMB_GET_FP(state);
     size_t count = 0;
@@ -64,7 +58,11 @@ bool emb_stack_walk(thread_t thread,
 
     // Walk the frame pointer chain.
     // Each frame record is: [saved_fp, return_address]
-    while (count < max_frames && fp >= stack_bottom && fp < stack_top) {
+    // Frame pointers must be aligned to sizeof(void *) * 2 bytes
+    // (16 bytes on the supported 64-bit architectures).
+    const uintptr_t fp_align_mask = sizeof(void *) * 2 - 1;
+    while (count < max_frames && fp >= stack_bottom && fp < stack_top
+           && ((uintptr_t)fp & fp_align_mask) == 0) {
         void **record = (void **)fp;
         void *next_fp = record[0];
         void *ret_addr = ptrauth_strip(record[1], ptrauth_key_return_address);

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
@@ -4,66 +4,75 @@
 
 #if !os(watchOS)
 
-import Darwin
-import EmbraceProfilingSampler
-import EmbraceProfilingTestSupport
-import XCTest
+    import Darwin
+    import EmbraceProfilingSampler
+    import EmbraceProfilingTestSupport
+    import XCTest
 
-final class StackWalkerBenchmarks: XCTestCase {
+    final class StackWalkerBenchmarks: XCTestCase {
 
-    // MARK: - Helpers
+        // MARK: - Helpers
 
-    /// Number of walks per measured iteration, so the total time is large
-    /// enough for XCTest to report meaningful values.
-    private static let walksPerIteration = 10_000
+        /// Number of walks per measured iteration, so the total time is large
+        /// enough for XCTest to report meaningful values.
+        private static let walksPerIteration = 10_000
 
-    private func walkSuspendedThread(port: thread_t) -> Int {
-        let maxFrames = 1024
-        var frames = [UInt](repeating: 0, count: maxFrames)
-        var count = 0
-        emb_stack_walk(port, &frames, maxFrames, &count)
-        return count
-    }
-
-    private func benchmarkWalk(stackDepth: size_t, label: String) throws {
-        guard let thread = emb_test_thread_create(stackDepth) else {
-            XCTFail("Failed to create test thread")
-            return
+        private func walkSuspendedThread(port: thread_t,
+                                         stackBottom: UnsafeRawPointer,
+                                         stackTop: UnsafeRawPointer) -> Int {
+            let maxFrames = 1024
+            var frames = [UInt](repeating: 0, count: maxFrames)
+            var count = 0
+            emb_stack_walk(port, stackBottom, stackTop, &frames, maxFrames, &count)
+            return count
         }
-        defer { emb_test_thread_destroy(thread) }
-        let port = emb_test_thread_get_port(thread)
 
-        let kr = thread_suspend(port)
-        XCTAssertEqual(kr, KERN_SUCCESS)
-        defer { thread_resume(port) }
+        private func benchmarkWalk(stackDepth: size_t, label: String) throws {
+            guard let thread = emb_test_thread_create(stackDepth) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(thread) }
+            let port = emb_test_thread_get_port(thread)
 
-        let frameCount = walkSuspendedThread(port: port)
-        print("\(label): \(frameCount) frames, \(Self.walksPerIteration) walks per iteration")
+            // Resolve stack bounds before suspending.
+            let pth = pthread_from_mach_thread_np(port)!
+            let top = pthread_get_stackaddr_np(pth)
+            let size = pthread_get_stacksize_np(pth)
+            let stackBottom = UnsafeRawPointer(top - size)
+            let stackTop = UnsafeRawPointer(top)
 
-        measure {
-            for _ in 0..<Self.walksPerIteration {
-                _ = self.walkSuspendedThread(port: port)
+            let kr = thread_suspend(port)
+            XCTAssertEqual(kr, KERN_SUCCESS)
+            defer { thread_resume(port) }
+
+            let frameCount = walkSuspendedThread(port: port, stackBottom: stackBottom, stackTop: stackTop)
+            print("\(label): \(frameCount) frames, \(Self.walksPerIteration) walks per iteration")
+
+            measure {
+                for _ in 0..<Self.walksPerIteration {
+                    _ = self.walkSuspendedThread(port: port, stackBottom: stackBottom, stackTop: stackTop)
+                }
             }
         }
-    }
 
-    // MARK: - Benchmarks
+        // MARK: - Benchmarks
 
-    func test_benchmark_shallowStack() throws {
-        try benchmarkWalk(stackDepth: 10, label: "Shallow stack")
-    }
+        func test_benchmark_shallowStack() throws {
+            try benchmarkWalk(stackDepth: 10, label: "Shallow stack")
+        }
 
-    func test_benchmark_averageStack() throws {
-        try benchmarkWalk(stackDepth: 30, label: "Average stack")
-    }
+        func test_benchmark_averageStack() throws {
+            try benchmarkWalk(stackDepth: 30, label: "Average stack")
+        }
 
-    func test_benchmark_deepStack() throws {
-        try benchmarkWalk(stackDepth: 100, label: "Deep stack")
-    }
+        func test_benchmark_deepStack() throws {
+            try benchmarkWalk(stackDepth: 100, label: "Deep stack")
+        }
 
-    func test_benchmark_veryDeepStack() throws {
-        try benchmarkWalk(stackDepth: 500, label: "Very deep stack")
+        func test_benchmark_veryDeepStack() throws {
+            try benchmarkWalk(stackDepth: 500, label: "Very deep stack")
+        }
     }
-}
 
 #endif

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+import Darwin
+import EmbraceProfilingSampler
+import EmbraceProfilingTestSupport
+import XCTest
+
+final class StackWalkerBenchmarks: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Number of walks per measured iteration, so the total time is large
+    /// enough for XCTest to report meaningful values.
+    private static let walksPerIteration = 10_000
+
+    private func walkSuspendedThread(port: thread_t) -> Int {
+        let maxFrames = 1024
+        var frames = [UInt](repeating: 0, count: maxFrames)
+        var count = 0
+        emb_stack_walk(port, &frames, maxFrames, &count)
+        return count
+    }
+
+    private func benchmarkWalk(stackDepth: size_t, label: String) throws {
+        guard let thread = emb_test_thread_create(stackDepth) else {
+            XCTFail("Failed to create test thread")
+            return
+        }
+        defer { emb_test_thread_destroy(thread) }
+        let port = emb_test_thread_get_port(thread)
+
+        let kr = thread_suspend(port)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        defer { thread_resume(port) }
+
+        let frameCount = walkSuspendedThread(port: port)
+        print("\(label): \(frameCount) frames, \(Self.walksPerIteration) walks per iteration")
+
+        measure {
+            for _ in 0..<Self.walksPerIteration {
+                _ = self.walkSuspendedThread(port: port)
+            }
+        }
+    }
+
+    // MARK: - Benchmarks
+
+    func test_benchmark_shallowStack() throws {
+        try benchmarkWalk(stackDepth: 10, label: "Shallow stack")
+    }
+
+    func test_benchmark_averageStack() throws {
+        try benchmarkWalk(stackDepth: 30, label: "Average stack")
+    }
+
+    func test_benchmark_deepStack() throws {
+        try benchmarkWalk(stackDepth: 100, label: "Deep stack")
+    }
+
+    func test_benchmark_veryDeepStack() throws {
+        try benchmarkWalk(stackDepth: 500, label: "Very deep stack")
+    }
+}
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
@@ -1,0 +1,82 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+import Darwin
+import EmbraceProfilingSampler
+import XCTest
+
+final class StackWalkerTests: XCTestCase {
+
+    func test_stackWalk_capturesFramesFromSuspendedThread() throws {
+        var targetPthread: pthread_t?
+
+        // Spawn a thread that sleeps, giving it a non-trivial stack to walk.
+        let ret = pthread_create(&targetPthread, nil, { _ -> UnsafeMutableRawPointer? in
+            Thread.sleep(forTimeInterval: 5.0)
+            return nil
+        }, nil)
+        XCTAssertEqual(ret, 0, "pthread_create should succeed")
+        guard let targetPthread = targetPthread else {
+            XCTFail("Failed to create thread")
+            return
+        }
+        defer { pthread_join(targetPthread, nil) }
+
+        // Give the thread time to enter sleep.
+        Thread.sleep(forTimeInterval: 0.05)
+
+        let machThread = pthread_mach_thread_np(targetPthread)
+
+        // Suspend the target thread so we can safely walk its stack.
+        let suspendResult = thread_suspend(machThread)
+        XCTAssertEqual(suspendResult, KERN_SUCCESS, "thread_suspend should succeed")
+
+        // Walk the stack.
+        let maxFrames = 512
+        var frames = [UInt](repeating: 0, count: maxFrames)
+        var count = 0
+        let walkResult = emb_stack_walk(machThread, &frames, maxFrames, &count)
+
+        // Resume immediately after walking.
+        let resumeResult = thread_resume(machThread)
+        XCTAssertEqual(resumeResult, KERN_SUCCESS, "thread_resume should succeed")
+
+        // Verify the walk succeeded and produced frames.
+        XCTAssertTrue(walkResult, "emb_stack_walk should succeed")
+        XCTAssertGreaterThan(count, 0, "Should capture at least one frame")
+
+        // Every reported frame address should be non-zero.
+        for i in 0..<count {
+            XCTAssertNotEqual(frames[i], 0, "Frame \(i) should be a non-zero address")
+        }
+    }
+
+    func test_stackWalk_failsWithInvalidThread() {
+        let maxFrames = 64
+        var frames = [UInt](repeating: 0, count: maxFrames)
+        var count = 0
+
+        // Mach thread port 0 is invalid; the walk should fail gracefully.
+        let result = emb_stack_walk(0, &frames, maxFrames, &count)
+        XCTAssertFalse(result, "Should fail with invalid thread")
+        XCTAssertEqual(count, 0)
+    }
+
+    func test_stackWalk_failsWithNullOutputs() {
+        var count = 0
+        let result = emb_stack_walk(mach_thread_self(), nil, 64, &count)
+        XCTAssertFalse(result, "Should fail with null frames_out")
+    }
+
+    func test_stackWalk_failsWithZeroMaxFrames() {
+        var frames = [UInt](repeating: 0, count: 1)
+        var count = 0
+        let result = emb_stack_walk(mach_thread_self(), &frames, 0, &count)
+        XCTAssertFalse(result, "Should fail with max_frames == 0")
+    }
+}
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)
@@ -306,6 +306,47 @@
             XCTAssertFalse(result, "Should fail with null count_out")
 
             thread_resume(port)
+        }
+
+        // MARK: - Additional coverage
+
+        func test_stackWalk_terminatedThread_returnsFalse() {
+            guard let t = emb_test_thread_create(10) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            let port = emb_test_thread_get_port(t)
+            guard let pth = pthread_from_mach_thread_np(port) else {
+                XCTFail("Failed to get pthread")
+                emb_test_thread_destroy(t)
+                return
+            }
+            let bounds = stackBounds(for: pth)
+            emb_test_thread_destroy(t)
+
+            var frames = [UInt](repeating: 0, count: 64)
+            var count = 0
+            let result = emb_stack_walk(port, bounds.bottom, bounds.top, &frames, 64, &count)
+            XCTAssertFalse(result, "Walk on a dead thread port should fail")
+            XCTAssertEqual(count, 0)
+        }
+
+        func test_stackWalk_frameAddresses_areRealistic() {
+            guard let t = emb_test_thread_create(10) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+            let (success, count, frames) = walkTestThread(t)
+            XCTAssertTrue(success)
+            XCTAssertGreaterThan(count, 0)
+            let minPlausibleAddress: UInt = 0x1_0000
+            for (i, frame) in frames.enumerated() {
+                XCTAssertGreaterThan(
+                    frame, minPlausibleAddress,
+                    "Frame \(i) address 0x\(String(frame, radix: 16)) is implausibly low"
+                )
+            }
         }
     }
 

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
@@ -4,79 +4,309 @@
 
 #if !os(watchOS)
 
-import Darwin
-import EmbraceProfilingSampler
-import XCTest
+    import Darwin
+    import EmbraceProfilingSampler
+    import EmbraceProfilingTestSupport
+    import XCTest
 
-final class StackWalkerTests: XCTestCase {
+    final class StackWalkerTests: XCTestCase {
 
-    func test_stackWalk_capturesFramesFromSuspendedThread() throws {
-        var targetPthread: pthread_t?
+        // MARK: - Helpers
 
-        // Spawn a thread that sleeps, giving it a non-trivial stack to walk.
-        let ret = pthread_create(&targetPthread, nil, { _ -> UnsafeMutableRawPointer? in
-            Thread.sleep(forTimeInterval: 5.0)
-            return nil
-        }, nil)
-        XCTAssertEqual(ret, 0, "pthread_create should succeed")
-        guard let targetPthread = targetPthread else {
-            XCTFail("Failed to create thread")
-            return
+        /// Resolve stack bounds for a pthread (safe to call before suspend).
+        private func stackBounds(for pth: pthread_t) -> (bottom: UnsafeRawPointer, top: UnsafeRawPointer) {
+            let top = pthread_get_stackaddr_np(pth)
+            let size = pthread_get_stacksize_np(pth)
+            return (UnsafeRawPointer(top - size), UnsafeRawPointer(top))
         }
-        defer { pthread_join(targetPthread, nil) }
 
-        // Give the thread time to enter sleep.
-        Thread.sleep(forTimeInterval: 0.05)
+        /// Walk the stack of a test thread (suspends, walks, resumes).
+        private func walkTestThread(
+            _ testThread: emb_test_thread_t,
+            maxFrames: Int = 512
+        ) -> (success: Bool, count: Int, frames: [UInt]) {
+            let port = emb_test_thread_get_port(testThread)
+            guard let pth = pthread_from_mach_thread_np(port) else {
+                return (false, 0, [])
+            }
+            let bounds = stackBounds(for: pth)
 
-        let machThread = pthread_mach_thread_np(targetPthread)
+            let suspendResult = thread_suspend(port)
+            guard suspendResult == KERN_SUCCESS else {
+                return (false, 0, [])
+            }
 
-        // Suspend the target thread so we can safely walk its stack.
-        let suspendResult = thread_suspend(machThread)
-        XCTAssertEqual(suspendResult, KERN_SUCCESS, "thread_suspend should succeed")
+            var frames = [UInt](repeating: 0, count: maxFrames)
+            var count = 0
+            let walkResult = emb_stack_walk(port, bounds.bottom, bounds.top,
+                                            &frames, maxFrames, &count)
 
-        // Walk the stack.
-        let maxFrames = 512
-        var frames = [UInt](repeating: 0, count: maxFrames)
-        var count = 0
-        let walkResult = emb_stack_walk(machThread, &frames, maxFrames, &count)
+            thread_resume(port)
+            return (walkResult, count, Array(frames.prefix(count)))
+        }
 
-        // Resume immediately after walking.
-        let resumeResult = thread_resume(machThread)
-        XCTAssertEqual(resumeResult, KERN_SUCCESS, "thread_resume should succeed")
+        // MARK: - Existing tests
 
-        // Verify the walk succeeded and produced frames.
-        XCTAssertTrue(walkResult, "emb_stack_walk should succeed")
-        XCTAssertGreaterThan(count, 0, "Should capture at least one frame")
+        func test_stackWalk_capturesFramesFromSuspendedThread() throws {
+            var targetPthread: pthread_t?
 
-        // Every reported frame address should be non-zero.
-        for i in 0..<count {
-            XCTAssertNotEqual(frames[i], 0, "Frame \(i) should be a non-zero address")
+            // Spawn a thread that sleeps, giving it a non-trivial stack to walk.
+            let ret = pthread_create(
+                &targetPthread, nil,
+                { _ -> UnsafeMutableRawPointer? in
+                    Thread.sleep(forTimeInterval: 5.0)
+                    return nil
+                }, nil)
+            XCTAssertEqual(ret, 0, "pthread_create should succeed")
+            guard let targetPthread = targetPthread else {
+                XCTFail("Failed to create thread")
+                return
+            }
+            defer { pthread_join(targetPthread, nil) }
+
+            // Give the thread time to enter sleep.
+            Thread.sleep(forTimeInterval: 0.05)
+
+            let machThread = pthread_mach_thread_np(targetPthread)
+            let bounds = stackBounds(for: targetPthread)
+
+            // Suspend the target thread so we can safely walk its stack.
+            let suspendResult = thread_suspend(machThread)
+            XCTAssertEqual(suspendResult, KERN_SUCCESS, "thread_suspend should succeed")
+
+            // Walk the stack.
+            let maxFrames = 512
+            var frames = [UInt](repeating: 0, count: maxFrames)
+            var count = 0
+            let walkResult = emb_stack_walk(machThread, bounds.bottom, bounds.top,
+                                            &frames, maxFrames, &count)
+
+            // Resume immediately after walking.
+            let resumeResult = thread_resume(machThread)
+            XCTAssertEqual(resumeResult, KERN_SUCCESS, "thread_resume should succeed")
+
+            // Verify the walk succeeded and produced frames.
+            XCTAssertTrue(walkResult, "emb_stack_walk should succeed")
+            XCTAssertGreaterThan(count, 0, "Should capture at least one frame")
+
+            // Every reported frame address should be non-zero.
+            for i in 0..<count {
+                XCTAssertNotEqual(frames[i], 0, "Frame \(i) should be a non-zero address")
+            }
+        }
+
+        func test_stackWalk_failsWithInvalidThread() {
+            let maxFrames = 64
+            var frames = [UInt](repeating: 0, count: maxFrames)
+            var count = 0
+
+            // Mach thread port 0 is invalid; the walk should fail gracefully.
+            // Provide dummy stack bounds. The call should fail on thread_get_state.
+            let dummy = UnsafeRawPointer(bitPattern: 1)!
+            let dummyTop = UnsafeRawPointer(bitPattern: UInt.max)!
+            let result = emb_stack_walk(0, dummy, dummyTop, &frames, maxFrames, &count)
+            XCTAssertFalse(result, "Should fail with invalid thread")
+            XCTAssertEqual(count, 0)
+        }
+
+        func test_stackWalk_failsWithNullOutputs() {
+            var count = 0
+            let dummy = UnsafeRawPointer(bitPattern: 1)!
+            let dummyTop = UnsafeRawPointer(bitPattern: UInt.max)!
+            let result = emb_stack_walk(mach_thread_self(), dummy, dummyTop, nil, 64, &count)
+            XCTAssertFalse(result, "Should fail with null frames_out")
+        }
+
+        func test_stackWalk_failsWithZeroMaxFrames() {
+            var frames = [UInt](repeating: 0, count: 1)
+            var count = 0
+            let dummy = UnsafeRawPointer(bitPattern: 1)!
+            let dummyTop = UnsafeRawPointer(bitPattern: UInt.max)!
+            let result = emb_stack_walk(mach_thread_self(), dummy, dummyTop, &frames, 0, &count)
+            XCTAssertFalse(result, "Should fail with max_frames == 0")
+        }
+
+        // MARK: - Depth validation tests (using emb_test_thread)
+
+        func test_stackWalk_shallowStack_capturesAtLeastDepth() {
+            guard let t = emb_test_thread_create(10) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let result = walkTestThread(t)
+            XCTAssertTrue(result.success, "Walk should succeed")
+            XCTAssertGreaterThanOrEqual(result.count, 10,
+                "Should capture at least 10 frames for depth-10 stack, got \(result.count)")
+        }
+
+        func test_stackWalk_deepStack_capturesAtLeastDepth() {
+            guard let t = emb_test_thread_create(100) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let result = walkTestThread(t)
+            XCTAssertTrue(result.success, "Walk should succeed")
+            XCTAssertGreaterThanOrEqual(result.count, 100,
+                "Should capture at least 100 frames for depth-100 stack, got \(result.count)")
+        }
+
+        func test_stackWalk_depthIncreases_withStackDepth() {
+            guard let shallow = emb_test_thread_create(10) else {
+                XCTFail("Failed to create shallow test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(shallow) }
+
+            guard let deep = emb_test_thread_create(50) else {
+                XCTFail("Failed to create deep test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(deep) }
+
+            let shallowResult = walkTestThread(shallow)
+            let deepResult = walkTestThread(deep)
+
+            XCTAssertTrue(shallowResult.success && deepResult.success)
+            XCTAssertGreaterThan(deepResult.count, shallowResult.count,
+                "Deeper stack (\(deepResult.count)) should yield more frames than shallow (\(shallowResult.count))")
+        }
+
+        func test_stackWalk_multipleWalks_consistent() {
+            guard let t = emb_test_thread_create(20) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let port = emb_test_thread_get_port(t)
+            guard let pth = pthread_from_mach_thread_np(port) else {
+                XCTFail("Failed to get pthread from mach thread")
+                return
+            }
+            let bounds = stackBounds(for: pth)
+
+            // Suspend once, walk multiple times.
+            let suspendResult = thread_suspend(port)
+            XCTAssertEqual(suspendResult, KERN_SUCCESS)
+
+            var firstFrames: [UInt]?
+            var firstCount = 0
+
+            for i in 0..<5 {
+                let maxFrames = 512
+                var frames = [UInt](repeating: 0, count: maxFrames)
+                var count = 0
+                let ok = emb_stack_walk(port, bounds.bottom, bounds.top,
+                                        &frames, maxFrames, &count)
+                XCTAssertTrue(ok, "Walk \(i) should succeed")
+
+                if let first = firstFrames {
+                    XCTAssertEqual(count, firstCount,
+                        "Walk \(i) count (\(count)) should match first walk (\(firstCount))")
+                    for j in 0..<min(count, firstCount) {
+                        XCTAssertEqual(frames[j], first[j],
+                            "Frame \(j) on walk \(i) should match first walk")
+                    }
+                } else {
+                    firstFrames = Array(frames.prefix(count))
+                    firstCount = count
+                }
+            }
+
+            thread_resume(port)
+        }
+
+        func test_stackWalk_respectsMaxFramesLimit() {
+            guard let t = emb_test_thread_create(100) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let result = walkTestThread(t, maxFrames: 5)
+            XCTAssertTrue(result.success, "Walk should succeed")
+            XCTAssertEqual(result.count, 5,
+                "Should capture exactly max_frames (5) frames, got \(result.count)")
+        }
+
+        // MARK: - Boundary / null parameter tests
+
+        func test_stackWalk_nullStackBounds_returnsFalse() {
+            guard let t = emb_test_thread_create(10) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let port = emb_test_thread_get_port(t)
+            let suspendResult = thread_suspend(port)
+            XCTAssertEqual(suspendResult, KERN_SUCCESS)
+
+            var frames = [UInt](repeating: 0, count: 64)
+            var count = 0
+            // Null stack_bottom.
+            let result = emb_stack_walk(port, nil, UnsafeRawPointer(bitPattern: UInt.max)!,
+                                        &frames, 64, &count)
+            XCTAssertFalse(result, "Should fail with null stack_bottom")
+
+            thread_resume(port)
+        }
+
+        func test_stackWalk_invertedStackBounds_returnsFalse() {
+            guard let t = emb_test_thread_create(10) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let port = emb_test_thread_get_port(t)
+            guard let pth = pthread_from_mach_thread_np(port) else {
+                XCTFail("Failed to get pthread")
+                return
+            }
+            let bounds = stackBounds(for: pth)
+
+            let suspendResult = thread_suspend(port)
+            XCTAssertEqual(suspendResult, KERN_SUCCESS)
+
+            var frames = [UInt](repeating: 0, count: 64)
+            var count = 0
+            // Inverted: bottom > top.
+            let result = emb_stack_walk(port, bounds.top, bounds.bottom,
+                                        &frames, 64, &count)
+            XCTAssertFalse(result, "Should fail with inverted stack bounds")
+
+            thread_resume(port)
+        }
+
+        func test_stackWalk_nullCountOut_returnsFalse() {
+            guard let t = emb_test_thread_create(10) else {
+                XCTFail("Failed to create test thread")
+                return
+            }
+            defer { emb_test_thread_destroy(t) }
+
+            let port = emb_test_thread_get_port(t)
+            guard let pth = pthread_from_mach_thread_np(port) else {
+                XCTFail("Failed to get pthread")
+                return
+            }
+            let bounds = stackBounds(for: pth)
+
+            let suspendResult = thread_suspend(port)
+            XCTAssertEqual(suspendResult, KERN_SUCCESS)
+
+            var frames = [UInt](repeating: 0, count: 64)
+            let result = emb_stack_walk(port, bounds.bottom, bounds.top,
+                                        &frames, 64, nil)
+            XCTAssertFalse(result, "Should fail with null count_out")
+
+            thread_resume(port)
         }
     }
-
-    func test_stackWalk_failsWithInvalidThread() {
-        let maxFrames = 64
-        var frames = [UInt](repeating: 0, count: maxFrames)
-        var count = 0
-
-        // Mach thread port 0 is invalid; the walk should fail gracefully.
-        let result = emb_stack_walk(0, &frames, maxFrames, &count)
-        XCTAssertFalse(result, "Should fail with invalid thread")
-        XCTAssertEqual(count, 0)
-    }
-
-    func test_stackWalk_failsWithNullOutputs() {
-        var count = 0
-        let result = emb_stack_walk(mach_thread_self(), nil, 64, &count)
-        XCTAssertFalse(result, "Should fail with null frames_out")
-    }
-
-    func test_stackWalk_failsWithZeroMaxFrames() {
-        var frames = [UInt](repeating: 0, count: 1)
-        var count = 0
-        let result = emb_stack_walk(mach_thread_self(), &frames, 0, &count)
-        XCTAssertFalse(result, "Should fail with max_frames == 0")
-    }
-}
 
 #endif

--- a/Tests/EmbraceProfilingTestSupport/include/EmbraceProfilingTestSupport.h
+++ b/Tests/EmbraceProfilingTestSupport/include/EmbraceProfilingTestSupport.h
@@ -1,0 +1,10 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#ifndef EmbraceProfilingTestSupport_h
+#define EmbraceProfilingTestSupport_h
+
+#include "emb_test_thread.h"
+
+#endif /* EmbraceProfilingTestSupport_h */

--- a/Tests/EmbraceProfilingTestSupport/include/EmbraceProfilingTestSupport.h
+++ b/Tests/EmbraceProfilingTestSupport/include/EmbraceProfilingTestSupport.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #ifndef EmbraceProfilingTestSupport_h

--- a/Tests/EmbraceProfilingTestSupport/include/emb_test_thread.h
+++ b/Tests/EmbraceProfilingTestSupport/include/emb_test_thread.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #ifndef emb_test_thread_h

--- a/Tests/EmbraceProfilingTestSupport/include/emb_test_thread.h
+++ b/Tests/EmbraceProfilingTestSupport/include/emb_test_thread.h
@@ -1,0 +1,39 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#ifndef emb_test_thread_h
+#define emb_test_thread_h
+
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
+#include <mach/mach_types.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque handle to a test thread.
+typedef struct emb_test_thread *emb_test_thread_t;
+
+/// Create a thread that recurses to the given stack depth then spins.
+/// The thread is running (not suspended) on return.
+/// Returns NULL on failure.
+emb_test_thread_t emb_test_thread_create(size_t stack_depth);
+
+/// Returns the Mach thread port for the test thread.
+thread_t emb_test_thread_get_port(emb_test_thread_t t);
+
+/// Signal the thread to stop and wait for it to exit, then free resources.
+void emb_test_thread_destroy(emb_test_thread_t t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !TARGET_OS_WATCH */
+
+#endif /* emb_test_thread_h */

--- a/Tests/EmbraceProfilingTestSupport/include/module.modulemap
+++ b/Tests/EmbraceProfilingTestSupport/include/module.modulemap
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+module EmbraceProfilingTestSupport {
+    umbrella header "EmbraceProfilingTestSupport.h"
+    export *
+    module * { export * }
+}

--- a/Tests/EmbraceProfilingTestSupport/include/module.modulemap
+++ b/Tests/EmbraceProfilingTestSupport/include/module.modulemap
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 module EmbraceProfilingTestSupport {

--- a/Tests/EmbraceProfilingTestSupport/source/emb_test_thread.c
+++ b/Tests/EmbraceProfilingTestSupport/source/emb_test_thread.c
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #include "emb_test_thread.h"
@@ -8,7 +8,6 @@
 
 #include <pthread.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <mach/mach.h>
 
 struct emb_test_thread {
@@ -16,23 +15,30 @@ struct emb_test_thread {
     thread_t mach_port;
     volatile int running;
     size_t stack_depth;
+    pthread_mutex_t ready_mutex;
+    pthread_cond_t ready_cond;
+    int ready;
 };
 
 // Volatile local prevents tail call optimization, preserving all frames.
 __attribute__((noinline))
-static void recurse(volatile int *flag, size_t depth) {
+static void recurse(struct emb_test_thread *t, size_t depth) {
     volatile size_t anchor = depth;
     if (depth > 0) {
-        recurse(flag, depth - 1);
+        recurse(t, depth - 1);
     } else {
-        while (*flag) { }
+        pthread_mutex_lock(&t->ready_mutex);
+        t->ready = 1;
+        pthread_cond_signal(&t->ready_cond);
+        pthread_mutex_unlock(&t->ready_mutex);
+        while (t->running) { }
     }
     (void)anchor;
 }
 
 static void *thread_entry(void *arg) {
     struct emb_test_thread *t = (struct emb_test_thread *)arg;
-    recurse(&t->running, t->stack_depth);
+    recurse(t, t->stack_depth);
     return NULL;
 }
 
@@ -44,16 +50,24 @@ emb_test_thread_t emb_test_thread_create(size_t stack_depth) {
 
     t->running = 1;
     t->stack_depth = stack_depth;
+    t->ready = 0;
+    pthread_mutex_init(&t->ready_mutex, NULL);
+    pthread_cond_init(&t->ready_cond, NULL);
 
     if (pthread_create(&t->pthread, NULL, thread_entry, t) != 0) {
+        pthread_mutex_destroy(&t->ready_mutex);
+        pthread_cond_destroy(&t->ready_cond);
         free(t);
         return NULL;
     }
 
-    // Let the thread settle into its spin loop.
-    usleep(50000);
-    t->mach_port = pthread_mach_thread_np(t->pthread);
+    pthread_mutex_lock(&t->ready_mutex);
+    while (!t->ready) {
+        pthread_cond_wait(&t->ready_cond, &t->ready_mutex);
+    }
+    pthread_mutex_unlock(&t->ready_mutex);
 
+    t->mach_port = pthread_mach_thread_np(t->pthread);
     return t;
 }
 
@@ -64,6 +78,8 @@ thread_t emb_test_thread_get_port(emb_test_thread_t t) {
 void emb_test_thread_destroy(emb_test_thread_t t) {
     t->running = 0;
     pthread_join(t->pthread, NULL);
+    pthread_mutex_destroy(&t->ready_mutex);
+    pthread_cond_destroy(&t->ready_cond);
     free(t);
 }
 

--- a/Tests/EmbraceProfilingTestSupport/source/emb_test_thread.c
+++ b/Tests/EmbraceProfilingTestSupport/source/emb_test_thread.c
@@ -1,0 +1,70 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#include "emb_test_thread.h"
+
+#if !TARGET_OS_WATCH
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <mach/mach.h>
+
+struct emb_test_thread {
+    pthread_t pthread;
+    thread_t mach_port;
+    volatile int running;
+    size_t stack_depth;
+};
+
+// Volatile local prevents tail call optimization, preserving all frames.
+__attribute__((noinline))
+static void recurse(volatile int *flag, size_t depth) {
+    volatile size_t anchor = depth;
+    if (depth > 0) {
+        recurse(flag, depth - 1);
+    } else {
+        while (*flag) { }
+    }
+    (void)anchor;
+}
+
+static void *thread_entry(void *arg) {
+    struct emb_test_thread *t = (struct emb_test_thread *)arg;
+    recurse(&t->running, t->stack_depth);
+    return NULL;
+}
+
+emb_test_thread_t emb_test_thread_create(size_t stack_depth) {
+    struct emb_test_thread *t = calloc(1, sizeof(*t));
+    if (t == NULL) {
+        return NULL;
+    }
+
+    t->running = 1;
+    t->stack_depth = stack_depth;
+
+    if (pthread_create(&t->pthread, NULL, thread_entry, t) != 0) {
+        free(t);
+        return NULL;
+    }
+
+    // Let the thread settle into its spin loop.
+    usleep(50000);
+    t->mach_port = pthread_mach_thread_np(t->pthread);
+
+    return t;
+}
+
+thread_t emb_test_thread_get_port(emb_test_thread_t t) {
+    return t->mach_port;
+}
+
+void emb_test_thread_destroy(emb_test_thread_t t) {
+    t->running = 0;
+    pthread_join(t->pthread, NULL);
+    free(t);
+}
+
+#endif /* !TARGET_OS_WATCH */

--- a/Tests/EmbraceProfilingTestSupportNoFP/include/EmbraceProfilingTestSupportNoFP.h
+++ b/Tests/EmbraceProfilingTestSupportNoFP/include/EmbraceProfilingTestSupportNoFP.h
@@ -1,0 +1,10 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#ifndef EmbraceProfilingTestSupportNoFP_h
+#define EmbraceProfilingTestSupportNoFP_h
+
+#include "emb_test_thread_nofp.h"
+
+#endif /* EmbraceProfilingTestSupportNoFP_h */

--- a/Tests/EmbraceProfilingTestSupportNoFP/include/EmbraceProfilingTestSupportNoFP.h
+++ b/Tests/EmbraceProfilingTestSupportNoFP/include/EmbraceProfilingTestSupportNoFP.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #ifndef EmbraceProfilingTestSupportNoFP_h

--- a/Tests/EmbraceProfilingTestSupportNoFP/include/emb_test_thread_nofp.h
+++ b/Tests/EmbraceProfilingTestSupportNoFP/include/emb_test_thread_nofp.h
@@ -1,0 +1,40 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#ifndef emb_test_thread_nofp_h
+#define emb_test_thread_nofp_h
+
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
+#include <mach/mach_types.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque handle to a test thread compiled without frame pointers.
+typedef struct emb_test_thread_nofp *emb_test_thread_nofp_t;
+
+/// Create a thread that recurses to the given stack depth then spins.
+/// This target is compiled with -fomit-frame-pointer.
+/// On arm64 the flag is ignored (ABI mandates FPs); on x86_64 it takes effect.
+/// Returns NULL on failure.
+emb_test_thread_nofp_t emb_test_thread_nofp_create(size_t stack_depth);
+
+/// Returns the Mach thread port for the test thread.
+thread_t emb_test_thread_nofp_get_port(emb_test_thread_nofp_t t);
+
+/// Signal the thread to stop and wait for it to exit, then free resources.
+void emb_test_thread_nofp_destroy(emb_test_thread_nofp_t t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !TARGET_OS_WATCH */
+
+#endif /* emb_test_thread_nofp_h */

--- a/Tests/EmbraceProfilingTestSupportNoFP/include/emb_test_thread_nofp.h
+++ b/Tests/EmbraceProfilingTestSupportNoFP/include/emb_test_thread_nofp.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #ifndef emb_test_thread_nofp_h

--- a/Tests/EmbraceProfilingTestSupportNoFP/include/module.modulemap
+++ b/Tests/EmbraceProfilingTestSupportNoFP/include/module.modulemap
@@ -1,0 +1,9 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+module EmbraceProfilingTestSupportNoFP {
+    umbrella header "EmbraceProfilingTestSupportNoFP.h"
+    export *
+    module * { export * }
+}

--- a/Tests/EmbraceProfilingTestSupportNoFP/include/module.modulemap
+++ b/Tests/EmbraceProfilingTestSupportNoFP/include/module.modulemap
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 module EmbraceProfilingTestSupportNoFP {

--- a/Tests/EmbraceProfilingTestSupportNoFP/source/emb_test_thread_nofp.c
+++ b/Tests/EmbraceProfilingTestSupportNoFP/source/emb_test_thread_nofp.c
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 // This file is intentionally compiled with -fomit-frame-pointer (set in

--- a/Tests/EmbraceProfilingTestSupportNoFP/source/emb_test_thread_nofp.c
+++ b/Tests/EmbraceProfilingTestSupportNoFP/source/emb_test_thread_nofp.c
@@ -1,0 +1,73 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+// This file is intentionally compiled with -fomit-frame-pointer (set in
+// Package.swift cSettings for this target). On arm64 the flag is a no-op
+// because the ABI mandates frame pointers; on x86_64 it strips them.
+
+#include "emb_test_thread_nofp.h"
+
+#if !TARGET_OS_WATCH
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <mach/mach.h>
+
+struct emb_test_thread_nofp {
+    pthread_t pthread;
+    thread_t mach_port;
+    volatile int running;
+    size_t stack_depth;
+};
+
+__attribute__((noinline))
+static void recurse_nofp(volatile int *flag, size_t depth) {
+    volatile size_t anchor = depth;
+    if (depth > 0) {
+        recurse_nofp(flag, depth - 1);
+    } else {
+        while (*flag) { }
+    }
+    (void)anchor;
+}
+
+static void *thread_entry_nofp(void *arg) {
+    struct emb_test_thread_nofp *t = (struct emb_test_thread_nofp *)arg;
+    recurse_nofp(&t->running, t->stack_depth);
+    return NULL;
+}
+
+emb_test_thread_nofp_t emb_test_thread_nofp_create(size_t stack_depth) {
+    struct emb_test_thread_nofp *t = calloc(1, sizeof(*t));
+    if (t == NULL) {
+        return NULL;
+    }
+
+    t->running = 1;
+    t->stack_depth = stack_depth;
+
+    if (pthread_create(&t->pthread, NULL, thread_entry_nofp, t) != 0) {
+        free(t);
+        return NULL;
+    }
+
+    // Let the thread settle into its spin loop.
+    usleep(50000);
+    t->mach_port = pthread_mach_thread_np(t->pthread);
+
+    return t;
+}
+
+thread_t emb_test_thread_nofp_get_port(emb_test_thread_nofp_t t) {
+    return t->mach_port;
+}
+
+void emb_test_thread_nofp_destroy(emb_test_thread_nofp_t t) {
+    t->running = 0;
+    pthread_join(t->pthread, NULL);
+    free(t);
+}
+
+#endif /* !TARGET_OS_WATCH */

--- a/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
+++ b/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
@@ -20,12 +20,19 @@ import XCTest
 /// Benchmarks comparing FP-based stack walking vs KSCrash fallback on stacks
 /// compiled with and without frame pointers.
 ///
-/// `-fomit-frame-pointer` takes effect on both arm64 and x86_64 with modern
-/// Clang. When frame pointers are omitted the FP walker loses most frames.
-/// The KSCrash fallback currently also relies on FP chains, so it is not
-/// meaningfully better for fully frameless stacks right now — it is structured
-/// as a fallback in anticipation of KSCrash gaining DWARF-based unwinding
-/// (see TODO below), which will recover full stacks regardless of FP presence.
+/// `-fomit-frame-pointer` takes effect on x86_64, and Apple suppresses it on
+/// arm64, but there are other ways for the FP to be unavailable:
+/// - mid-prologue or mid-epilogue
+/// - in a leaf function before the frame is set up
+/// - hand written assembly
+/// - signal trampolines
+/// - objc_msgSend shenanigans
+/// - game engines, embedded VMs, Unity, Unreal, etc
+/// When frame pointers are omitted the FP walker loses most frames. The
+/// KSCrash fallback currently also relies on FP chains, so it is not
+/// meaningfully better for fully frameless stacks right now. it is structured
+/// as a fallback in anticipation of KSCrash gaining DWARF-based unwinding (see
+/// TODO below), which will recover full stacks regardless of FP presence.
 final class FallbackBenchmarks: XCTestCase {
 
     private static let walksPerIteration = 10_000

--- a/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
+++ b/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
@@ -1,0 +1,169 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+import Darwin
+@testable import EmbraceProfiling
+import EmbraceProfilingSampler
+import EmbraceProfilingTestSupport
+import EmbraceProfilingTestSupportNoFP
+import XCTest
+
+#if canImport(KSCrash)
+    import KSCrash
+#else
+    import KSCrashRecording
+#endif
+
+/// Benchmarks comparing FP-based stack walking vs KSCrash fallback on stacks
+/// compiled with and without frame pointers.
+///
+/// `-fomit-frame-pointer` takes effect on both arm64 and x86_64 with modern
+/// Clang. When frame pointers are omitted, both the FP walker and KSCrash's
+/// `captureBacktrace` lose most frames (both use FP chain walking internally).
+/// A DWARF-based unwinder would be needed for true frameless code support.
+final class FallbackBenchmarks: XCTestCase {
+
+    private static let walksPerIteration = 10_000
+    private static let stackDepth: size_t = 30
+    private static let maxFrames = 512
+
+    // MARK: - Helpers
+
+    private func walkWithFP(port: thread_t) -> Int {
+        var frames = [UInt](repeating: 0, count: Self.maxFrames)
+        var count = 0
+        emb_stack_walk(port, &frames, Self.maxFrames, &count)
+        return count
+    }
+
+    private func walkWithKSCrash(port: thread_t) -> Int {
+        guard let pthread = pthread_from_mach_thread_np(port) else { return 0 }
+        var frames = [UInt](repeating: 0, count: Self.maxFrames)
+        let count = captureBacktrace(thread: pthread, addresses: &frames, count: Int32(Self.maxFrames))
+        return Int(count)
+    }
+
+    private func walkWithFallback(port: thread_t) -> Int {
+        let frames = captureStack(thread: port, maxFrames: Self.maxFrames)
+        return frames.count
+    }
+
+    // MARK: - Normal stack (with frame pointers)
+
+    func test_benchmark_fpWalk_normalStack() throws {
+        guard let thread = emb_test_thread_create(Self.stackDepth) else {
+            XCTFail("Failed to create test thread")
+            return
+        }
+        defer { emb_test_thread_destroy(thread) }
+        let port = emb_test_thread_get_port(thread)
+
+        let kr = thread_suspend(port)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        defer { thread_resume(port) }
+
+        let frameCount = walkWithFP(port: port)
+        print("FP walk (normal stack): \(frameCount) frames")
+
+        measure {
+            for _ in 0..<Self.walksPerIteration {
+                _ = self.walkWithFP(port: port)
+            }
+        }
+    }
+
+    func test_benchmark_kscrash_normalStack() throws {
+        guard let thread = emb_test_thread_create(Self.stackDepth) else {
+            XCTFail("Failed to create test thread")
+            return
+        }
+        defer { emb_test_thread_destroy(thread) }
+        let port = emb_test_thread_get_port(thread)
+
+        let kr = thread_suspend(port)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        defer { thread_resume(port) }
+
+        let frameCount = walkWithKSCrash(port: port)
+        print("KSCrash walk (normal stack): \(frameCount) frames")
+
+        measure {
+            for _ in 0..<Self.walksPerIteration {
+                _ = self.walkWithKSCrash(port: port)
+            }
+        }
+    }
+
+    // MARK: - No-FP stack (compiled with -fomit-frame-pointer)
+
+    func test_benchmark_fpWalk_noFPStack() throws {
+        guard let thread = emb_test_thread_nofp_create(Self.stackDepth) else {
+            XCTFail("Failed to create no-FP test thread")
+            return
+        }
+        defer { emb_test_thread_nofp_destroy(thread) }
+        let port = emb_test_thread_nofp_get_port(thread)
+
+        let kr = thread_suspend(port)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        defer { thread_resume(port) }
+
+        let frameCount = walkWithFP(port: port)
+        print("FP walk (no-FP stack): \(frameCount) frames — on arm64 this should match the normal stack")
+
+        measure {
+            for _ in 0..<Self.walksPerIteration {
+                _ = self.walkWithFP(port: port)
+            }
+        }
+    }
+
+    func test_benchmark_kscrash_noFPStack() throws {
+        guard let thread = emb_test_thread_nofp_create(Self.stackDepth) else {
+            XCTFail("Failed to create no-FP test thread")
+            return
+        }
+        defer { emb_test_thread_nofp_destroy(thread) }
+        let port = emb_test_thread_nofp_get_port(thread)
+
+        let kr = thread_suspend(port)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        defer { thread_resume(port) }
+
+        let frameCount = walkWithKSCrash(port: port)
+        print("KSCrash walk (no-FP stack): \(frameCount) frames")
+
+        measure {
+            for _ in 0..<Self.walksPerIteration {
+                _ = self.walkWithKSCrash(port: port)
+            }
+        }
+    }
+
+    func test_benchmark_fallback_noFPStack() throws {
+        guard let thread = emb_test_thread_nofp_create(Self.stackDepth) else {
+            XCTFail("Failed to create no-FP test thread")
+            return
+        }
+        defer { emb_test_thread_nofp_destroy(thread) }
+        let port = emb_test_thread_nofp_get_port(thread)
+
+        let kr = thread_suspend(port)
+        XCTAssertEqual(kr, KERN_SUCCESS)
+        defer { thread_resume(port) }
+
+        let frameCount = walkWithFallback(port: port)
+        print("Fallback (no-FP stack): \(frameCount) frames — tries FP first, falls back to KSCrash")
+
+        measure {
+            for _ in 0..<Self.walksPerIteration {
+                _ = self.walkWithFallback(port: port)
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
+++ b/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)
@@ -21,9 +21,11 @@ import XCTest
 /// compiled with and without frame pointers.
 ///
 /// `-fomit-frame-pointer` takes effect on both arm64 and x86_64 with modern
-/// Clang. When frame pointers are omitted, both the FP walker and KSCrash's
-/// `captureBacktrace` lose most frames (both use FP chain walking internally).
-/// A DWARF-based unwinder would be needed for true frameless code support.
+/// Clang. When frame pointers are omitted the FP walker loses most frames.
+/// The KSCrash fallback currently also relies on FP chains, so it is not
+/// meaningfully better for fully frameless stacks right now — it is structured
+/// as a fallback in anticipation of KSCrash gaining DWARF-based unwinding
+/// (see TODO below), which will recover full stacks regardless of FP presence.
 final class FallbackBenchmarks: XCTestCase {
 
     private static let walksPerIteration = 10_000
@@ -32,10 +34,17 @@ final class FallbackBenchmarks: XCTestCase {
 
     // MARK: - Helpers
 
-    private func walkWithFP(port: thread_t) -> Int {
+    private func resolveStackBounds(port: thread_t) -> (bottom: UnsafeRawPointer, top: UnsafeRawPointer)? {
+        guard let pth = pthread_from_mach_thread_np(port) else { return nil }
+        let top = pthread_get_stackaddr_np(pth)
+        let size = pthread_get_stacksize_np(pth)
+        return (UnsafeRawPointer(top - size), UnsafeRawPointer(top))
+    }
+
+    private func walkWithFP(port: thread_t, stackBottom: UnsafeRawPointer, stackTop: UnsafeRawPointer) -> Int {
         var frames = [UInt](repeating: 0, count: Self.maxFrames)
         var count = 0
-        emb_stack_walk(port, &frames, Self.maxFrames, &count)
+        emb_stack_walk(port, stackBottom, stackTop, &frames, Self.maxFrames, &count)
         return count
     }
 
@@ -61,16 +70,21 @@ final class FallbackBenchmarks: XCTestCase {
         defer { emb_test_thread_destroy(thread) }
         let port = emb_test_thread_get_port(thread)
 
+        guard let bounds = resolveStackBounds(port: port) else {
+            XCTFail("Failed to resolve stack bounds")
+            return
+        }
+
         let kr = thread_suspend(port)
         XCTAssertEqual(kr, KERN_SUCCESS)
         defer { thread_resume(port) }
 
-        let frameCount = walkWithFP(port: port)
+        let frameCount = walkWithFP(port: port, stackBottom: bounds.bottom, stackTop: bounds.top)
         print("FP walk (normal stack): \(frameCount) frames")
 
         measure {
             for _ in 0..<Self.walksPerIteration {
-                _ = self.walkWithFP(port: port)
+                _ = self.walkWithFP(port: port, stackBottom: bounds.bottom, stackTop: bounds.top)
             }
         }
     }
@@ -107,16 +121,21 @@ final class FallbackBenchmarks: XCTestCase {
         defer { emb_test_thread_nofp_destroy(thread) }
         let port = emb_test_thread_nofp_get_port(thread)
 
+        guard let bounds = resolveStackBounds(port: port) else {
+            XCTFail("Failed to resolve stack bounds")
+            return
+        }
+
         let kr = thread_suspend(port)
         XCTAssertEqual(kr, KERN_SUCCESS)
         defer { thread_resume(port) }
 
-        let frameCount = walkWithFP(port: port)
+        let frameCount = walkWithFP(port: port, stackBottom: bounds.bottom, stackTop: bounds.top)
         print("FP walk (no-FP stack): \(frameCount) frames — on arm64 this should match the normal stack")
 
         measure {
             for _ in 0..<Self.walksPerIteration {
-                _ = self.walkWithFP(port: port)
+                _ = self.walkWithFP(port: port, stackBottom: bounds.bottom, stackTop: bounds.top)
             }
         }
     }

--- a/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
+++ b/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
@@ -47,8 +47,8 @@ final class FallbackBenchmarks: XCTestCase {
     }
 
     private func walkWithFallback(port: thread_t) -> Int {
-        let frames = captureStack(thread: port, maxFrames: Self.maxFrames)
-        return frames.count
+        let result = captureStack(thread: port, maxFrames: Self.maxFrames)
+        return result.frames.count
     }
 
     // MARK: - Normal stack (with frame pointers)

--- a/Tests/ProfilingBenchmarkRunner/main.swift
+++ b/Tests/ProfilingBenchmarkRunner/main.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 // Standalone benchmark runner for profiling stack walkers.

--- a/Tests/ProfilingBenchmarkRunner/main.swift
+++ b/Tests/ProfilingBenchmarkRunner/main.swift
@@ -1,0 +1,169 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+// Standalone benchmark runner for profiling stack walkers.
+// Build: swift build --product ProfilingBenchmarkRunner --disable-sandbox
+// Run:   .build/arm64-apple-macosx/debug/ProfilingBenchmarkRunner
+
+#if !os(watchOS)
+
+import Darwin
+import EmbraceProfilingSampler
+import EmbraceProfilingTestSupport
+import EmbraceProfilingTestSupportNoFP
+
+#if canImport(KSCrash)
+    import KSCrash
+#else
+    import KSCrashRecording
+#endif
+
+// MARK: - Configuration
+
+let iterations = 10_000
+let maxFrames = 512
+let stackDepth: size_t = 30
+
+// MARK: - Helpers
+
+func timeBlock(body: () -> Void) -> Double {
+    // Warm up
+    body()
+
+    var best = Double.infinity
+    for _ in 0..<5 {
+        let start = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        body()
+        let end = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+        let elapsed = Double(end - start) / 1e9
+        best = min(best, elapsed)
+    }
+    return best
+}
+
+func walkFP(port: thread_t) -> Int {
+    var frames = [UInt](repeating: 0, count: maxFrames)
+    var count = 0
+    emb_stack_walk(port, &frames, maxFrames, &count)
+    return count
+}
+
+func walkKSCrash(port: thread_t) -> Int {
+    guard let pthread = pthread_from_mach_thread_np(port) else { return 0 }
+    var frames = [UInt](repeating: 0, count: maxFrames)
+    let count = captureBacktrace(thread: pthread, addresses: &frames, count: Int32(maxFrames))
+    return Int(count)
+}
+
+struct BenchResult {
+    let label: String
+    let frames: Int
+    let totalSeconds: Double
+    let perWalkNs: Double
+}
+
+func benchmark(label: String, port: thread_t, walker: (thread_t) -> Int) -> BenchResult {
+    let frameCount = walker(port)
+    let elapsed = timeBlock {
+        for _ in 0..<iterations {
+            _ = walker(port)
+        }
+    }
+    let perWalk = (elapsed / Double(iterations)) * 1e9
+    return BenchResult(label: label, frames: frameCount, totalSeconds: elapsed, perWalkNs: perWalk)
+}
+
+func printResult(_ r: BenchResult) {
+    let perWalkUs = r.perWalkNs / 1000.0
+    let paddedLabel = r.label.padding(toLength: 40, withPad: " ", startingAt: 0)
+    print("  \(paddedLabel)  \(String(format: "%3d", r.frames)) frames  \(String(format: "%8.1f", r.perWalkNs)) ns/walk  (\(String(format: "%6.2f", perWalkUs)) µs/walk)")
+}
+
+func withSuspendedThread(port: thread_t, body: () -> Void) {
+    let kr = thread_suspend(port)
+    precondition(kr == KERN_SUCCESS, "thread_suspend failed: \(kr)")
+    body()
+    thread_resume(port)
+}
+
+// MARK: - Run benchmarks
+
+print("Stack Walker Fallback Benchmarks")
+print("================================")
+print("Iterations per measurement: \(iterations)")
+print("Stack depth: \(stackDepth)")
+#if arch(arm64)
+print("CPU: arm64")
+#elseif arch(x86_64)
+print("CPU: x86_64")
+#endif
+print()
+
+// --- Normal stack (with frame pointers) ---
+print("Normal stack (compiled with frame pointers):")
+
+guard let normalThread = emb_test_thread_create(stackDepth) else {
+    fatalError("Failed to create normal test thread")
+}
+let normalPort = emb_test_thread_get_port(normalThread)
+
+var fpNormal: BenchResult!
+var ksNormal: BenchResult!
+withSuspendedThread(port: normalPort) {
+    fpNormal = benchmark(label: "FP walk", port: normalPort, walker: walkFP)
+    ksNormal = benchmark(label: "KSCrash captureBacktrace", port: normalPort, walker: walkKSCrash)
+}
+printResult(fpNormal)
+printResult(ksNormal)
+emb_test_thread_destroy(normalThread)
+
+// --- No-FP stack (compiled with -fomit-frame-pointer) ---
+print()
+print("No-FP stack (compiled with -fomit-frame-pointer):")
+
+guard let nofpThread = emb_test_thread_nofp_create(stackDepth) else {
+    fatalError("Failed to create no-FP test thread")
+}
+let nofpPort = emb_test_thread_nofp_get_port(nofpThread)
+
+var fpNofp: BenchResult!
+var ksNofp: BenchResult!
+withSuspendedThread(port: nofpPort) {
+    fpNofp = benchmark(label: "FP walk", port: nofpPort, walker: walkFP)
+    ksNofp = benchmark(label: "KSCrash captureBacktrace", port: nofpPort, walker: walkKSCrash)
+}
+printResult(fpNofp)
+printResult(ksNofp)
+emb_test_thread_nofp_destroy(nofpThread)
+
+// --- Summary ---
+print()
+print("Summary:")
+print("--------")
+
+let fpSpeedup = ksNormal.perWalkNs / fpNormal.perWalkNs
+print("  FP walk is \(String(format: "%.1f", fpSpeedup))x faster than KSCrash on normal stacks")
+
+if fpNofp.frames < fpNormal.frames {
+    let loss = (1.0 - Double(fpNofp.frames) / Double(fpNormal.frames)) * 100
+    print("  FP walk captured \(fpNofp.frames)/\(fpNormal.frames) frames on no-FP stack (\(String(format: "%.0f", loss))% loss)")
+
+    if ksNofp.frames > fpNofp.frames {
+        print("  KSCrash recovered \(ksNofp.frames) frames on no-FP stack (vs \(fpNofp.frames) from FP walk)")
+        print("  → KSCrash fallback provides value")
+    } else {
+        print("  KSCrash also captured only \(ksNofp.frames) frames (it also uses FP walking)")
+        print("  → KSCrash fallback does NOT help for frameless code")
+        print("  → A DWARF-based unwinder would be needed for true frameless support")
+    }
+} else {
+    print("  FP walk captured same frames on both stacks (-fomit-frame-pointer had no effect)")
+    print("  → KSCrash fallback would NOT activate on this architecture")
+}
+
+print()
+
+#else
+print("Benchmarks not available on watchOS")
+#endif


### PR DESCRIPTION
Replaced the stub emb_stack_walk with a real implementation that reads thread state (arm64 + x86_64), walks the frame pointer chain with ptrauth stripping, and uses stack bounds to guard against unsafe memory access.

The frame type is now uintptr_t rather than uint64_t for better C spec adherence (this is mostly cosmetic since all pointers on Apple hardware is 64 bits now).

The tests can be run with and without frame pointers (EmbraceProfilingTestSupportNoFP target), but these won't pass until KSCrash is updated.

Added sampler benchmark tests which will also measure no-frame-pointer fallback mode once available.

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
