### PR TITLE
[EMBR-11325] Fix: Fix missing metric kit symbol when compiling with 26.4 and running 26.2 or below

### DIFF
--- a/Sources/EmbraceCommonInternal/MetricKitSpan.swift
+++ b/Sources/EmbraceCommonInternal/MetricKitSpan.swift
@@ -53,7 +53,7 @@ import os
             self.name = name
             self.signpostId = signpostId
             if let signpostId {
-                mxSignpost(.begin, log: Self.log, name: name, signpostID: signpostId)
+                os_signpost(.begin, log: Self.log, name: name, signpostID: signpostId)
             }
         }
 


### PR DESCRIPTION
To reproduce: compile the app with xcode 26.4 and run it on a device or simulator running 26.2 or below.

SDK 26.4 has changed `mxSignpost` and the compiler injects a new parameter that is not available on 26.2 or below, triggering a "symbol not found" crash when executing the app. 

This PR replaces the call to `mxSignpost` to `os_singpost` with the same signature, which is what `mxSignpost` was wrapping to in the first place, resolving the issue.