### PR TITLE
[EMBR-11373] Fix: Fix crash when launchign on arm64_32 devices

### DIFF
--- a/Sources/EmbraceCommonInternal/Storage/Model/EmbraceSession.swift
+++ b/Sources/EmbraceCommonInternal/Storage/Model/EmbraceSession.swift
@@ -17,7 +17,7 @@ public protocol EmbraceSession {
     var coldStart: Bool { get }
     var cleanExit: Bool { get }
     var appTerminated: Bool { get }
-    var sessionNumber: Int { get }
+    var sessionNumber: EMBInt { get }
 }
 
 extension EmbraceSession {

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -44,7 +44,7 @@ struct SessionSpanUtils {
         from session: EmbraceSession,
         spanData: SpanData? = nil,
         properties: [EmbraceMetadata] = [],
-        sessionNumber: Int
+        sessionNumber: EMBInt
     ) -> SpanPayload {
         return SpanPayload(from: session, spanData: spanData, properties: properties, sessionNumber: sessionNumber)
     }
@@ -55,7 +55,7 @@ extension SpanPayload {
         from session: EmbraceSession,
         spanData: SpanData? = nil,
         properties: [EmbraceMetadata],
-        sessionNumber: Int
+        sessionNumber: EMBInt
     ) {
         self.traceId = session.traceId
         self.spanId = session.spanId

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Metadata.swift
@@ -300,19 +300,19 @@ extension EmbraceStorage {
 
     /// Increments the numeric value by 1 of a permanent resource for the given key.
     /// If no record exists it will create one with a value of 1.
-    public func incrementCountForPermanentResource(key: String) -> Int {
+    public func incrementCountForPermanentResource(key: String) -> EMBInt {
         coreData.performOperation(save: true) { context in
             // fetch existing metadata
             let request = fetchMetadataRequest(key: key, type: .requiredResource, lifespan: .permanent)
 
             // update it if it exists
             if let metadata = fetchMetadata(request: request, context: context) {
-                let val = (Int(metadata.value) ?? 0) + 1
+                let val = (EMBInt(metadata.value) ?? 0) + 1
                 metadata.value = String(val)
                 return val
                 // create it with a value of 1 if it doesn't exist
             } else {
-                let val = 1
+                let val: EMBInt = 1
                 _ = MetadataRecord.create(
                     context: context,
                     key: key,

--- a/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
+++ b/Sources/EmbraceStorageInternal/Records/EmbraceStorage+Session.swift
@@ -38,7 +38,7 @@ extension EmbraceStorage {
         coldStart: Bool = false,
         cleanExit: Bool = false,
         appTerminated: Bool = false,
-        sessionNumber: Int = 0,
+        sessionNumber: EMBInt = 0,
         completion: (() -> Void)? = nil
     ) -> EmbraceSession? {
 

--- a/Sources/EmbraceStorageInternal/Records/SessionRecord.swift
+++ b/Sources/EmbraceStorageInternal/Records/SessionRecord.swift
@@ -32,7 +32,7 @@ public class SessionRecord: NSManagedObject {
     @NSManaged public var appTerminated: Bool
 
     /// The value of the `emb.session.upload_index` counter at the time this session was created
-    @NSManaged public var sessionNumber: Int
+    @NSManaged public var sessionNumber: EMBInt
 
     /// Note that this must be called within a `perform` on the CoreData context.
     class func create(
@@ -49,7 +49,7 @@ public class SessionRecord: NSManagedObject {
         coldStart: Bool = false,
         cleanExit: Bool = false,
         appTerminated: Bool = false,
-        sessionNumber: Int = 0
+        sessionNumber: EMBInt = 0
     ) -> Bool {
         guard let description = NSEntityDescription.entity(forEntityName: Self.entityName, in: context) else {
             return false
@@ -193,5 +193,5 @@ struct ImmutableSessionRecord: EmbraceSession {
     let coldStart: Bool
     let cleanExit: Bool
     let appTerminated: Bool
-    let sessionNumber: Int
+    let sessionNumber: EMBInt
 }


### PR DESCRIPTION
The new `sessionNumber` record is Int which is 64 bit on arm64 devices, but 32 bit on arm64_32 devices like most Apple Watches. This causes a crash when trying to read it from the db as a `integer64AttributeType`. This PR uses the `EMBInt` macro for this record which turns it into Int64 when compiling for arm64_32, fixing the problem.
