### PR TITLE
Add lock-free ring buffer implementation for profiling samples

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -340,7 +340,8 @@ let package = Package(
 
         // profiling ----------------------------------------------------------------
         .target(
-            name: "EmbraceProfilingSampler"
+            name: "EmbraceProfilingSampler",
+            publicHeadersPath: "include"
         ),
         .target(
             name: "EmbraceProfiling",

--- a/Sources/EmbraceProfilingSampler/include/EmbraceProfilingSampler.h
+++ b/Sources/EmbraceProfilingSampler/include/EmbraceProfilingSampler.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #ifndef EmbraceProfilingSampler_h

--- a/Sources/EmbraceProfilingSampler/include/EmbraceProfilingSampler.h
+++ b/Sources/EmbraceProfilingSampler/include/EmbraceProfilingSampler.h
@@ -5,6 +5,7 @@
 #ifndef EmbraceProfilingSampler_h
 #define EmbraceProfilingSampler_h
 
+#include "emb_ring_buffer.h"
 #include "emb_stack_walker.h"
 #include "emb_sampler.h"
 

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 /// Lock-free ring buffer for holding stack trace samples.

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -11,6 +11,7 @@
 
 #include <stdbool.h>
 #include <stdatomic.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -1,0 +1,121 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#ifndef emb_ring_buffer_h
+#define emb_ring_buffer_h
+
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Ring buffer for profiling stack trace samples.
+///
+/// Single-writer, multiple-reader. The write path is async-safe (no heap
+/// allocation, no locks). Readers are not async-safe and may retry.
+///
+/// Uses a VM double-mapping trick: the same physical pages are mapped at two
+/// contiguous virtual addresses. A write that straddles the end of the buffer
+/// wraps to the beginning transparently, with no special-case code.
+///
+/// DESIGN ASSUMPTIONS:
+/// - There will only ever be one writer, and multiple concurrent readers.
+/// - The writer will not write often enough to cause more than one torn read for any given reader.
+///   Officially, the minimum is 1ms between writes, even though it could likely handle tighter cadence.
+typedef struct {
+    uint8_t *data;               // Double-mapped virtual region (2 × capacity).
+    size_t capacity;             // Usable buffer size in bytes (page-aligned).
+    uint64_t next_seq;           // Writer-local seqlock counter (single-writer).
+    _Atomic uint64_t write_pos;  // Monotonically increasing write position.
+    _Atomic uint64_t oldest_pos; // Position of the oldest surviving record.
+} emb_ring_buffer_t;
+
+/// Create a ring buffer.
+///
+/// This function is not async-safe.
+///
+/// @param capacity_bytes Minimum usable capacity; rounded up to a page boundary.
+/// @return A newly allocated buffer, or NULL on failure.
+emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes);
+
+/// Destroy a ring buffer and release all VM and heap resources.
+///
+/// This function is not async-safe.
+///
+/// Safe to call with NULL.
+void emb_ring_buffer_destroy(emb_ring_buffer_t *buf);
+
+/// Write a record to the ring buffer. Evicts old records if necessary.
+///
+/// Copies the frame data into the buffer and makes it visible to readers.
+///
+/// This function is async-safe.
+///
+/// Invariants:
+/// - Only one concurrent writer
+/// - Minimum 1ms between writes
+/// - Less than 1 million stack trace frames
+///
+/// @param buf The ring buffer.
+/// @param timestamp_ns Monotonic timestamp (nanoseconds).
+/// @param frames Array of frame addresses to copy.
+/// @param frame_count Number of frames in the array. Must not exceed UINT32_MAX.
+/// @return true if the write succeeded, false if buf or frames is NULL.
+bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
+                           uint64_t timestamp_ns,
+                           const uintptr_t *frames,
+                           size_t frame_count);
+
+/// Consumer-facing record (returned by read functions).
+typedef struct {
+    uint64_t timestamp_ns;   // Monotonic timestamp (nanoseconds).
+    size_t frame_count;      // Number of frames in this sample.
+    const uintptr_t *frames; // Frame addresses (points into allocation).
+} emb_ring_record_t;
+
+/// Result from a read operation.
+typedef struct {
+    emb_ring_record_t *records; // Array of records.
+    size_t count;               // Number of valid records.
+} emb_ring_read_result_t;
+
+/// Read records from the ring buffer within a time range.
+///
+/// Returns records with timestamps in the range [start_ns, end_ns].
+/// Use end_ns = UINT64_MAX to read up to the current write position.
+///
+/// Returns a single allocation containing the record array and frame data.
+/// Free with emb_ring_read_result_free().
+///
+/// This function is not async-safe.
+///
+/// @param buf The ring buffer.
+/// @param start_ns Start timestamp (inclusive, nanoseconds).
+/// @param end_ns End timestamp (inclusive, nanoseconds). Use UINT64_MAX for "up to now".
+/// @return Result containing matching records. count=0 if empty, out of range, or buf is NULL.
+emb_ring_read_result_t emb_ring_buffer_read_range(const emb_ring_buffer_t *buf,
+                                                   uint64_t start_ns,
+                                                   uint64_t end_ns);
+
+/// Free a buffer read result.
+///
+/// This function is not async-safe.
+///
+/// Safe to call with a zeroed result (records=NULL).
+void emb_ring_read_result_free(emb_ring_read_result_t *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !TARGET_OS_WATCH */
+
+#endif /* emb_ring_buffer_h */

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -2,6 +2,30 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
+/// Lock-free ring buffer for holding stack trace samples.
+///
+/// Single-writer, multiple-reader. All functions are async-safe except for
+/// create and destroy.
+///
+/// In order to keep memory churn to a minimum, a caller must pass in a buffer
+/// to receive the data when reading. The caller (in our case, ProfilingEngine)
+/// maintains its own persistent read buffer of the same size as this ring buffer,
+/// and then in turn provides smaller allocations to its callers, with its own
+/// concurrency guarantees.
+///
+/// CAPACITY GUIDANCE:
+/// The buffer is designed for records much smaller than the total capacity.
+/// Individual records (header + frames) should be less than 25% of the
+/// buffer size to guarantee safe reads with a write interval down to 1ms.
+/// Concurrent reads may see torn data if a record size approaches the
+/// buffer capacity and/or frequency is too high, because the writer could
+/// overwrite the record mid-read.
+///
+/// DESIGN ASSUMPTIONS:
+/// - There will only ever be one writer, and multiple concurrent readers.
+/// - The writer will not write often enough to cause more than one torn read for any given reader.
+///   Officially, the minimum is 1ms between writes, even though it could likely handle tighter cadence.
+
 #ifndef emb_ring_buffer_h
 #define emb_ring_buffer_h
 
@@ -18,30 +42,56 @@
 extern "C" {
 #endif
 
-/// Ring buffer for profiling stack trace samples.
-///
-/// Single-writer, multiple-reader. The write path is async-safe (no heap
-/// allocation, no locks). Readers are not async-safe and may retry.
-///
-/// Uses a VM double-mapping trick: the same physical pages are mapped at two
-/// contiguous virtual addresses. A write that straddles the end of the buffer
-/// wraps to the beginning transparently, with no special-case code.
-///
-/// DESIGN ASSUMPTIONS:
-/// - There will only ever be one writer, and multiple concurrent readers.
-/// - The writer will not write often enough to cause more than one torn read for any given reader.
-///   Officially, the minimum is 1ms between writes, even though it could likely handle tighter cadence.
 typedef struct {
     uint8_t *data;               // Double-mapped virtual region (2 × capacity).
     size_t capacity;             // Usable buffer size in bytes (page-aligned).
     uint64_t next_seq;           // Writer-local seqlock counter (single-writer).
     _Atomic uint64_t write_pos;  // Monotonically increasing write position.
     _Atomic uint64_t oldest_pos; // Position of the oldest surviving record.
+    _Atomic uint32_t active_readers; // Number of concurrent read_range calls (for reset safety).
+    _Atomic bool resetting;      // True while reset is in progress.
+                                 // Uses Dekker-style mutual exclusion with active_readers:
+                                 // both sides use seq_cst to prevent ARM64 store-buffer
+                                 // reordering. See emb_ring_buffer_reset and read_range.
 } emb_ring_buffer_t;
+
+/// Public facing view of the record header stored in the ring buffer.
+/// We do this to simplify reading the records. It's expected that the caller would
+/// then convert the retrieved records to a more suitable user-facing format.
+///
+/// Each record consists of this header followed by `frame_count` values of
+/// type `uintptr_t` (the captured frame addresses). Use `emb_ring_record_size`
+/// to compute the total byte size of a record.
+///
+/// The `seq` field is an internal seqlock value used for torn-read detection,
+/// and callers should ignore it.
+typedef struct {
+    uint32_t seq;          // Internal seqlock value (ignore).
+    uint32_t frame_count;  // Number of frames following this header.
+    uint64_t timestamp_ns; // Monotonic timestamp (nanoseconds).
+} emb_ring_record_header_t;
+
+// The record layout assumes 64-bit pointers (uintptr_t == 8 bytes).
+// The Swift layer reads frame data as UInt (also 8 bytes on 64-bit).
+// Catch any hypothetical 32-bit platform at compile time.
+_Static_assert(sizeof(uintptr_t) == 8,
+               "Ring buffer record layout requires 64-bit pointers");
+
+/// Compute the total byte size of a record with the given frame count.
+static inline size_t emb_ring_record_size(uint32_t frame_count) {
+    return sizeof(emb_ring_record_header_t) + (size_t)frame_count * sizeof(uintptr_t);
+}
+
+/// Result from a read operation.
+typedef struct {
+    size_t records_offset; // Offset in bytes to the first matching record.
+    size_t record_count;   // Number of matching records written to the output buffer.
+    size_t total_bytes;    // Total size in bytes of the matching record set.
+} emb_ring_read_result_t;
 
 /// Create a ring buffer.
 ///
-/// This function is not async-safe.
+/// This function is NOT async-safe.
 ///
 /// @param capacity_bytes Minimum usable capacity; rounded up to a page boundary.
 /// @return A newly allocated buffer, or NULL on failure.
@@ -49,10 +99,30 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes);
 
 /// Destroy a ring buffer and release all VM and heap resources.
 ///
-/// This function is not async-safe.
+/// This function is NOT async-safe.
 ///
 /// Safe to call with NULL.
 void emb_ring_buffer_destroy(emb_ring_buffer_t *buf);
+
+/// Reset a ring buffer, clearing all data and resetting positions.
+///
+/// The caller must ensure no concurrent writer is active.
+///
+/// Returns false if buf is NULL or if readers are active.
+///
+/// @return true if the buffer was successfully reset, false otherwise.
+bool emb_ring_buffer_reset(emb_ring_buffer_t *buf);
+
+/// Return the usable capacity of the ring buffer in bytes.
+///
+/// This is the page-aligned capacity, which may be larger than the value
+/// passed to emb_ring_buffer_create.
+///
+/// This function is async-safe.
+///
+/// @param buf The ring buffer. Returns 0 if NULL.
+/// @return Capacity in bytes, or 0 if buf is NULL.
+size_t emb_ring_buffer_capacity(const emb_ring_buffer_t *buf);
 
 /// Write a record to the ring buffer. Evicts old records if necessary.
 ///
@@ -63,7 +133,6 @@ void emb_ring_buffer_destroy(emb_ring_buffer_t *buf);
 /// Invariants:
 /// - Only one concurrent writer
 /// - Minimum 1ms between writes
-/// - Less than 1 million stack trace frames
 ///
 /// @param buf The ring buffer.
 /// @param timestamp_ns Monotonic timestamp (nanoseconds).
@@ -75,43 +144,37 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
                            const uintptr_t *frames,
                            size_t frame_count);
 
-/// Consumer-facing record (returned by read functions).
-typedef struct {
-    uint64_t timestamp_ns;   // Monotonic timestamp (nanoseconds).
-    size_t frame_count;      // Number of frames in this sample.
-    const uintptr_t *frames; // Frame addresses (points into allocation).
-} emb_ring_record_t;
-
-/// Result from a read operation.
-typedef struct {
-    emb_ring_record_t *records; // Array of records.
-    size_t count;               // Number of valid records.
-} emb_ring_read_result_t;
-
 /// Read records from the ring buffer within a time range.
 ///
-/// Returns records with timestamps in the range [start_ns, end_ns].
-/// Use end_ns = UINT64_MAX to read up to the current write position.
+/// Scans the live buffer to locate the matching time range, then copies only
+/// the matching records into the caller-provided output buffer. This avoids
+/// copying the entire ring buffer contents for small time ranges.
 ///
-/// Returns a single allocation containing the record array and frame data.
-/// Free with emb_ring_read_result_free().
+/// Walk the results starting at `output + result.offset`, casting to
+/// `emb_ring_record_header_t *`, reading `frame_count`, advancing by
+/// `emb_ring_record_size(frame_count)`, and repeating for `result.count`
+/// records.
 ///
-/// This function is not async-safe.
+/// The output buffer must be large enough to hold the matching records.
+/// Using `emb_ring_buffer_capacity(buf)` bytes guarantees all possible
+/// results fit. A smaller buffer will truncate the results.
+///
+/// Returns empty immediately if the buffer is currently being reset.
+///
+/// This function is async-safe.
 ///
 /// @param buf The ring buffer.
 /// @param start_ns Start timestamp (inclusive, nanoseconds).
 /// @param end_ns End timestamp (inclusive, nanoseconds). Use UINT64_MAX for "up to now".
-/// @return Result containing matching records. count=0 if empty, out of range, or buf is NULL.
-emb_ring_read_result_t emb_ring_buffer_read_range(const emb_ring_buffer_t *buf,
+/// @param output Caller-provided output buffer.
+/// @param output_size Size of the output buffer in bytes.
+/// @return Result containing count and total bytes written. count=0 if empty,
+///         out of range, buf is NULL, output is NULL, or a reset is in progress.
+emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
                                                    uint64_t start_ns,
-                                                   uint64_t end_ns);
-
-/// Free a buffer read result.
-///
-/// This function is not async-safe.
-///
-/// Safe to call with a zeroed result (records=NULL).
-void emb_ring_read_result_free(emb_ring_read_result_t *result);
+                                                   uint64_t end_ns,
+                                                   uint8_t *output,
+                                                   size_t output_size);
 
 #ifdef __cplusplus
 }

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -33,10 +33,28 @@
 
 #if !TARGET_OS_WATCH
 
+#include <mach/kern_return.h>
 #include <stdbool.h>
 #include <stdatomic.h>
 #include <stddef.h>
 #include <stdint.h>
+
+/// Status codes returned by emb_ring_buffer_write.
+typedef enum {
+    EMB_RING_WRITE_OK                  = 0,
+    EMB_RING_WRITE_BAD_ARGS            = 1,
+    EMB_RING_WRITE_RECORD_TOO_LARGE    = 2,
+    EMB_RING_WRITE_CORRUPTION_DETECTED = 3,
+} emb_ring_write_status_t;
+
+/// Status codes returned in emb_ring_read_result_t.
+typedef enum {
+    EMB_RING_READ_OK        = 0,
+    EMB_RING_READ_BAD_ARGS  = 1,
+    EMB_RING_READ_RESETTING = 2,
+    EMB_RING_READ_EMPTY     = 3,
+    EMB_RING_READ_TRUNCATED = 4,
+} emb_ring_read_status_t;
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,9 +102,10 @@ static inline size_t emb_ring_record_size(uint32_t frame_count) {
 
 /// Result from a read operation.
 typedef struct {
-    size_t records_offset; // Offset in bytes to the first matching record.
-    size_t record_count;   // Number of matching records written to the output buffer.
-    size_t total_bytes;    // Total size in bytes of the matching record set.
+    size_t records_offset;         // Offset in bytes to the first matching record.
+    size_t record_count;           // Number of matching records written to the output buffer.
+    size_t total_bytes;            // Total size in bytes of the matching record set.
+    emb_ring_read_status_t status; // Status code describing the outcome.
 } emb_ring_read_result_t;
 
 /// Create a ring buffer.
@@ -94,8 +113,9 @@ typedef struct {
 /// This function is NOT async-safe.
 ///
 /// @param capacity_bytes Minimum usable capacity; rounded up to a page boundary.
+/// @param kr_out  On failure, receives the kern_return_t that caused the error. May be NULL.
 /// @return A newly allocated buffer, or NULL on failure.
-emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes);
+emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes, kern_return_t *kr_out);
 
 /// Destroy a ring buffer and release all VM and heap resources.
 ///
@@ -138,11 +158,14 @@ size_t emb_ring_buffer_capacity(const emb_ring_buffer_t *buf);
 /// @param timestamp_ns Monotonic timestamp (nanoseconds).
 /// @param frames Array of frame addresses to copy.
 /// @param frame_count Number of frames in the array. Must not exceed UINT32_MAX.
-/// @return true if the write succeeded, false if buf or frames is NULL.
-bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
-                           uint64_t timestamp_ns,
-                           const uintptr_t *frames,
-                           size_t frame_count);
+/// @return EMB_RING_WRITE_OK on success; EMB_RING_WRITE_BAD_ARGS if buf or frames is NULL or
+///         frame_count exceeds UINT32_MAX; EMB_RING_WRITE_RECORD_TOO_LARGE if the record does
+///         not fit in the buffer; EMB_RING_WRITE_CORRUPTION_DETECTED if a corrupted header was
+///         found during eviction.
+emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
+                                               uint64_t timestamp_ns,
+                                               const uintptr_t *frames,
+                                               size_t frame_count);
 
 /// Read records from the ring buffer within a time range.
 ///
@@ -150,9 +173,9 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
 /// the matching records into the caller-provided output buffer. This avoids
 /// copying the entire ring buffer contents for small time ranges.
 ///
-/// Walk the results starting at `output + result.offset`, casting to
+/// Walk the results starting at `output + result.records_offset`, casting to
 /// `emb_ring_record_header_t *`, reading `frame_count`, advancing by
-/// `emb_ring_record_size(frame_count)`, and repeating for `result.count`
+/// `emb_ring_record_size(frame_count)`, and repeating for `result.record_count`
 /// records.
 ///
 /// The output buffer must be large enough to hold the matching records.
@@ -168,8 +191,9 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
 /// @param end_ns End timestamp (inclusive, nanoseconds). Use UINT64_MAX for "up to now".
 /// @param output Caller-provided output buffer.
 /// @param output_size Size of the output buffer in bytes.
-/// @return Result containing count and total bytes written. count=0 if empty,
-///         out of range, buf is NULL, output is NULL, or a reset is in progress.
+/// @return Result containing count, total bytes written, and a status code.
+///         record_count=0 if empty, out of range, buf is NULL, output is NULL, or
+///         a reset is in progress. Check result.status for the specific reason.
 emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
                                                    uint64_t start_ns,
                                                    uint64_t end_ns,

--- a/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #include "emb_ring_buffer.h"
@@ -111,7 +111,8 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
 
     remap_succeeded = true;
 
-    // Sanity-check: VM_FLAGS_FIXED should guarantee the address didn't move.
+    // Sanity-check: with VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE this branch is
+    // unreachable — the kernel must place the mapping at the requested address.
     if (second_half != region + half) {
         goto fail;
     }
@@ -219,7 +220,9 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
 
     // Current write position (monotonically increasing byte offset).
     uint64_t write_pos = atomic_load_explicit(&buf->write_pos, memory_order_relaxed);
-    uint64_t oldest_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+    // relaxed: the writer is the only thread that advances oldest_pos, so no
+    // synchronisation is needed here — we only need our own prior stores.
+    uint64_t oldest_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_relaxed);
 
     // Evict old records that would be overlapped by this write.
     // The loop condition: oldest_pos + capacity < write_pos + record_size
@@ -281,7 +284,7 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     // Set seq to odd (writing). Release ordering ensures this store is visible
     // to readers before any subsequent data writes, which is necessary for
     // correct seqlock protocol on weakly-ordered architectures (ARM64).
-    atomic_store_explicit(&header->seq, buf->next_seq | 1, memory_order_release);
+    atomic_store_explicit(&header->seq, (uint32_t)(buf->next_seq | 1), memory_order_release);
 
     // Copy frame data into the buffer.
     uintptr_t *dest_frames = (uintptr_t *)(header + 1);
@@ -292,7 +295,7 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     header->timestamp_ns = timestamp_ns;
 
     // Seal the seqlock (transition to even = stable).
-    atomic_store_explicit(&header->seq, buf->next_seq, memory_order_release);
+    atomic_store_explicit(&header->seq, (uint32_t)buf->next_seq, memory_order_release);
 
     // Advance write_pos by the actual record size.
     atomic_store_explicit(&buf->write_pos, write_pos + record_size(frame_count), memory_order_release);

--- a/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
@@ -8,26 +8,9 @@
 
 #include <mach/mach.h>
 #include <mach/vm_map.h>
+#include <os/log.h>
 #include <stdlib.h>
 #include <string.h>
-
-// Internal record header layout (stored in the ring buffer).
-typedef struct {
-    _Atomic uint32_t seq;  // Seqlock: odd = writing, even = stable.
-    uint32_t frame_count;  // Number of frames in this record.
-    uint64_t timestamp_ns; // Monotonic timestamp.
-} emb_ring_record_header_t;
-
-static const size_t header_size = sizeof(emb_ring_record_header_t);
-static const size_t frame_size = sizeof(((emb_ring_record_t *)0)->frames[0]);
-static const size_t unbelievable_frame_count = 1000000;
-
-/// Calculate the size of a record with the given number of frames.
-/// This will work out to the header size + 8 bytes per frame.
-static inline size_t record_size(size_t frame_count)
-{
-    return header_size + frame_size * frame_count;
-}
 
 // mach_vm_* functions are macOS-only; on iOS/tvOS we use vm_* equivalents
 #if TARGET_OS_OSX
@@ -44,6 +27,35 @@ typedef vm_size_t emb_vm_size_t;
 #define emb_vm_remap vm_remap
 #define emb_vm_deallocate vm_deallocate
 #endif
+
+// Internal write header with atomic seq for the seqlock protocol.
+// Layout-compatible with the public emb_ring_record_header_t.
+typedef struct {
+    _Atomic uint32_t seq;
+    uint32_t frame_count;
+    uint64_t timestamp_ns;
+} emb_ring_write_header_t;
+
+_Static_assert(sizeof(emb_ring_write_header_t) == sizeof(emb_ring_record_header_t),
+               "write header must match public header layout");
+_Static_assert(_Alignof(emb_ring_write_header_t) == _Alignof(emb_ring_record_header_t),
+               "write header alignment must match public header");
+_Static_assert(offsetof(emb_ring_write_header_t, seq) == offsetof(emb_ring_record_header_t, seq),
+               "seq offset mismatch");
+_Static_assert(offsetof(emb_ring_write_header_t, frame_count) == offsetof(emb_ring_record_header_t, frame_count),
+               "frame_count offset mismatch");
+_Static_assert(offsetof(emb_ring_write_header_t, timestamp_ns) == offsetof(emb_ring_record_header_t, timestamp_ns),
+               "timestamp_ns offset mismatch");
+
+static const size_t header_size = sizeof(emb_ring_record_header_t);
+static const size_t frame_size = sizeof(uintptr_t);
+
+/// Calculate the size of a record with the given number of frames.
+/// This will work out to the header size + 8 bytes per frame.
+static inline size_t record_size(size_t frame_count)
+{
+    return header_size + frame_size * frame_count;
+}
 
 static size_t round_size_up_to_page_boundary(size_t size)
 {
@@ -63,9 +75,9 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
     // so writes past the end of the first half seamlessly wrap around.
     const emb_vm_size_t half = (emb_vm_size_t)capacity;
     const emb_vm_size_t region_size = half * 2;
- 
+
     bool remap_succeeded = false;
- 
+
     emb_vm_address_t region = 0;
     kern_return_t kr = emb_vm_allocate(mach_task_self(),
                                        &region,
@@ -74,14 +86,14 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
     if (kr != KERN_SUCCESS) {
         return NULL;
     }
- 
+
     // Remap the first half's physical pages over the second half.
     // copy = false so both halves share the same physical pages rather than
     // getting an independent copy.
     emb_vm_address_t second_half = region + half;
     vm_prot_t cur_prot = VM_PROT_NONE;
     vm_prot_t max_prot = VM_PROT_NONE;
- 
+
     kr = emb_vm_remap(mach_task_self(),
                       &second_half,
                       half,
@@ -96,27 +108,29 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
     if (kr != KERN_SUCCESS) {
         goto fail;
     }
- 
+
     remap_succeeded = true;
- 
+
     // Sanity-check: VM_FLAGS_FIXED should guarantee the address didn't move.
     if (second_half != region + half) {
         goto fail;
     }
- 
+
     emb_ring_buffer_t *buf = calloc(1, sizeof(*buf));
     if (buf == NULL) {
         goto fail;
     }
- 
+
     buf->data       = (uint8_t *)region;
     buf->capacity   = capacity;
     buf->next_seq   = 0;
     atomic_store_explicit(&buf->write_pos,  0, memory_order_relaxed);
     atomic_store_explicit(&buf->oldest_pos, 0, memory_order_relaxed);
- 
+    atomic_store_explicit(&buf->active_readers, 0, memory_order_relaxed);
+    atomic_store_explicit(&buf->resetting, false, memory_order_relaxed);
+
     return buf;
- 
+
 fail:
     if (remap_succeeded) {
         // After vm_remap with VM_FLAGS_OVERWRITE the region may have been split
@@ -128,6 +142,8 @@ fail:
         // second half before failing, so we can only safely free the first half.
         // The second half is either still part of the original allocation (and
         // this covers it) or already gone.
+        // Note: vm_deallocate on XNU handles partially-mapped ranges gracefully,
+        // so passing the full region_size is safe even if parts are already gone.
         emb_vm_deallocate(mach_task_self(), region, region_size);
     }
     return NULL;
@@ -146,12 +162,50 @@ void emb_ring_buffer_destroy(emb_ring_buffer_t *buf)
     free(buf);
 }
 
+bool emb_ring_buffer_reset(emb_ring_buffer_t *buf)
+{
+    if (buf == NULL) {
+        return false;
+    }
+
+    // Dekker-style mutual exclusion with read_range:
+    // Both sides use seq_cst on their respective flag/counter to prevent
+    // ARM64 store-buffer reordering (the classic two-flag pattern).
+    atomic_store_explicit(&buf->resetting, true, memory_order_seq_cst);
+
+    if (atomic_load_explicit(&buf->active_readers, memory_order_seq_cst) > 0) {
+        atomic_store_explicit(&buf->resetting, false, memory_order_seq_cst);
+        return false;
+    }
+
+    memset(buf->data, 0, buf->capacity);
+    buf->next_seq = 0;
+    atomic_store_explicit(&buf->write_pos, 0, memory_order_release);
+    atomic_store_explicit(&buf->oldest_pos, 0, memory_order_release);
+
+    atomic_store_explicit(&buf->resetting, false, memory_order_seq_cst);
+    return true;
+}
+
+size_t emb_ring_buffer_capacity(const emb_ring_buffer_t *buf)
+{
+    if (buf == NULL) {
+        return 0;
+    }
+    return buf->capacity;
+}
+
 bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
                            uint64_t timestamp_ns,
                            const uintptr_t *frames,
                            size_t frame_count)
 {
-    if (buf == NULL || frames == NULL || frame_count > unbelievable_frame_count) {
+    if (buf == NULL || (frames == NULL && frame_count > 0)) {
+        return false;
+    }
+
+    // The header stores frame_count as uint32_t.
+    if (frame_count > UINT32_MAX) {
         return false;
     }
 
@@ -159,8 +213,6 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     size_t record_size_needed = record_size(frame_count);
 
     // A single record must fit within the buffer capacity.
-    // Should never happen since we check against unbelievable_frame_count,
-    // but good just in case a future change allows it to slip through.
     if (record_size_needed > buf->capacity) {
         return false;
     }
@@ -174,25 +226,61 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     // This means the oldest record would be overwritten.
     while (oldest_pos + buf->capacity < write_pos + record_size_needed) {
         // Read the header of the oldest record to determine its size.
+        // Safe: we're the single writer and this is our own committed record.
         size_t offset = oldest_pos % buf->capacity;
-        emb_ring_record_header_t *old_header = (emb_ring_record_header_t *)(buf->data + offset);
-
-        // Read frame_count (relaxed is safe: we're the single writer and this
-        // is an old committed record).
+        emb_ring_write_header_t *old_header = (emb_ring_write_header_t *)(buf->data + offset);
         size_t old_frame_count = old_header->frame_count;
+        size_t old_record_size = record_size(old_frame_count);
+
+        // Guard against corrupted headers (e.g. bit flip, stale VM page).
+        // A valid record is always <= capacity (enforced by the write path).
+        // On corruption, evict everything to prevent cascading garbage reads.
+        if (old_record_size > buf->capacity) {
+            oldest_pos = write_pos;
+            atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
+            break;
+        }
 
         // Advance oldest_pos past this record.
-        oldest_pos += record_size(old_frame_count);
+        oldest_pos += old_record_size;
 
         // Publish the new oldest_pos.
         atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
     }
 
-    // Now that space is guaranteed, mark the record as "writing" via seqlock.
-    size_t offset = write_pos % buf->capacity;
-    emb_ring_record_header_t *header = (emb_ring_record_header_t *)(buf->data + offset);
+    // Full barrier: ensures the oldest_pos advance(s) above are globally visible
+    // before the data writes below. Without this, ARM64's weak ordering allows
+    // subsequent stores (the memcpy into evicted space) to become visible to
+    // readers before the oldest_pos release store, causing undetectable torn reads
+    // for readers that use oldest_pos to guard against eviction.
+    //
+    // Concrete failure without this fence:
+    //   Writer                           Reader
+    //   ------                           ------
+    //   memcpy(new data over old)        load oldest_pos → sees OLD value
+    //   store(oldest_pos, release)       read header at old position → TORN
+    //
+    // ARM64 allows the memcpy stores to become globally visible before the
+    // release store to oldest_pos. The reader sees oldest_pos unchanged,
+    // concludes its position is safe, but the data has already been
+    // overwritten. The seq_cst fence closes this window.
+    atomic_thread_fence(memory_order_seq_cst);
 
-    // Set seq to odd (writing).
+    // Now that space is guaranteed, mark the record as "writing" via seqlock.
+    //
+    // NOTE: The seqlock (odd seq = writing, even seq = stable) is an advisory
+    // defence-in-depth mechanism. Primary read correctness comes from the
+    // oldest_pos protocol in emb_ring_buffer_read_range, which checks whether
+    // the writer has evicted the reader's position. The seq field provides an
+    // additional signal that readers can use to detect a mid-write record, but
+    // the read path does NOT rely on a full seqlock acquire/release handshake
+    // for data consistency.
+    size_t offset = write_pos % buf->capacity;
+    emb_ring_write_header_t *header = (emb_ring_write_header_t *)(buf->data + offset);
+
+    // Set seq to odd (writing). Release ordering ensures this store is visible
+    // to readers before any subsequent data writes, which is necessary for
+    // correct seqlock protocol on weakly-ordered architectures (ARM64).
     atomic_store_explicit(&header->seq, buf->next_seq | 1, memory_order_release);
 
     // Copy frame data into the buffer.
@@ -215,179 +303,234 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     return true;
 }
 
-typedef struct {
-    uint64_t start;
-    uint64_t end;
-    size_t count;
-} buffer_range;
-
-static buffer_range find_range(const emb_ring_buffer_t *buf,
-                               uint64_t low_pos,
-                               uint64_t high_pos,
-                               uint64_t start_ns,
-                               uint64_t end_ns)
-{
-    const buffer_range not_found = {0};
-    const size_t capacity = buf->capacity;
-    uint8_t *data = buf->data;
-    buffer_range range = {0};
-    uint64_t pos = low_pos;
-
-    // Find start (leading edge of first record where time >= start_ns)
-    while (pos < high_pos) {
-        size_t offset = pos % capacity;
-        emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data + offset);
-        uint64_t timestamp_ns = header->timestamp_ns;
-        size_t frame_count = header->frame_count;
-
-        if (frame_count > unbelievable_frame_count) {
-            return not_found;
-        }
-
-        if (timestamp_ns >= start_ns) {
-            break;
-        }
-
-        pos += record_size(frame_count);
-    }
-
-    if(pos >= high_pos) {
-        return not_found;
-    }
-    range.start = pos;
-
-    // Find end (trailing edge of last record where time <= end_ns)
-    while (pos < high_pos) {
-        size_t offset = pos % capacity;
-        emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data + offset);
-        uint64_t timestamp_ns = header->timestamp_ns;
-        size_t frame_count = header->frame_count;
-
-        if (frame_count > unbelievable_frame_count) {
-            return not_found;
-        }
-        if (timestamp_ns < start_ns) {
-            break;
-        }
-
-        if (timestamp_ns > end_ns) {
-            break;
-        }
-        range.count++;
-
-        pos += record_size(frame_count);
-    }
-    range.end = pos;
-    return range;
+/// Read a record header directly from the live ring buffer at the given
+/// absolute position. The double-mapping guarantees contiguous access.
+static inline emb_ring_record_header_t read_live_header(emb_ring_buffer_t *buf,
+                                                         uint64_t absolute_pos) {
+    size_t offset = (size_t)(absolute_pos % buf->capacity);
+    const emb_ring_record_header_t *hdr =
+        (const emb_ring_record_header_t *)(buf->data + offset);
+    return *hdr;
 }
 
-emb_ring_read_result_t emb_ring_buffer_read_range(const emb_ring_buffer_t *buf,
+emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
                                                    uint64_t start_ns,
-                                                   uint64_t end_ns)
+                                                   uint64_t end_ns,
+                                                   uint8_t *output,
+                                                   size_t output_size)
 {
-    emb_ring_read_result_t result = {NULL, 0};
+    emb_ring_read_result_t result = {0};
 
-    if (buf == NULL) {
+    if (buf == NULL || output == NULL || output_size == 0) {
         return result;
     }
 
-    const uint64_t initial_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
-    const uint64_t initial_end_pos = atomic_load_explicit(&buf->write_pos, memory_order_acquire);
+    // Track active readers so emb_ring_buffer_reset can detect concurrent use.
+    atomic_fetch_add_explicit(&buf->active_readers, 1, memory_order_seq_cst);
 
-    if (initial_start_pos >= initial_end_pos) {
-        // Buffer is empty.
-        return result;
-    }
-    
-    buffer_range range = find_range(buf, initial_start_pos, initial_end_pos, start_ns, end_ns);
-
-    const uint64_t snapshot_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
-    const uint64_t snapshot_end_pos = atomic_load_explicit(&buf->write_pos, memory_order_acquire);
-    
-    if(snapshot_start_pos != initial_start_pos || snapshot_end_pos != initial_end_pos) {
-        // Torn read while computing range, so find it again.
-        // This is safe because we have only one periodic writer, so we won't get torn again.
-        range = find_range(buf, snapshot_start_pos, snapshot_end_pos, start_ns, end_ns);
-    }
-
-    if (range.count == 0) {
+    // Dekker-style check: after incrementing active_readers (seq_cst),
+    // check if a reset is in progress. The seq_cst on both sides prevents
+    // ARM64 store-buffer reordering that could let both sides miss each other.
+    if (atomic_load_explicit(&buf->resetting, memory_order_seq_cst)) {
+        atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
         return result;
     }
 
-    // Allocate space for record array + raw data.
-    const size_t record_array_byte_count = range.count * sizeof(emb_ring_record_t);
-    const size_t data_byte_count = range.end - range.start;
-    if (data_byte_count > buf->capacity) {
-        // If the write frequency invariant is violated and we tear more than once in a bad way, we'll catch it here.
-        return result;
-    }
-    uint8_t *allocation = malloc(record_array_byte_count + data_byte_count);
-    if (allocation == NULL) {
+    // Snapshot the occupied region boundaries.
+    uint64_t oldest_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+    const uint64_t write_pos = atomic_load_explicit(&buf->write_pos, memory_order_acquire);
+
+    if (oldest_pos >= write_pos) {
+        atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
         return result;
     }
 
-    emb_ring_record_t *records = (emb_ring_record_t *)allocation;
-    uint8_t *data_region = allocation + record_array_byte_count;
-
-    // Copy the raw data in one memcpy (safe due to double-mapping).
-    memcpy(data_region, buf->data + range.start % buf->capacity, data_byte_count);
-
-    const uint64_t current_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
-    uint64_t pos = 0;
-    if (current_start_pos > range.start) {
-        // Data at the front was evicted during the copy, so exclude it.
-        const uint64_t eviction_delta = current_start_pos - range.start;
-        if (eviction_delta >= (uint64_t)data_byte_count) {
-            // The entire copied window is stale.
-            free(allocation);
-            return result;
-        }
-        pos = (size_t)eviction_delta;
+    const size_t total_data = (size_t)(write_pos - oldest_pos);
+    if (total_data > buf->capacity) {
+        atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
+        return result;
     }
 
-    size_t valid_count = 0;
+    // ========================================================================
+    // Phase 1: Scan live buffer headers to find the byte range to copy.
+    //
+    // THREE-LAYER CORRECTNESS MODEL:
+    //
+    // 1. PRIMARY (write_pos): scan_pos never advances past write_pos. This
+    //    prevents reading uncommitted records. The record_size > (write_pos -
+    //    scan_pos) check catches corrupted frame_count values that would
+    //    extend past committed data.
+    //
+    // 2. EVICTION SAFETY (oldest_pos + seq_cst fence): Before and after
+    //    reading each header, we check whether oldest_pos has advanced past
+    //    our scan_pos. The seq_cst fence in the write path guarantees that
+    //    if we observe oldest_pos unchanged, the data at our position has
+    //    not been overwritten. If oldest_pos has advanced, we skip forward.
+    //
+    // 3. ADVISORY (seqlock seq field): The odd-seq check (hdr.seq & 1)
+    //    provides defense-in-depth torn-read detection, but the read path
+    //    does NOT rely on a full seqlock acquire/release handshake for data
+    //    consistency. It is a belt-and-suspenders signal: if we happen to
+    //    read a header mid-write, the odd seq causes us to stop scanning
+    //    rather than parse garbage.
+    //
+    // Records between oldest_pos and write_pos are committed (even seq, stable
+    // data). The writer only writes at write_pos. The seq_cst fence in the
+    // write path guarantees that if we observe oldest_pos unchanged after
+    // reading a header, the header data was not overwritten by a wrapping write.
+    // ========================================================================
 
-    while (pos < data_byte_count) {
-        if (pos + header_size > data_byte_count) {
-            break;
-        }
-        const emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data_region + pos);
-        const uint64_t seq = header->seq;
-        const size_t frame_count = header->frame_count;
+    uint64_t scan_pos = oldest_pos;
 
-        if ((seq & 1) != 0) {
-            // An odd seq means that a write was in progress when memcpy reached this header.
-            // Any data after this point is unusable.
-            break;
+    // Skip records before start_ns.
+    while (scan_pos + header_size <= write_pos) {
+        // Check if the writer evicted past our position.
+        uint64_t current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        if (current_oldest > scan_pos) {
+            scan_pos = current_oldest;
+            continue;
         }
 
-        const size_t rsize = record_size(frame_count);
-        if (frame_count > unbelievable_frame_count || rsize > data_byte_count - pos) {
-            // Corrupt or torn frame_count; stop parsing.
-            break;
+        emb_ring_record_header_t hdr = read_live_header(buf, scan_pos);
+
+        // Re-check oldest_pos after reading. The seq_cst fence in the writer
+        // guarantees that if oldest_pos hasn't advanced past us, the data at
+        // our position has not been overwritten.
+        current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        if (current_oldest > scan_pos) {
+            scan_pos = current_oldest;
+            continue;
         }
 
-        records[valid_count].timestamp_ns = header->timestamp_ns;
-        records[valid_count].frame_count = frame_count;
-        records[valid_count].frames = (const uintptr_t *)(header + 1);
-        valid_count++;
+        if (hdr.seq & 1) { goto done; }
+        const size_t fc = hdr.frame_count;
+        const size_t rsize = record_size(fc);
+        if (rsize > (size_t)(write_pos - scan_pos)) { goto done; }
 
-        // Advance to next record.
-        pos += rsize;
+        if (hdr.timestamp_ns >= start_ns) { break; }
+        scan_pos += rsize;
     }
 
-    result.records = records;
-    result.count = valid_count;
+    uint64_t copy_start = scan_pos;
+
+    // Find end of matching range, counting records as we go.
+    size_t scan_record_count = 0;
+    while (scan_pos + header_size <= write_pos) {
+        uint64_t current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        if (current_oldest > scan_pos) {
+            // Record evicted. Restart from new oldest position.
+            copy_start = current_oldest;
+            scan_pos = current_oldest;
+            scan_record_count = 0;
+            continue;
+        }
+
+        emb_ring_record_header_t hdr = read_live_header(buf, scan_pos);
+
+        current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        if (current_oldest > scan_pos) {
+            // Record evicted. Restart from new oldest position.
+            copy_start = current_oldest;
+            scan_pos = current_oldest;
+            scan_record_count = 0;
+            continue;
+        }
+
+        if (hdr.seq & 1) { break; }
+        const size_t fc = hdr.frame_count;
+        const size_t rsize = record_size(fc);
+        if (rsize > (size_t)(write_pos - scan_pos)) { break; }
+
+        if (hdr.timestamp_ns > end_ns) { break; }
+        scan_pos += rsize;
+        scan_record_count++;
+    }
+
+    const uint64_t copy_end = scan_pos;
+
+    if (copy_end <= copy_start) {
+        goto done;
+    }
+
+    // ========================================================================
+    // Phase 2: Targeted copy of just the matching range.
+    // ========================================================================
+
+    size_t copy_size = (size_t)(copy_end - copy_start);
+    if (copy_size > output_size) {
+        copy_size = output_size;
+    }
+
+    memcpy(output, buf->data + (copy_start % buf->capacity), copy_size);
+
+    // ========================================================================
+    // Phase 3: Post-copy validation.
+    //
+    // Re-check oldest_pos. If it hasn't advanced into our copy range, all
+    // records are intact. If it has, records from post_oldest onward are
+    // guaranteed stable (the writer only overwrites behind oldest_pos), so
+    // we can compute the skip offset directly without per-record torn-read
+    // checks.
+    // ========================================================================
+
+    uint64_t post_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+
+    // Fast path: no eviction reached our copy range, so all records intact.
+    if (post_oldest <= copy_start) {
+        result.records_offset = 0;
+        if (copy_size < (size_t)(copy_end - copy_start)) {
+            // Output was truncated. Recount records that actually fit.
+            size_t local_offset = 0;
+            size_t fitted_count = 0;
+            while (local_offset + header_size <= copy_size) {
+                const emb_ring_record_header_t *hdr =
+                    (const emb_ring_record_header_t *)(output + local_offset);
+                const size_t rsize = record_size(hdr->frame_count);
+                if (rsize > copy_size - local_offset) { break; }
+                fitted_count++;
+                local_offset += rsize;
+            }
+            result.record_count = fitted_count;
+            result.total_bytes = local_offset;
+        } else {
+            result.record_count = scan_record_count;
+            result.total_bytes = copy_size;
+        }
+        goto done;
+    }
+
+    // Eviction advanced into our copy range. Records from post_oldest onward
+    // are stable (the writer hasn't touched them), so skip the evicted prefix
+    // and count the remaining records.
+    size_t evicted = (size_t)(post_oldest - copy_start);
+    if (evicted >= copy_size) {
+        goto done;
+    }
+
+    {
+        size_t local_offset = evicted;
+        size_t record_count = 0;
+
+        while (local_offset + header_size <= copy_size) {
+            const emb_ring_record_header_t *hdr =
+                (const emb_ring_record_header_t *)(output + local_offset);
+            if (hdr->seq & 1) { break; }
+            const size_t fc = hdr->frame_count;
+            const size_t rsize = record_size(fc);
+            if (rsize > copy_size - local_offset) { break; }
+            if (hdr->timestamp_ns > end_ns) { break; }
+            record_count++;
+            local_offset += rsize;
+        }
+
+        result.records_offset = evicted;
+        result.record_count = record_count;
+        result.total_bytes = local_offset - evicted;
+    }
+
+done:
+    atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
     return result;
-}
-
-void emb_ring_read_result_free(emb_ring_read_result_t *result)
-{
-    if (result != NULL && result->records != NULL) {
-        free(result->records);
-        result->records = NULL;
-        result->count = 0;
-    }
 }
 
 #endif /* !TARGET_OS_WATCH */

--- a/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
@@ -20,6 +20,7 @@ typedef struct {
 
 static const size_t header_size = sizeof(emb_ring_record_header_t);
 static const size_t frame_size = sizeof(((emb_ring_record_t *)0)->frames[0]);
+static const size_t unbelievable_frame_count = 1000000;
 
 /// Calculate the size of a record with the given number of frames.
 /// This will work out to the header size + 8 bytes per frame.
@@ -150,12 +151,19 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
                            const uintptr_t *frames,
                            size_t frame_count)
 {
-    if (buf == NULL || frames == NULL || frame_count > UINT32_MAX) {
+    if (buf == NULL || frames == NULL || frame_count > unbelievable_frame_count) {
         return false;
     }
 
     // Record size for the requested frame count.
     size_t record_size_needed = record_size(frame_count);
+
+    // A single record must fit within the buffer capacity.
+    // Should never happen since we check against unbelievable_frame_count,
+    // but good just in case a future change allows it to slip through.
+    if (record_size_needed > buf->capacity) {
+        return false;
+    }
 
     // Current write position (monotonically increasing byte offset).
     uint64_t write_pos = atomic_load_explicit(&buf->write_pos, memory_order_relaxed);
@@ -220,7 +228,6 @@ static buffer_range find_range(const emb_ring_buffer_t *buf,
                                uint64_t end_ns)
 {
     const buffer_range not_found = {0};
-    const size_t unbelievable_frame_count = 1000000;
     const size_t capacity = buf->capacity;
     uint8_t *data = buf->data;
     buffer_range range = {0};
@@ -260,7 +267,7 @@ static buffer_range find_range(const emb_ring_buffer_t *buf,
             return not_found;
         }
         if (timestamp_ns < start_ns) {
-            return not_found;
+            break;
         }
 
         if (timestamp_ns > end_ns) {
@@ -327,14 +334,23 @@ emb_ring_read_result_t emb_ring_buffer_read_range(const emb_ring_buffer_t *buf,
 
     const uint64_t current_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
     uint64_t pos = 0;
-    if (current_start_pos != snapshot_start_pos) {
+    if (current_start_pos > range.start) {
         // Data at the front was evicted during the copy, so exclude it.
-        pos = (current_start_pos - snapshot_start_pos) % buf->capacity;
+        const uint64_t eviction_delta = current_start_pos - range.start;
+        if (eviction_delta >= (uint64_t)data_byte_count) {
+            // The entire copied window is stale.
+            free(allocation);
+            return result;
+        }
+        pos = (size_t)eviction_delta;
     }
 
     size_t valid_count = 0;
 
     while (pos < data_byte_count) {
+        if (pos + header_size > data_byte_count) {
+            break;
+        }
         const emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data_region + pos);
         const uint64_t seq = header->seq;
         const size_t frame_count = header->frame_count;
@@ -345,13 +361,19 @@ emb_ring_read_result_t emb_ring_buffer_read_range(const emb_ring_buffer_t *buf,
             break;
         }
 
+        const size_t rsize = record_size(frame_count);
+        if (frame_count > unbelievable_frame_count || rsize > data_byte_count - pos) {
+            // Corrupt or torn frame_count; stop parsing.
+            break;
+        }
+
         records[valid_count].timestamp_ns = header->timestamp_ns;
         records[valid_count].frame_count = frame_count;
         records[valid_count].frames = (const uintptr_t *)(header + 1);
         valid_count++;
 
         // Advance to next record.
-        pos += record_size(frame_count);
+        pos += rsize;
     }
 
     result.records = records;

--- a/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
@@ -1,0 +1,371 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#include "emb_ring_buffer.h"
+
+#if !TARGET_OS_WATCH
+
+#include <mach/mach.h>
+#include <mach/vm_map.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Internal record header layout (stored in the ring buffer).
+typedef struct {
+    _Atomic uint32_t seq;  // Seqlock: odd = writing, even = stable.
+    uint32_t frame_count;  // Number of frames in this record.
+    uint64_t timestamp_ns; // Monotonic timestamp.
+} emb_ring_record_header_t;
+
+static const size_t header_size = sizeof(emb_ring_record_header_t);
+static const size_t frame_size = sizeof(((emb_ring_record_t *)0)->frames[0]);
+
+/// Calculate the size of a record with the given number of frames.
+/// This will work out to the header size + 8 bytes per frame.
+static inline size_t record_size(size_t frame_count)
+{
+    return header_size + frame_size * frame_count;
+}
+
+// mach_vm_* functions are macOS-only; on iOS/tvOS we use vm_* equivalents
+#if TARGET_OS_OSX
+#include <mach/mach_vm.h>
+typedef mach_vm_address_t emb_vm_address_t;
+typedef mach_vm_size_t emb_vm_size_t;
+#define emb_vm_allocate mach_vm_allocate
+#define emb_vm_remap mach_vm_remap
+#define emb_vm_deallocate mach_vm_deallocate
+#else
+typedef vm_address_t emb_vm_address_t;
+typedef vm_size_t emb_vm_size_t;
+#define emb_vm_allocate vm_allocate
+#define emb_vm_remap vm_remap
+#define emb_vm_deallocate vm_deallocate
+#endif
+
+static size_t round_size_up_to_page_boundary(size_t size)
+{
+    size_t page = vm_page_size;
+    return (size + page - 1) & ~(page - 1);
+}
+
+emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
+{
+    const size_t capacity = round_size_up_to_page_boundary(capacity_bytes);
+    if (capacity == 0) {
+        return NULL;
+    }
+
+    // Allocate a contiguous virtual region of 2 * capacity.
+    // The second half will be remapped to alias the first half's physical pages,
+    // so writes past the end of the first half seamlessly wrap around.
+    const emb_vm_size_t half = (emb_vm_size_t)capacity;
+    const emb_vm_size_t region_size = half * 2;
+ 
+    bool remap_succeeded = false;
+ 
+    emb_vm_address_t region = 0;
+    kern_return_t kr = emb_vm_allocate(mach_task_self(),
+                                       &region,
+                                       region_size,
+                                       VM_FLAGS_ANYWHERE);
+    if (kr != KERN_SUCCESS) {
+        return NULL;
+    }
+ 
+    // Remap the first half's physical pages over the second half.
+    // copy = false so both halves share the same physical pages rather than
+    // getting an independent copy.
+    emb_vm_address_t second_half = region + half;
+    vm_prot_t cur_prot = VM_PROT_NONE;
+    vm_prot_t max_prot = VM_PROT_NONE;
+ 
+    kr = emb_vm_remap(mach_task_self(),
+                      &second_half,
+                      half,
+                      0,                                   // alignment mask
+                      VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE,
+                      mach_task_self(),
+                      region,                              // source = first half
+                      false,                               // copy
+                      &cur_prot,
+                      &max_prot,
+                      VM_INHERIT_NONE);
+    if (kr != KERN_SUCCESS) {
+        goto fail;
+    }
+ 
+    remap_succeeded = true;
+ 
+    // Sanity-check: VM_FLAGS_FIXED should guarantee the address didn't move.
+    if (second_half != region + half) {
+        goto fail;
+    }
+ 
+    emb_ring_buffer_t *buf = calloc(1, sizeof(*buf));
+    if (buf == NULL) {
+        goto fail;
+    }
+ 
+    buf->data       = (uint8_t *)region;
+    buf->capacity   = capacity;
+    buf->next_seq   = 0;
+    atomic_store_explicit(&buf->write_pos,  0, memory_order_relaxed);
+    atomic_store_explicit(&buf->oldest_pos, 0, memory_order_relaxed);
+ 
+    return buf;
+ 
+fail:
+    if (remap_succeeded) {
+        // After vm_remap with VM_FLAGS_OVERWRITE the region may have been split
+        // into two VM map entries. Deallocate each half independently.
+        emb_vm_deallocate(mach_task_self(), region,        half);
+        emb_vm_deallocate(mach_task_self(), region + half, half);
+    } else {
+        // vm_remap failed. VM_FLAGS_OVERWRITE may have already torn out the
+        // second half before failing, so we can only safely free the first half.
+        // The second half is either still part of the original allocation (and
+        // this covers it) or already gone.
+        emb_vm_deallocate(mach_task_self(), region, region_size);
+    }
+    return NULL;
+}
+
+void emb_ring_buffer_destroy(emb_ring_buffer_t *buf)
+{
+    if (buf == NULL) {
+        return;
+    }
+    // Deallocate the full 2 × capacity virtual region (both the original
+    // allocation and the remap share the same address range).
+    emb_vm_deallocate(mach_task_self(),
+                      (emb_vm_address_t)buf->data,
+                      (emb_vm_size_t)buf->capacity * 2);
+    free(buf);
+}
+
+bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
+                           uint64_t timestamp_ns,
+                           const uintptr_t *frames,
+                           size_t frame_count)
+{
+    if (buf == NULL || frames == NULL || frame_count > UINT32_MAX) {
+        return false;
+    }
+
+    // Record size for the requested frame count.
+    size_t record_size_needed = record_size(frame_count);
+
+    // Current write position (monotonically increasing byte offset).
+    uint64_t write_pos = atomic_load_explicit(&buf->write_pos, memory_order_relaxed);
+    uint64_t oldest_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+
+    // Evict old records that would be overlapped by this write.
+    // The loop condition: oldest_pos + capacity < write_pos + record_size
+    // This means the oldest record would be overwritten.
+    while (oldest_pos + buf->capacity < write_pos + record_size_needed) {
+        // Read the header of the oldest record to determine its size.
+        size_t offset = oldest_pos % buf->capacity;
+        emb_ring_record_header_t *old_header = (emb_ring_record_header_t *)(buf->data + offset);
+
+        // Read frame_count (relaxed is safe: we're the single writer and this
+        // is an old committed record).
+        size_t old_frame_count = old_header->frame_count;
+
+        // Advance oldest_pos past this record.
+        oldest_pos += record_size(old_frame_count);
+
+        // Publish the new oldest_pos.
+        atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
+    }
+
+    // Now that space is guaranteed, mark the record as "writing" via seqlock.
+    size_t offset = write_pos % buf->capacity;
+    emb_ring_record_header_t *header = (emb_ring_record_header_t *)(buf->data + offset);
+
+    // Set seq to odd (writing).
+    atomic_store_explicit(&header->seq, buf->next_seq | 1, memory_order_release);
+
+    // Copy frame data into the buffer.
+    uintptr_t *dest_frames = (uintptr_t *)(header + 1);
+    memcpy(dest_frames, frames, frame_count * sizeof(*dest_frames));
+
+    // Write the header fields (frame_count and timestamp).
+    header->frame_count = (uint32_t)frame_count;
+    header->timestamp_ns = timestamp_ns;
+
+    // Seal the seqlock (transition to even = stable).
+    atomic_store_explicit(&header->seq, buf->next_seq, memory_order_release);
+
+    // Advance write_pos by the actual record size.
+    atomic_store_explicit(&buf->write_pos, write_pos + record_size(frame_count), memory_order_release);
+
+    // Increment the seqlock counter for the next write.
+    buf->next_seq += 2;
+
+    return true;
+}
+
+typedef struct {
+    uint64_t start;
+    uint64_t end;
+    size_t count;
+} buffer_range;
+
+static buffer_range find_range(const emb_ring_buffer_t *buf,
+                               uint64_t low_pos,
+                               uint64_t high_pos,
+                               uint64_t start_ns,
+                               uint64_t end_ns)
+{
+    const buffer_range not_found = {0};
+    const size_t unbelievable_frame_count = 1000000;
+    const size_t capacity = buf->capacity;
+    uint8_t *data = buf->data;
+    buffer_range range = {0};
+    uint64_t pos = low_pos;
+
+    // Find start (leading edge of first record where time >= start_ns)
+    while (pos < high_pos) {
+        size_t offset = pos % capacity;
+        emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data + offset);
+        uint64_t timestamp_ns = header->timestamp_ns;
+        size_t frame_count = header->frame_count;
+
+        if (frame_count > unbelievable_frame_count) {
+            return not_found;
+        }
+
+        if (timestamp_ns >= start_ns) {
+            break;
+        }
+
+        pos += record_size(frame_count);
+    }
+
+    if(pos >= high_pos) {
+        return not_found;
+    }
+    range.start = pos;
+
+    // Find end (trailing edge of last record where time <= end_ns)
+    while (pos < high_pos) {
+        size_t offset = pos % capacity;
+        emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data + offset);
+        uint64_t timestamp_ns = header->timestamp_ns;
+        size_t frame_count = header->frame_count;
+
+        if (frame_count > unbelievable_frame_count) {
+            return not_found;
+        }
+        if (timestamp_ns < start_ns) {
+            return not_found;
+        }
+
+        if (timestamp_ns > end_ns) {
+            break;
+        }
+        range.count++;
+
+        pos += record_size(frame_count);
+    }
+    range.end = pos;
+    return range;
+}
+
+emb_ring_read_result_t emb_ring_buffer_read_range(const emb_ring_buffer_t *buf,
+                                                   uint64_t start_ns,
+                                                   uint64_t end_ns)
+{
+    emb_ring_read_result_t result = {NULL, 0};
+
+    if (buf == NULL) {
+        return result;
+    }
+
+    const uint64_t initial_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+    const uint64_t initial_end_pos = atomic_load_explicit(&buf->write_pos, memory_order_acquire);
+
+    if (initial_start_pos >= initial_end_pos) {
+        // Buffer is empty.
+        return result;
+    }
+    
+    buffer_range range = find_range(buf, initial_start_pos, initial_end_pos, start_ns, end_ns);
+
+    const uint64_t snapshot_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+    const uint64_t snapshot_end_pos = atomic_load_explicit(&buf->write_pos, memory_order_acquire);
+    
+    if(snapshot_start_pos != initial_start_pos || snapshot_end_pos != initial_end_pos) {
+        // Torn read while computing range, so find it again.
+        // This is safe because we have only one periodic writer, so we won't get torn again.
+        range = find_range(buf, snapshot_start_pos, snapshot_end_pos, start_ns, end_ns);
+    }
+
+    if (range.count == 0) {
+        return result;
+    }
+
+    // Allocate space for record array + raw data.
+    const size_t record_array_byte_count = range.count * sizeof(emb_ring_record_t);
+    const size_t data_byte_count = range.end - range.start;
+    if (data_byte_count > buf->capacity) {
+        // If the write frequency invariant is violated and we tear more than once in a bad way, we'll catch it here.
+        return result;
+    }
+    uint8_t *allocation = malloc(record_array_byte_count + data_byte_count);
+    if (allocation == NULL) {
+        return result;
+    }
+
+    emb_ring_record_t *records = (emb_ring_record_t *)allocation;
+    uint8_t *data_region = allocation + record_array_byte_count;
+
+    // Copy the raw data in one memcpy (safe due to double-mapping).
+    memcpy(data_region, buf->data + range.start % buf->capacity, data_byte_count);
+
+    const uint64_t current_start_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+    uint64_t pos = 0;
+    if (current_start_pos != snapshot_start_pos) {
+        // Data at the front was evicted during the copy, so exclude it.
+        pos = (current_start_pos - snapshot_start_pos) % buf->capacity;
+    }
+
+    size_t valid_count = 0;
+
+    while (pos < data_byte_count) {
+        const emb_ring_record_header_t *header = (emb_ring_record_header_t *)(data_region + pos);
+        const uint64_t seq = header->seq;
+        const size_t frame_count = header->frame_count;
+
+        if ((seq & 1) != 0) {
+            // An odd seq means that a write was in progress when memcpy reached this header.
+            // Any data after this point is unusable.
+            break;
+        }
+
+        records[valid_count].timestamp_ns = header->timestamp_ns;
+        records[valid_count].frame_count = frame_count;
+        records[valid_count].frames = (const uintptr_t *)(header + 1);
+        valid_count++;
+
+        // Advance to next record.
+        pos += record_size(frame_count);
+    }
+
+    result.records = records;
+    result.count = valid_count;
+    return result;
+}
+
+void emb_ring_read_result_free(emb_ring_read_result_t *result)
+{
+    if (result != NULL && result->records != NULL) {
+        free(result->records);
+        result->records = NULL;
+        result->count = 0;
+    }
+}
+
+#endif /* !TARGET_OS_WATCH */

--- a/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
@@ -63,10 +63,15 @@ static size_t round_size_up_to_page_boundary(size_t size)
     return (size + page - 1) & ~(page - 1);
 }
 
-emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
+emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes, kern_return_t *kr_out)
 {
+    kern_return_t kr_dummy;
+    if (kr_out == NULL) { kr_out = &kr_dummy; }
+    *kr_out = KERN_SUCCESS;
+
     const size_t capacity = round_size_up_to_page_boundary(capacity_bytes);
     if (capacity == 0) {
+        *kr_out = KERN_INVALID_ARGUMENT;
         return NULL;
     }
 
@@ -84,6 +89,7 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
                                        region_size,
                                        VM_FLAGS_ANYWHERE);
     if (kr != KERN_SUCCESS) {
+        *kr_out = kr;
         return NULL;
     }
 
@@ -106,6 +112,7 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
                       &max_prot,
                       VM_INHERIT_NONE);
     if (kr != KERN_SUCCESS) {
+        *kr_out = kr;
         goto fail;
     }
 
@@ -114,11 +121,13 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes)
     // Sanity-check: with VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE this branch is
     // unreachable — the kernel must place the mapping at the requested address.
     if (second_half != region + half) {
+        *kr_out = KERN_FAILURE;
         goto fail;
     }
 
     emb_ring_buffer_t *buf = calloc(1, sizeof(*buf));
     if (buf == NULL) {
+        *kr_out = KERN_RESOURCE_SHORTAGE;
         goto fail;
     }
 
@@ -196,18 +205,18 @@ size_t emb_ring_buffer_capacity(const emb_ring_buffer_t *buf)
     return buf->capacity;
 }
 
-bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
-                           uint64_t timestamp_ns,
-                           const uintptr_t *frames,
-                           size_t frame_count)
+emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
+                                               uint64_t timestamp_ns,
+                                               const uintptr_t *frames,
+                                               size_t frame_count)
 {
     if (buf == NULL || (frames == NULL && frame_count > 0)) {
-        return false;
+        return EMB_RING_WRITE_BAD_ARGS;
     }
 
     // The header stores frame_count as uint32_t.
     if (frame_count > UINT32_MAX) {
-        return false;
+        return EMB_RING_WRITE_BAD_ARGS;
     }
 
     // Record size for the requested frame count.
@@ -215,7 +224,7 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
 
     // A single record must fit within the buffer capacity.
     if (record_size_needed > buf->capacity) {
-        return false;
+        return EMB_RING_WRITE_RECORD_TOO_LARGE;
     }
 
     // Current write position (monotonically increasing byte offset).
@@ -227,6 +236,7 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     // Evict old records that would be overlapped by this write.
     // The loop condition: oldest_pos + capacity < write_pos + record_size
     // This means the oldest record would be overwritten.
+    bool corruption_detected = false;
     while (oldest_pos + buf->capacity < write_pos + record_size_needed) {
         // Read the header of the oldest record to determine its size.
         // Safe: we're the single writer and this is our own committed record.
@@ -241,6 +251,7 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
         if (old_record_size > buf->capacity) {
             oldest_pos = write_pos;
             atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
+            corruption_detected = true;
             break;
         }
 
@@ -249,6 +260,10 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
 
         // Publish the new oldest_pos.
         atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
+    }
+
+    if (corruption_detected) {
+        return EMB_RING_WRITE_CORRUPTION_DETECTED;
     }
 
     // Full barrier: ensures the oldest_pos advance(s) above are globally visible
@@ -303,7 +318,7 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
     // Increment the seqlock counter for the next write.
     buf->next_seq += 2;
 
-    return true;
+    return EMB_RING_WRITE_OK;
 }
 
 /// Read a record header directly from the live ring buffer at the given
@@ -311,9 +326,13 @@ bool emb_ring_buffer_write(emb_ring_buffer_t *buf,
 static inline emb_ring_record_header_t read_live_header(emb_ring_buffer_t *buf,
                                                          uint64_t absolute_pos) {
     size_t offset = (size_t)(absolute_pos % buf->capacity);
-    const emb_ring_record_header_t *hdr =
-        (const emb_ring_record_header_t *)(buf->data + offset);
-    return *hdr;
+    const emb_ring_write_header_t *whdr =
+        (const emb_ring_write_header_t *)(buf->data + offset);
+    emb_ring_record_header_t hdr;
+    hdr.seq          = atomic_load_explicit(&whdr->seq, memory_order_acquire);
+    hdr.frame_count  = whdr->frame_count;
+    hdr.timestamp_ns = whdr->timestamp_ns;
+    return hdr;
 }
 
 emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
@@ -323,8 +342,10 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
                                                    size_t output_size)
 {
     emb_ring_read_result_t result = {0};
+    result.status = EMB_RING_READ_OK;
 
     if (buf == NULL || output == NULL || output_size == 0) {
+        result.status = EMB_RING_READ_BAD_ARGS;
         return result;
     }
 
@@ -336,6 +357,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
     // ARM64 store-buffer reordering that could let both sides miss each other.
     if (atomic_load_explicit(&buf->resetting, memory_order_seq_cst)) {
         atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
+        result.status = EMB_RING_READ_RESETTING;
         return result;
     }
 
@@ -345,12 +367,14 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
 
     if (oldest_pos >= write_pos) {
         atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
+        result.status = EMB_RING_READ_EMPTY;
         return result;
     }
 
     const size_t total_data = (size_t)(write_pos - oldest_pos);
     if (total_data > buf->capacity) {
         atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
+        result.status = EMB_RING_READ_EMPTY;
         return result;
     }
 
@@ -495,6 +519,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
             }
             result.record_count = fitted_count;
             result.total_bytes = local_offset;
+            result.status = EMB_RING_READ_TRUNCATED;
         } else {
             result.record_count = scan_record_count;
             result.total_bytes = copy_size;

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
@@ -48,15 +48,13 @@
         // MARK: - Helpers
 
         /// Write-pattern sentinel: frame[j] of write-index `idx` = idx * 10_000 + j + 1.
-        /// This encodes the record identity into every frame so readers can verify integrity.
         private func makeFrames(writeIndex: Int, count: Int) -> [UInt] {
             let base = UInt(writeIndex) * 10_000
             return (0..<count).map { base + UInt($0) + 1 }
         }
 
         /// Verify a single record against the write pattern.
-        /// `intervalNs` is the ns step between consecutive write-index timestamps.
-        private func frameError(_ rec: emb_ring_record_t, intervalNs: UInt64) -> String? {
+        private func frameError(_ rec: TestRecord, intervalNs: UInt64) -> String? {
             guard intervalNs > 0 else { return nil }
             let idx = Int(rec.timestamp_ns / intervalNs)
             let base = UInt(idx) * 10_000
@@ -70,11 +68,10 @@
         }
 
         /// Spin up `readerCount` concurrent readers while `writerBlock` runs on the calling thread.
-        /// Each reader calls `validate` with every result it obtains.
         private func runWithReaders(
             buf: UnsafeMutablePointer<emb_ring_buffer_t>,
             readerCount: Int,
-            validate: @escaping (emb_ring_read_result_t, FailureCollector) -> Void,
+            validate: @escaping ([TestRecord], FailureCollector) -> Void,
             writerBlock: (FailureCollector) -> Void
         ) -> FailureCollector {
             let failures = FailureCollector()
@@ -82,13 +79,19 @@
             let group = DispatchGroup()
             let queue = DispatchQueue(label: "ring.test.readers", attributes: .concurrent)
 
+            let capacity = emb_ring_buffer_capacity(buf)
+
             for _ in 0..<readerCount {
                 group.enter()
                 queue.async {
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
                     while !stop.isSet {
-                        var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-                        validate(result, failures)
-                        emb_ring_read_result_free(&result)
+                        let result = emb_ring_buffer_read_range(
+                            buf, 0, UINT64_MAX, output, capacity)
+                        let records = parseRecords(output, result)
+                        validate(records, failures)
                     }
                     group.leave()
                 }
@@ -118,9 +121,9 @@
 
             let failures = runWithReaders(
                 buf: buf, readerCount: 4,
-                validate: { result, fc in
-                    for i in 0..<result.count {
-                        if let err = self.frameError(result.records[i], intervalNs: intervalNs) {
+                validate: { records, fc in
+                    for i in 0..<records.count {
+                        if let err = self.frameError(records[i], intervalNs: intervalNs) {
                             fc.record("Frame corruption: \(err)")
                         }
                     }
@@ -144,11 +147,11 @@
 
             let failures = runWithReaders(
                 buf: buf, readerCount: 4,
-                validate: { result, fc in
-                    guard result.count > 1 else { return }
-                    for i in 1..<result.count {
-                        let prev = result.records[i - 1].timestamp_ns
-                        let cur = result.records[i].timestamp_ns
+                validate: { records, fc in
+                    guard records.count > 1 else { return }
+                    for i in 1..<records.count {
+                        let prev = records[i - 1].timestamp_ns
+                        let cur = records[i].timestamp_ns
                         if cur <= prev {
                             fc.record("Non-ascending timestamps at index \(i): \(prev) >= \(cur)")
                         }
@@ -166,22 +169,18 @@
             assertNoFailures(failures)
         }
 
-        /// Every returned record must have believable frame_count (≤ 10 000) and
-        /// a non-nil frames pointer when frame_count > 0.
+        /// Every returned record must have believable frame_count (≤ 10 000).
         func test_periodicWriter_multipleReaders_recordStructureAlwaysValid() {
             let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let failures = runWithReaders(
                 buf: buf, readerCount: 4,
-                validate: { result, fc in
-                    for i in 0..<result.count {
-                        let rec = result.records[i]
+                validate: { records, fc in
+                    for i in 0..<records.count {
+                        let rec = records[i]
                         if rec.frame_count > 10_000 {
                             fc.record("record[\(i)].frame_count=\(rec.frame_count) is impossibly large")
-                        }
-                        if rec.frame_count > 0 && rec.frames == nil {
-                            fc.record("record[\(i)] has frame_count=\(rec.frame_count) but nil frames pointer")
                         }
                     }
                 },
@@ -205,15 +204,14 @@
 
             let failures = runWithReaders(
                 buf: buf, readerCount: 4,
-                validate: { result, fc in
-                    for i in 0..<result.count {
-                        if result.records[i].frame_count > 10_000 {
+                validate: { records, fc in
+                    for i in 0..<records.count {
+                        if records[i].frame_count > 10_000 {
                             fc.record("wrap-around: record[\(i)].frame_count is corrupt")
                         }
                     }
                 },
                 writerBlock: { _ in
-                    // 60 writes with a one-page buffer forces many wrap-arounds.
                     for i in 0..<60 {
                         let fc = (i % 12) + 1
                         let f = self.makeFrames(writeIndex: i, count: fc)
@@ -233,16 +231,16 @@
 
             let failures = runWithReaders(
                 buf: buf, readerCount: 6,
-                validate: { result, fc in
-                    for i in 0..<result.count {
-                        if result.records[i].frame_count > 10_000 {
+                validate: { records, fc in
+                    for i in 0..<records.count {
+                        if records[i].frame_count > 10_000 {
                             fc.record("eviction: record[\(i)].frame_count corrupt")
                         }
                     }
-                    guard result.count > 1 else { return }
-                    for i in 1..<result.count {
-                        let prev = result.records[i - 1].timestamp_ns
-                        let cur = result.records[i].timestamp_ns
+                    guard records.count > 1 else { return }
+                    for i in 1..<records.count {
+                        let prev = records[i - 1].timestamp_ns
+                        let cur = records[i].timestamp_ns
                         if cur < prev {
                             fc.record("eviction: timestamp went backwards \(prev) → \(cur)")
                         }
@@ -261,12 +259,10 @@
         }
 
         /// Many concurrent readers all read simultaneously after a batch of writes.
-        /// All readers must get the same record count and identical timestamps.
         func test_simultaneousReaders_sameBuffer_consistentResults() {
             let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            // Pre-populate with 20 records.
             for i in 0..<20 {
                 let fc = (i % 5) + 1
                 let f = makeFrames(writeIndex: i, count: fc)
@@ -278,13 +274,17 @@
             var snapshots = [[UInt64]]()
             let group = DispatchGroup()
             let queue = DispatchQueue(label: "ring.simultaneous", attributes: .concurrent)
+            let capacity = emb_ring_buffer_capacity(buf)
 
             for _ in 0..<readerCount {
                 group.enter()
                 queue.async {
-                    var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-                    let ts = (0..<result.count).map { result.records[$0].timestamp_ns }
-                    emb_ring_read_result_free(&result)
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
+                    let result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX, output, capacity)
+                    let records = parseRecords(output, result)
+                    let ts = records.map { $0.timestamp_ns }
                     resultsLock.lock()
                     snapshots.append(ts)
                     resultsLock.unlock()
@@ -314,19 +314,24 @@
             let stop = StopFlag()
             let group = DispatchGroup()
             let queue = DispatchQueue(label: "ring.window.readers", attributes: .concurrent)
+            let capacity = emb_ring_buffer_capacity(buf)
 
             for _ in 0..<4 {
                 group.enter()
                 queue.async {
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
                     while !stop.isSet {
-                        var result = emb_ring_buffer_read_range(buf, windowStart, windowEnd)
-                        for i in 0..<result.count {
-                            let ts = result.records[i].timestamp_ns
+                        let result = emb_ring_buffer_read_range(
+                            buf, windowStart, windowEnd, output, capacity)
+                        let records = parseRecords(output, result)
+                        for i in 0..<records.count {
+                            let ts = records[i].timestamp_ns
                             if ts < windowStart || ts > windowEnd {
                                 failures.record("windowed read: ts=\(ts) outside [\(windowStart), \(windowEnd)]")
                             }
                         }
-                        emb_ring_read_result_free(&result)
                     }
                     group.leave()
                 }
@@ -344,39 +349,33 @@
         }
 
         /// Stress: 8 readers + high-frequency writer (no sleep between writes).
-        ///
-        /// This test intentionally violates the "1 ms periodic writer" invariant to
-        /// verify the buffer does not crash or deadlock under pathological write rates.
-        /// This should never happen under proper usage, but we test it anyway.
-        /// The implementation documents that a second torn read after retry is possible when
-        /// the writer is continuous; this test therefore only checks liveness (no crash /
-        /// no deadlock / no infinite loop), NOT frame-data correctness.
         func test_stress_highFrequencyWriter_manyReaders_noCrash() {
             let buf = emb_ring_buffer_create(2 * Int(getpagesize()))!
             defer { emb_ring_buffer_destroy(buf) }
 
-            // Threshold matches the implementation's own sanity limit (unbelievable_frame_count).
             let unbelievableFrameCount = 1_000_000
 
             let failures = FailureCollector()
             let stop = StopFlag()
             let group = DispatchGroup()
             let queue = DispatchQueue(label: "ring.stress.readers", attributes: .concurrent)
+            let capacity = emb_ring_buffer_capacity(buf)
 
             for _ in 0..<8 {
                 group.enter()
                 queue.async {
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
                     while !stop.isSet {
-                        var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-                        // Under continuous writes the implementation may deliver a record whose
-                        // frame_count was read mid-write. Accept anything below the
-                        // implementation's own unbelievable_frame_count sanity limit.
-                        for i in 0..<result.count {
-                            if result.records[i].frame_count > unbelievableFrameCount {
-                                failures.record("stress: frame_count \(result.records[i].frame_count) exceeds implementation limit")
+                        let result = emb_ring_buffer_read_range(
+                            buf, 0, UINT64_MAX, output, capacity)
+                        let records = parseRecords(output, result)
+                        for i in 0..<records.count {
+                            if records[i].frame_count > unbelievableFrameCount {
+                                failures.record("stress: frame_count \(records[i].frame_count) exceeds implementation limit")
                             }
                         }
-                        emb_ring_read_result_free(&result)
                     }
                     group.leave()
                 }
@@ -414,19 +413,24 @@
             let stop = StopFlag()
             let group = DispatchGroup()
             let queue = DispatchQueue(label: "ring.partition.readers", attributes: .concurrent)
+            let capacity = emb_ring_buffer_capacity(buf)
 
             for window in windows {
                 group.enter()
                 queue.async {
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
                     while !stop.isSet {
-                        var result = emb_ring_buffer_read_range(buf, window.start, window.end)
-                        for i in 0..<result.count {
-                            let ts = result.records[i].timestamp_ns
+                        let result = emb_ring_buffer_read_range(
+                            buf, window.start, window.end, output, capacity)
+                        let records = parseRecords(output, result)
+                        for i in 0..<records.count {
+                            let ts = records[i].timestamp_ns
                             if ts < window.start || ts > window.end {
                                 failures.record("partition violation: ts=\(ts) not in [\(window.start), \(window.end)]")
                             }
                         }
-                        emb_ring_read_result_free(&result)
                     }
                     group.leave()
                 }
@@ -439,6 +443,54 @@
             }
             stop.set()
             group.wait()
+
+            assertNoFailures(failures)
+        }
+
+        /// Small (1-page) buffer with high-frequency writer forcing wrap-around.
+        /// 4+ concurrent readers verify no frame corruption and ascending timestamps.
+        func test_smallBuffer_highFrequencyWrapAround_noCorruption() {
+            let buf = emb_ring_buffer_create(Int(getpagesize()))!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let writeCount = 500
+            let frameCount = 8
+
+            let failures = runWithReaders(
+                buf: buf, readerCount: 4,
+                validate: { records, fc in
+                    // Timestamps must be ascending.
+                    if records.count > 1 {
+                        for i in 1..<records.count {
+                            let prev = records[i - 1].timestamp_ns
+                            let cur = records[i].timestamp_ns
+                            if cur < prev {
+                                fc.record("wrap-around: timestamps went backwards \(prev) → \(cur)")
+                            }
+                        }
+                    }
+                    // Frame data must be internally consistent: frame[j] = idx * 10_000 + j + 1.
+                    for rec in records {
+                        let intervalNs: UInt64 = 1_000
+                        let idx = Int(rec.timestamp_ns / intervalNs)
+                        let base = UInt(idx) * 10_000
+                        for j in 0..<rec.frame_count {
+                            let expected = base + UInt(j) + 1
+                            if rec.frames[j] != expected {
+                                fc.record("wrap-around: ts=\(rec.timestamp_ns) frame[\(j)]: expected \(expected), got \(rec.frames[j])")
+                                break
+                            }
+                        }
+                    }
+                },
+                writerBlock: { _ in
+                    for i in 0..<writeCount {
+                        let f = self.makeFrames(writeIndex: i, count: frameCount)
+                        emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, frameCount)
+                        // No sleep. Maximum write pressure to force rapid wrap-around.
+                    }
+                }
+            )
 
             assertNoFailures(failures)
         }
@@ -458,13 +510,17 @@
             var snapshots = [[UInt64]]()
             let group = DispatchGroup()
             let queue = DispatchQueue(label: "ring.stable.readers", attributes: .concurrent)
+            let capacity = emb_ring_buffer_capacity(buf)
 
             for _ in 0..<readerCount {
                 group.enter()
                 queue.async {
-                    var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-                    let ts = (0..<result.count).map { result.records[$0].timestamp_ns }
-                    emb_ring_read_result_free(&result)
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
+                    let result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX, output, capacity)
+                    let records = parseRecords(output, result)
+                    let ts = records.map { $0.timestamp_ns }
                     lock.lock()
                     snapshots.append(ts)
                     lock.unlock()

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
@@ -1,0 +1,485 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import Darwin
+    import EmbraceProfilingSampler
+    import XCTest
+
+    /// Tests for the ring buffer under concurrent access.
+    ///
+    /// Simulates the production scenario: one periodic writer (100 ms cadence)
+    /// and multiple simultaneous readers. All assertions run inside the reader
+    /// threads so that race-condition failures are caught as XCTest failures.
+    final class RingBufferConcurrencyTests: XCTestCase {
+
+        // MARK: - Shared test state
+
+        /// Thread-safe bag used by reader tasks to accumulate failure messages.
+        private final class FailureCollector {
+            private let lock = NSLock()
+            private(set) var messages: [String] = []
+
+            func record(_ msg: String) {
+                lock.lock()
+                messages.append(msg)
+                lock.unlock()
+            }
+        }
+
+        /// Thread-safe stop flag for reader loops.
+        private final class StopFlag {
+            private let lock = NSLock()
+            private var _stop = false
+            var isSet: Bool {
+                lock.lock()
+                defer { lock.unlock() }
+                return _stop
+            }
+            func set() {
+                lock.lock()
+                _stop = true
+                lock.unlock()
+            }
+        }
+
+        // MARK: - Helpers
+
+        /// Write-pattern sentinel: frame[j] of write-index `idx` = idx * 10_000 + j + 1.
+        /// This encodes the record identity into every frame so readers can verify integrity.
+        private func makeFrames(writeIndex: Int, count: Int) -> [UInt] {
+            let base = UInt(writeIndex) * 10_000
+            return (0..<count).map { base + UInt($0) + 1 }
+        }
+
+        /// Verify a single record against the write pattern.
+        /// `intervalNs` is the ns step between consecutive write-index timestamps.
+        private func frameError(_ rec: emb_ring_record_t, intervalNs: UInt64) -> String? {
+            guard intervalNs > 0 else { return nil }
+            let idx = Int(rec.timestamp_ns / intervalNs)
+            let base = UInt(idx) * 10_000
+            for j in 0..<rec.frame_count {
+                let expected = base + UInt(j) + 1
+                if rec.frames[j] != expected {
+                    return "ts=\(rec.timestamp_ns) frame[\(j)]: expected \(expected), got \(rec.frames[j])"
+                }
+            }
+            return nil
+        }
+
+        /// Spin up `readerCount` concurrent readers while `writerBlock` runs on the calling thread.
+        /// Each reader calls `validate` with every result it obtains.
+        private func runWithReaders(
+            buf: UnsafeMutablePointer<emb_ring_buffer_t>,
+            readerCount: Int,
+            validate: @escaping (emb_ring_read_result_t, FailureCollector) -> Void,
+            writerBlock: (FailureCollector) -> Void
+        ) -> FailureCollector {
+            let failures = FailureCollector()
+            let stop = StopFlag()
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "ring.test.readers", attributes: .concurrent)
+
+            for _ in 0..<readerCount {
+                group.enter()
+                queue.async {
+                    while !stop.isSet {
+                        var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+                        validate(result, failures)
+                        emb_ring_read_result_free(&result)
+                    }
+                    group.leave()
+                }
+            }
+
+            writerBlock(failures)
+            stop.set()
+            group.wait()
+
+            return failures
+        }
+
+        private func assertNoFailures(_ fc: FailureCollector) {
+            for msg in fc.messages { XCTFail(msg) }
+        }
+
+        // MARK: - Tests
+
+        /// 100 ms periodic writer, 4 readers: frame data must be internally consistent.
+        func test_periodicWriter_multipleReaders_noFrameCorruption() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let intervalNs: UInt64 = 100_000_000
+            let writeCount = 10
+            let frameCount = 20
+
+            let failures = runWithReaders(
+                buf: buf, readerCount: 4,
+                validate: { result, fc in
+                    for i in 0..<result.count {
+                        if let err = self.frameError(result.records[i], intervalNs: intervalNs) {
+                            fc.record("Frame corruption: \(err)")
+                        }
+                    }
+                },
+                writerBlock: { _ in
+                    for i in 0..<writeCount {
+                        let f = self.makeFrames(writeIndex: i, count: frameCount)
+                        emb_ring_buffer_write(buf, UInt64(i) * intervalNs, f, frameCount)
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+            )
+
+            assertNoFailures(failures)
+        }
+
+        /// Each read result must have strictly ascending timestamps.
+        func test_periodicWriter_multipleReaders_timestampsAscendingWithinResult() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let failures = runWithReaders(
+                buf: buf, readerCount: 4,
+                validate: { result, fc in
+                    guard result.count > 1 else { return }
+                    for i in 1..<result.count {
+                        let prev = result.records[i - 1].timestamp_ns
+                        let cur = result.records[i].timestamp_ns
+                        if cur <= prev {
+                            fc.record("Non-ascending timestamps at index \(i): \(prev) >= \(cur)")
+                        }
+                    }
+                },
+                writerBlock: { _ in
+                    for i in 0..<10 {
+                        let f: [UInt] = [UInt(i + 1)]
+                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, 1)
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+            )
+
+            assertNoFailures(failures)
+        }
+
+        /// Every returned record must have believable frame_count (≤ 10 000) and
+        /// a non-nil frames pointer when frame_count > 0.
+        func test_periodicWriter_multipleReaders_recordStructureAlwaysValid() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let failures = runWithReaders(
+                buf: buf, readerCount: 4,
+                validate: { result, fc in
+                    for i in 0..<result.count {
+                        let rec = result.records[i]
+                        if rec.frame_count > 10_000 {
+                            fc.record("record[\(i)].frame_count=\(rec.frame_count) is impossibly large")
+                        }
+                        if rec.frame_count > 0 && rec.frames == nil {
+                            fc.record("record[\(i)] has frame_count=\(rec.frame_count) but nil frames pointer")
+                        }
+                    }
+                },
+                writerBlock: { _ in
+                    for i in 0..<10 {
+                        let fc = (i % 8) + 1
+                        let f = self.makeFrames(writeIndex: i, count: fc)
+                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, fc)
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+            )
+
+            assertNoFailures(failures)
+        }
+
+        /// Readers survive a one-page buffer wrapping many times.
+        func test_periodicWriter_multipleReaders_wrapAroundNoCrash() {
+            let buf = emb_ring_buffer_create(4 * Int(getpagesize()))!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let failures = runWithReaders(
+                buf: buf, readerCount: 4,
+                validate: { result, fc in
+                    for i in 0..<result.count {
+                        if result.records[i].frame_count > 10_000 {
+                            fc.record("wrap-around: record[\(i)].frame_count is corrupt")
+                        }
+                    }
+                },
+                writerBlock: { _ in
+                    // 60 writes with a one-page buffer forces many wrap-arounds.
+                    for i in 0..<60 {
+                        let fc = (i % 12) + 1
+                        let f = self.makeFrames(writeIndex: i, count: fc)
+                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, fc)
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+            )
+
+            assertNoFailures(failures)
+        }
+
+        /// Readers survive evictions happening while they are mid-read.
+        func test_periodicWriter_multipleReaders_evictionDuringRead() {
+            let buf = emb_ring_buffer_create(Int(getpagesize()))!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let failures = runWithReaders(
+                buf: buf, readerCount: 6,
+                validate: { result, fc in
+                    for i in 0..<result.count {
+                        if result.records[i].frame_count > 10_000 {
+                            fc.record("eviction: record[\(i)].frame_count corrupt")
+                        }
+                    }
+                    guard result.count > 1 else { return }
+                    for i in 1..<result.count {
+                        let prev = result.records[i - 1].timestamp_ns
+                        let cur = result.records[i].timestamp_ns
+                        if cur < prev {
+                            fc.record("eviction: timestamp went backwards \(prev) → \(cur)")
+                        }
+                    }
+                },
+                writerBlock: { _ in
+                    for i in 0..<40 {
+                        let f = self.makeFrames(writeIndex: i, count: 10)
+                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, 10)
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+            )
+
+            assertNoFailures(failures)
+        }
+
+        /// Many concurrent readers all read simultaneously after a batch of writes.
+        /// All readers must get the same record count and identical timestamps.
+        func test_simultaneousReaders_sameBuffer_consistentResults() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Pre-populate with 20 records.
+            for i in 0..<20 {
+                let fc = (i % 5) + 1
+                let f = makeFrames(writeIndex: i, count: fc)
+                emb_ring_buffer_write(buf, UInt64(i + 1) * 1_000_000, f, fc)
+            }
+
+            let readerCount = 8
+            let resultsLock = NSLock()
+            var snapshots = [[UInt64]]()
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "ring.simultaneous", attributes: .concurrent)
+
+            for _ in 0..<readerCount {
+                group.enter()
+                queue.async {
+                    var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+                    let ts = (0..<result.count).map { result.records[$0].timestamp_ns }
+                    emb_ring_read_result_free(&result)
+                    resultsLock.lock()
+                    snapshots.append(ts)
+                    resultsLock.unlock()
+                    group.leave()
+                }
+            }
+            group.wait()
+
+            let ref = snapshots[0]
+            for r in 1..<snapshots.count {
+                XCTAssertEqual(
+                    snapshots[r], ref,
+                    "reader \(r) got different timestamps than reader 0")
+            }
+        }
+
+        /// Windowed readers must only ever see records inside their requested range.
+        func test_periodicWriter_rangeReaders_onlySeeWindowedRecords() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let intervalNs: UInt64 = 100_000_000
+            let windowStart: UInt64 = 2 * intervalNs
+            let windowEnd: UInt64 = 7 * intervalNs
+
+            let failures = FailureCollector()
+            let stop = StopFlag()
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "ring.window.readers", attributes: .concurrent)
+
+            for _ in 0..<4 {
+                group.enter()
+                queue.async {
+                    while !stop.isSet {
+                        var result = emb_ring_buffer_read_range(buf, windowStart, windowEnd)
+                        for i in 0..<result.count {
+                            let ts = result.records[i].timestamp_ns
+                            if ts < windowStart || ts > windowEnd {
+                                failures.record("windowed read: ts=\(ts) outside [\(windowStart), \(windowEnd)]")
+                            }
+                        }
+                        emb_ring_read_result_free(&result)
+                    }
+                    group.leave()
+                }
+            }
+
+            for i in 0..<10 {
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, UInt64(i) * intervalNs, f, 1)
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+            stop.set()
+            group.wait()
+
+            assertNoFailures(failures)
+        }
+
+        /// Stress: 8 readers + high-frequency writer (no sleep between writes).
+        ///
+        /// This test intentionally violates the "1 ms periodic writer" invariant to
+        /// verify the buffer does not crash or deadlock under pathological write rates.
+        /// This should never happen under proper usage, but we test it anyway.
+        /// The implementation documents that a second torn read after retry is possible when
+        /// the writer is continuous; this test therefore only checks liveness (no crash /
+        /// no deadlock / no infinite loop), NOT frame-data correctness.
+        func test_stress_highFrequencyWriter_manyReaders_noCrash() {
+            let buf = emb_ring_buffer_create(2 * Int(getpagesize()))!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Threshold matches the implementation's own sanity limit (unbelievable_frame_count).
+            let unbelievableFrameCount = 1_000_000
+
+            let failures = FailureCollector()
+            let stop = StopFlag()
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "ring.stress.readers", attributes: .concurrent)
+
+            for _ in 0..<8 {
+                group.enter()
+                queue.async {
+                    while !stop.isSet {
+                        var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+                        // Under continuous writes the implementation may deliver a record whose
+                        // frame_count was read mid-write. Accept anything below the
+                        // implementation's own unbelievable_frame_count sanity limit.
+                        for i in 0..<result.count {
+                            if result.records[i].frame_count > unbelievableFrameCount {
+                                failures.record("stress: frame_count \(result.records[i].frame_count) exceeds implementation limit")
+                            }
+                        }
+                        emb_ring_read_result_free(&result)
+                    }
+                    group.leave()
+                }
+            }
+
+            let deadline = Date().addingTimeInterval(0.5)
+            var writeCount = 0
+            while Date() < deadline {
+                let fc = (writeCount % 10) + 1
+                let f = makeFrames(writeIndex: writeCount, count: fc)
+                emb_ring_buffer_write(buf, UInt64(writeCount + 1) * 1_000_000, f, fc)
+                writeCount += 1
+            }
+
+            stop.set()
+            group.wait()
+
+            assertNoFailures(failures)
+            XCTAssertGreaterThan(writeCount, 0)
+        }
+
+        /// Three non-overlapping range readers: no reader ever sees a record outside its window.
+        func test_periodicWriter_partitionedRangeReaders_noRangeViolation() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let intervalNs: UInt64 = 100_000_000
+            let windows: [(start: UInt64, end: UInt64)] = [
+                (0, 3 * intervalNs),
+                (3 * intervalNs + 1, 6 * intervalNs),
+                (6 * intervalNs + 1, 9 * intervalNs)
+            ]
+
+            let failures = FailureCollector()
+            let stop = StopFlag()
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "ring.partition.readers", attributes: .concurrent)
+
+            for window in windows {
+                group.enter()
+                queue.async {
+                    while !stop.isSet {
+                        var result = emb_ring_buffer_read_range(buf, window.start, window.end)
+                        for i in 0..<result.count {
+                            let ts = result.records[i].timestamp_ns
+                            if ts < window.start || ts > window.end {
+                                failures.record("partition violation: ts=\(ts) not in [\(window.start), \(window.end)]")
+                            }
+                        }
+                        emb_ring_read_result_free(&result)
+                    }
+                    group.leave()
+                }
+            }
+
+            for i in 0..<10 {
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, UInt64(i) * intervalNs, f, 1)
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+            stop.set()
+            group.wait()
+
+            assertNoFailures(failures)
+        }
+
+        /// After the writer stops, 20 concurrent readers must all see identical data.
+        func test_afterWriterStops_readsAreStable() {
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 0..<10 {
+                let f = makeFrames(writeIndex: i, count: 5)
+                emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, 5)
+            }
+
+            let readerCount = 20
+            let lock = NSLock()
+            var snapshots = [[UInt64]]()
+            let group = DispatchGroup()
+            let queue = DispatchQueue(label: "ring.stable.readers", attributes: .concurrent)
+
+            for _ in 0..<readerCount {
+                group.enter()
+                queue.async {
+                    var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+                    let ts = (0..<result.count).map { result.records[$0].timestamp_ns }
+                    emb_ring_read_result_free(&result)
+                    lock.lock()
+                    snapshots.append(ts)
+                    lock.unlock()
+                    group.leave()
+                }
+            }
+            group.wait()
+
+            let ref = snapshots[0]
+            for i in 1..<snapshots.count {
+                XCTAssertEqual(
+                    snapshots[i], ref,
+                    "reader \(i) saw different data than reader 0 after writer stopped")
+            }
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
@@ -112,7 +112,7 @@
 
         /// 100 ms periodic writer, 4 readers: frame data must be internally consistent.
         func test_periodicWriter_multipleReaders_noFrameCorruption() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let intervalNs: UInt64 = 100_000_000
@@ -142,7 +142,7 @@
 
         /// Each read result must have strictly ascending timestamps.
         func test_periodicWriter_multipleReaders_timestampsAscendingWithinResult() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let failures = runWithReaders(
@@ -171,7 +171,7 @@
 
         /// Every returned record must have believable frame_count (≤ 10 000).
         func test_periodicWriter_multipleReaders_recordStructureAlwaysValid() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let failures = runWithReaders(
@@ -197,9 +197,9 @@
             assertNoFailures(failures)
         }
 
-        /// Readers survive a one-page buffer wrapping many times.
+        /// Readers survive a four-page buffer wrapping many times.
         func test_periodicWriter_multipleReaders_wrapAroundNoCrash() {
-            let buf = emb_ring_buffer_create(4 * Int(getpagesize()))!
+            let buf = emb_ring_buffer_create(4 * Int(getpagesize()), nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let failures = runWithReaders(
@@ -226,7 +226,7 @@
 
         /// Readers survive evictions happening while they are mid-read.
         func test_periodicWriter_multipleReaders_evictionDuringRead() {
-            let buf = emb_ring_buffer_create(Int(getpagesize()))!
+            let buf = emb_ring_buffer_create(Int(getpagesize()), nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let failures = runWithReaders(
@@ -260,7 +260,7 @@
 
         /// Many concurrent readers all read simultaneously after a batch of writes.
         func test_simultaneousReaders_sameBuffer_consistentResults() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 0..<20 {
@@ -303,7 +303,7 @@
 
         /// Windowed readers must only ever see records inside their requested range.
         func test_periodicWriter_rangeReaders_onlySeeWindowedRecords() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let intervalNs: UInt64 = 100_000_000
@@ -350,7 +350,7 @@
 
         /// Stress: 8 readers + high-frequency writer (no sleep between writes).
         func test_stress_highFrequencyWriter_manyReaders_noCrash() {
-            let buf = emb_ring_buffer_create(2 * Int(getpagesize()))!
+            let buf = emb_ring_buffer_create(2 * Int(getpagesize()), nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let unbelievableFrameCount = 1_000_000
@@ -399,7 +399,7 @@
 
         /// Three non-overlapping range readers: no reader ever sees a record outside its window.
         func test_periodicWriter_partitionedRangeReaders_noRangeViolation() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let intervalNs: UInt64 = 100_000_000
@@ -450,7 +450,7 @@
         /// Small (1-page) buffer with high-frequency writer forcing wrap-around.
         /// 4+ concurrent readers verify no frame corruption and ascending timestamps.
         func test_smallBuffer_highFrequencyWrapAround_noCorruption() {
-            let buf = emb_ring_buffer_create(Int(getpagesize()))!
+            let buf = emb_ring_buffer_create(Int(getpagesize()), nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let writeCount = 500
@@ -497,7 +497,7 @@
 
         /// After the writer stops, 20 concurrent readers must all see identical data.
         func test_afterWriterStops_readsAreStable() {
-            let buf = emb_ring_buffer_create(1 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(1 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 0..<10 {

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
@@ -13,9 +13,9 @@
     final class RingBufferEdgeCaseTests: XCTestCase {
 
         // Record layout constants (64-bit):
-        //   _Atomic uint32_t seq       = 4 bytes
-        //   uint32_t frame_count       = 4 bytes
-        //   uint64_t timestamp_ns      = 8 bytes
+        //   uint32_t seq             = 4 bytes
+        //   uint32_t frame_count     = 4 bytes
+        //   uint64_t timestamp_ns    = 8 bytes
         //   + 8 bytes per frame
         static let headerSize = 16
         static let frameSize = 8
@@ -27,7 +27,6 @@
         // MARK: - Lifecycle
 
         func test_create_zeroCapacity_returnsNil() {
-            // round_size_up_to_page_boundary(0) == 0, implementation returns NULL.
             let buf = emb_ring_buffer_create(0)
             XCTAssertNil(buf)
         }
@@ -72,14 +71,16 @@
             guard let buf else { return XCTFail() }
             defer { emb_ring_buffer_destroy(buf) }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
-            XCTAssertEqual(result.count, 0)
-            XCTAssertNil(result.records)
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 0)
         }
 
         func test_destroy_nil_doesNotCrash() {
             emb_ring_buffer_destroy(nil)
+        }
+
+        func test_capacity_nil_returnsZero() {
+            XCTAssertEqual(emb_ring_buffer_capacity(nil), 0)
         }
 
         func test_create_destroy_repeatedCycles_noLeak() {
@@ -155,9 +156,8 @@
             defer { emb_ring_buffer_destroy(buf) }
             emb_ring_buffer_write(buf, 1_000, nil, 3)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
-            XCTAssertEqual(result.count, 0)
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 0)
         }
 
         // MARK: - Frame data preservation
@@ -169,13 +169,12 @@
             let frames: [UInt] = [0xDEAD_BEEF, 0xCAFE_BABE, 0x1234_5678, 0xFFFF_FFFF]
             emb_ring_buffer_write(buf, 42_000, frames, frames.count)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result.records[0].frame_count, frames.count)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].frame_count, frames.count)
             for i in 0..<frames.count {
-                XCTAssertEqual(result.records[0].frames[i], frames[i], "frame \(i)")
+                XCTAssertEqual(records[0].frames[i], frames[i], "frame \(i)")
             }
         }
 
@@ -186,12 +185,11 @@
             let frames = [UInt](repeating: 0, count: 8)
             emb_ring_buffer_write(buf, 1_000, frames, frames.count)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(records.count, 1)
             for i in 0..<frames.count {
-                XCTAssertEqual(result.records[0].frames[i], 0, "frame \(i)")
+                XCTAssertEqual(records[0].frames[i], 0, "frame \(i)")
             }
         }
 
@@ -202,12 +200,11 @@
             let frames = [UInt](repeating: UInt.max, count: 8)
             emb_ring_buffer_write(buf, 2_000, frames, frames.count)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(records.count, 1)
             for i in 0..<frames.count {
-                XCTAssertEqual(result.records[0].frames[i], UInt.max, "frame \(i)")
+                XCTAssertEqual(records[0].frames[i], UInt.max, "frame \(i)")
             }
         }
 
@@ -219,13 +216,12 @@
             let frames = (0..<count).map { UInt($0 + 1) }
             emb_ring_buffer_write(buf, 99_000, frames, count)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result.records[0].frame_count, count)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].frame_count, count)
             for i in 0..<count {
-                XCTAssertEqual(result.records[0].frames[i], UInt(i + 1), "frame \(i)")
+                XCTAssertEqual(records[0].frames[i], UInt(i + 1), "frame \(i)")
             }
         }
 
@@ -245,12 +241,11 @@
                 emb_ring_buffer_write(buf, def.ts, def.frames, def.frames.count)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, recordDefs.count)
-            for i in 0..<result.count {
-                let rec = result.records[i]
+            XCTAssertEqual(records.count, recordDefs.count)
+            for i in 0..<records.count {
+                let rec = records[i]
                 let def = recordDefs[i]
                 XCTAssertEqual(rec.timestamp_ns, def.ts, "record \(i) timestamp")
                 XCTAssertEqual(rec.frame_count, def.frames.count, "record \(i) frame_count")
@@ -263,7 +258,6 @@
         // MARK: - Eviction edge cases
 
         func test_eviction_exactFit_noEviction() {
-            // 1-frame records: 24 bytes each (16 header + 8 frame).
             let page = Int(getpagesize())
             let buf = emb_ring_buffer_create(page)!
             defer { emb_ring_buffer_destroy(buf) }
@@ -276,12 +270,11 @@
                 emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, fits, "all \(fits) records must fit without eviction")
-            XCTAssertEqual(result.records[0].timestamp_ns, 1)
-            XCTAssertEqual(result.records[fits - 1].timestamp_ns, UInt64(fits))
+            XCTAssertEqual(records.count, fits, "all \(fits) records must fit without eviction")
+            XCTAssertEqual(records[0].timestamp_ns, 1)
+            XCTAssertEqual(records[fits - 1].timestamp_ns, UInt64(fits))
         }
 
         func test_eviction_onePastCapacity_evictsOldest() {
@@ -297,18 +290,16 @@
                 emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
             }
 
-            // One more triggers eviction of record 1 (ts=1).
             let f: [UInt] = [0xBEEF]
             emb_ring_buffer_write(buf, UInt64(fits + 1), f, 1)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, fits)
+            XCTAssertEqual(records.count, fits)
             XCTAssertEqual(
-                result.records[0].timestamp_ns, 2,
+                records[0].timestamp_ns, 2,
                 "record with ts=1 should be evicted")
-            XCTAssertEqual(result.records[fits - 1].timestamp_ns, UInt64(fits + 1))
+            XCTAssertEqual(records[fits - 1].timestamp_ns, UInt64(fits + 1))
         }
 
         func test_eviction_largeRecordEvictsMultipleSmallOnes() {
@@ -316,33 +307,27 @@
             let buf = emb_ring_buffer_create(page)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            // Fill with 1-frame (24-byte) records.
             let smallCount = page / RingBufferEdgeCaseTests.recordSize(1)
             for i in 0..<smallCount {
                 let f: [UInt] = [UInt(i + 1)]
                 emb_ring_buffer_write(buf, UInt64(i + 1) * 100, f, 1)
             }
 
-            var before = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            let cntBefore = before.count
-            emb_ring_read_result_free(&before)
+            let cntBefore = testReadRange(buf, 0, UINT64_MAX).count
             XCTAssertEqual(cntBefore, smallCount)
 
-            // Write one large record (50 frames = 416 bytes).
-            // It must evict ceil(416/24) ≈ 18 small records before fitting.
             let largeFC = 50
             let largeFrames = [UInt](repeating: 0xDEAD, count: largeFC)
             let largeTS: UInt64 = UInt64(smallCount + 1) * 100
             emb_ring_buffer_write(buf, largeTS, largeFrames, largeFC)
 
-            var after = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&after) }
+            let after = testReadRange(buf, 0, UINT64_MAX)
 
             XCTAssertLessThan(
                 after.count, smallCount + 1,
                 "large write must have evicted some small records")
 
-            let last = after.records[after.count - 1]
+            let last = after[after.count - 1]
             XCTAssertEqual(last.timestamp_ns, largeTS)
             XCTAssertEqual(last.frame_count, largeFC)
             for j in 0..<largeFC {
@@ -355,7 +340,6 @@
             let buf = emb_ring_buffer_create(page)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            // Zero-frame records are 16 bytes (header only). 4096/16 = 256 fit.
             let zeroSize = RingBufferEdgeCaseTests.headerSize
             let zeroCount = page / zeroSize
 
@@ -364,20 +348,16 @@
                 emb_ring_buffer_write(buf, UInt64(i + 1) * 100, empty, 0)
             }
 
-            var before = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            let cntBefore = before.count
-            emb_ring_read_result_free(&before)
+            let cntBefore = testReadRange(buf, 0, UINT64_MAX).count
             XCTAssertEqual(cntBefore, zeroCount)
 
-            // Write one more zero-frame record — evicts the oldest.
             emb_ring_buffer_write(buf, UInt64(zeroCount + 1) * 100, empty, 0)
 
-            var after = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&after) }
+            let after = testReadRange(buf, 0, UINT64_MAX)
 
             XCTAssertEqual(after.count, zeroCount)
             XCTAssertEqual(
-                after.records[0].timestamp_ns, 200,
+                after[0].timestamp_ns, 200,
                 "oldest (ts=100) should be evicted; next is ts=200")
         }
 
@@ -388,24 +368,22 @@
 
             let rSize = RingBufferEdgeCaseTests.recordSize(10)
             let perPage = page / rSize
-            let totalWrites = perPage * 5  // five complete passes
+            let totalWrites = perPage * 5
 
             for i in 0..<totalWrites {
                 let f = [UInt](repeating: UInt(i + 1), count: 10)
                 emb_ring_buffer_write(buf, UInt64(i + 1), f, 10)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertGreaterThan(result.count, 0)
-            XCTAssertLessThanOrEqual(result.count, perPage + 1)
+            XCTAssertGreaterThan(records.count, 0)
+            XCTAssertLessThanOrEqual(records.count, perPage + 1)
 
-            // All surviving timestamps come from the final pass.
             let finalPassStart = UInt64(perPage * 4)
-            for i in 0..<result.count {
+            for i in 0..<records.count {
                 XCTAssertGreaterThan(
-                    result.records[i].timestamp_ns, finalPassStart,
+                    records[i].timestamp_ns, finalPassStart,
                     "record \(i) should be from the last pass")
             }
         }
@@ -416,10 +394,9 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             var ts: UInt64 = 0
-
-            // Write alternating small (1 frame, 24 B) and large (20 frames, 176 B).
             let smallFC = 1
             let largeFC = 20
+
             let smallSz = RingBufferEdgeCaseTests.recordSize(smallFC)
             let largeSz = RingBufferEdgeCaseTests.recordSize(largeFC)
 
@@ -440,22 +417,20 @@
 
             let firstTS: UInt64 = 1
 
-            // Trigger eviction.
             ts += 1
             let extra: [UInt] = [UInt(ts)]
             emb_ring_buffer_write(buf, ts, extra, smallFC)
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
             XCTAssertGreaterThan(
-                result.records[0].timestamp_ns, firstTS,
+                records[0].timestamp_ns, firstTS,
                 "oldest record must be evicted")
 
-            for i in 1..<result.count {
+            for i in 1..<records.count {
                 XCTAssertGreaterThan(
-                    result.records[i].timestamp_ns,
-                    result.records[i - 1].timestamp_ns,
+                    records[i].timestamp_ns,
+                    records[i - 1].timestamp_ns,
                     "timestamps must be strictly ascending after eviction")
             }
         }
@@ -468,38 +443,32 @@
             let rSize = RingBufferEdgeCaseTests.recordSize(1)
             let fits = page / rSize
 
-            // Fill, then write one more to evict ts=1.
-            for i in 0...fits {  // fits+1 writes
+            for i in 0...fits {
                 let f: [UInt] = [UInt(i + 1)]
                 emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
             }
 
-            // Querying exactly for the evicted timestamp should return nothing.
-            var evicted = emb_ring_buffer_read_range(buf, 1, 1)
-            defer { emb_ring_read_result_free(&evicted) }
+            let evicted = testReadRange(buf, 1, 1)
             XCTAssertEqual(evicted.count, 0, "evicted record should not appear in range query")
         }
 
-        // MARK: - Non-monotonic timestamps
+        // MARK: - Prefix skip
 
-        func test_readRange_nonMonotonicTimestamps_returnsContiguousBlock() {
-            // Timestamps go backwards mid-buffer: [100, 200, 50, 300].
-            // A range query starting at 100 enters the second loop at the first
-            // record (ts=100), advances through 200, then hits 50 < start_ns and
-            // stops, returning the contiguous in-range block [100, 200].
+        func test_readRange_skipsPrefix_returnsSuffix() {
             let buf = emb_ring_buffer_create(1024 * 1024)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            for ts: UInt64 in [100, 200, 50, 300] {
+            // Monotonic timestamps; query skips the first two.
+            for ts: UInt64 in [100, 200, 300, 400, 500] {
                 let f: [UInt] = [UInt(ts)]
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 100, 300)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 300, 400)
 
-            XCTAssertEqual(result.count, 2,
-                           "non-monotonic timestamps should return the contiguous in-range block")
+            XCTAssertEqual(records.count, 2)
+            XCTAssertEqual(records[0].timestamp_ns, 300)
+            XCTAssertEqual(records[1].timestamp_ns, 400)
         }
 
         // MARK: - Timestamp range edge cases
@@ -513,13 +482,12 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 300, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 300, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 3)
-            XCTAssertEqual(result.records[0].timestamp_ns, 300)
-            XCTAssertEqual(result.records[1].timestamp_ns, 400)
-            XCTAssertEqual(result.records[2].timestamp_ns, 500)
+            XCTAssertEqual(records.count, 3)
+            XCTAssertEqual(records[0].timestamp_ns, 300)
+            XCTAssertEqual(records[1].timestamp_ns, 400)
+            XCTAssertEqual(records[2].timestamp_ns, 500)
         }
 
         func test_readRange_exactEndBoundary_included() {
@@ -531,13 +499,12 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, 300)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, 300)
 
-            XCTAssertEqual(result.count, 3)
-            XCTAssertEqual(result.records[0].timestamp_ns, 100)
-            XCTAssertEqual(result.records[1].timestamp_ns, 200)
-            XCTAssertEqual(result.records[2].timestamp_ns, 300)
+            XCTAssertEqual(records.count, 3)
+            XCTAssertEqual(records[0].timestamp_ns, 100)
+            XCTAssertEqual(records[1].timestamp_ns, 200)
+            XCTAssertEqual(records[2].timestamp_ns, 300)
         }
 
         func test_readRange_startEqualsEnd_matchingRecord_returnsOne() {
@@ -549,11 +516,10 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 200, 200)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 200, 200)
 
-            XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result.records[0].timestamp_ns, 200)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].timestamp_ns, 200)
         }
 
         func test_readRange_startEqualsEnd_noMatchingRecord_returnsEmpty() {
@@ -565,10 +531,8 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 150, 150)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 0)
+            let records = testReadRange(buf, 150, 150)
+            XCTAssertEqual(records.count, 0)
         }
 
         func test_readRange_startGreaterThanEnd_returnsEmpty() {
@@ -580,10 +544,8 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 500, 100)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 0)
+            let records = testReadRange(buf, 500, 100)
+            XCTAssertEqual(records.count, 0)
         }
 
         func test_readRange_allRecordsBeforeStart_returnsEmpty() {
@@ -595,10 +557,8 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 400, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 0)
+            let records = testReadRange(buf, 400, UINT64_MAX)
+            XCTAssertEqual(records.count, 0)
         }
 
         func test_readRange_allRecordsAfterEnd_returnsEmpty() {
@@ -610,26 +570,21 @@
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, 300)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 0)
+            let records = testReadRange(buf, 0, 300)
+            XCTAssertEqual(records.count, 0)
         }
 
         func test_readRange_gapBetweenRecords_returnsEmpty() {
             let buf = emb_ring_buffer_create(1024 * 1024)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            // Records at 100 and 300; query [150, 250] falls in the gap.
             for ts: UInt64 in [100, 300] {
                 let f: [UInt] = [1]
                 emb_ring_buffer_write(buf, ts, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 150, 250)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 0)
+            let records = testReadRange(buf, 150, 250)
+            XCTAssertEqual(records.count, 0)
         }
 
         func test_readRange_duplicateTimestamps_allReturned() {
@@ -642,12 +597,11 @@
                 emb_ring_buffer_write(buf, sharedTS, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, sharedTS, sharedTS)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, sharedTS, sharedTS)
 
-            XCTAssertEqual(result.count, 7)
-            for i in 0..<result.count {
-                XCTAssertEqual(result.records[i].timestamp_ns, sharedTS)
+            XCTAssertEqual(records.count, 7)
+            for i in 0..<records.count {
+                XCTAssertEqual(records[i].timestamp_ns, sharedTS)
             }
         }
 
@@ -658,12 +612,11 @@
             let f: [UInt] = [0xABCD]
             emb_ring_buffer_write(buf, 0, f, 1)
 
-            var result = emb_ring_buffer_read_range(buf, 0, 0)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, 0)
 
-            XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result.records[0].timestamp_ns, 0)
-            XCTAssertEqual(result.records[0].frames[0], 0xABCD)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].timestamp_ns, 0)
+            XCTAssertEqual(records[0].frames[0], 0xABCD)
         }
 
         func test_readRange_timestampMaxUInt64_matchedByMaxEnd() {
@@ -673,11 +626,10 @@
             let f: [UInt] = [0x1234]
             emb_ring_buffer_write(buf, UINT64_MAX, f, 1)
 
-            var result = emb_ring_buffer_read_range(buf, UINT64_MAX, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, UINT64_MAX, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result.records[0].timestamp_ns, UINT64_MAX)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].timestamp_ns, UINT64_MAX)
         }
 
         func test_readRange_singleRecordInLargeSet() {
@@ -689,19 +641,17 @@
                 emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 1)
             }
 
-            // Only timestamp 11_000 (i=11) is in range [11000, 11000].
-            var result = emb_ring_buffer_read_range(buf, 11_000, 11_000)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 11_000, 11_000)
 
-            XCTAssertEqual(result.count, 1)
-            XCTAssertEqual(result.records[0].timestamp_ns, 11_000)
-            XCTAssertEqual(result.records[0].frames[0], 11)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].timestamp_ns, 11_000)
+            XCTAssertEqual(records[0].frames[0], 11)
         }
 
         func test_readRange_nilBuffer_returnsEmptyResult() {
-            let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX)
-            XCTAssertEqual(result.count, 0)
-            XCTAssertNil(result.records)
+            var output = [UInt8](repeating: 0, count: 16)
+            let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX, &output, output.count)
+            XCTAssertEqual(result.record_count, 0)
         }
 
         func test_readRange_subsetInMiddle() {
@@ -713,38 +663,15 @@
                 emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 1)
             }
 
-            // Range [5000, 10000] should return records at 5000..10000 inclusive.
-            var result = emb_ring_buffer_read_range(buf, 5_000, 10_000)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 5_000, 10_000)
 
-            XCTAssertEqual(result.count, 6)
-            for i in 0..<result.count {
-                XCTAssertEqual(result.records[i].timestamp_ns, UInt64(i + 5) * 1_000)
+            XCTAssertEqual(records.count, 6)
+            for i in 0..<records.count {
+                XCTAssertEqual(records[i].timestamp_ns, UInt64(i + 5) * 1_000)
             }
         }
 
         // MARK: - Read result integrity
-
-        func test_readResult_freeNilRecords_doesNotCrash() {
-            var zero = emb_ring_read_result_t(records: nil, count: 0)
-            emb_ring_read_result_free(&zero)
-        }
-
-        func test_readResult_free_clearsFieldsToZero() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
-            defer { emb_ring_buffer_destroy(buf) }
-
-            let f: [UInt] = [1, 2, 3]
-            emb_ring_buffer_write(buf, 1_000, f, f.count)
-
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            XCTAssertNotNil(result.records)
-            XCTAssertGreaterThan(result.count, 0)
-
-            emb_ring_read_result_free(&result)
-            XCTAssertNil(result.records)
-            XCTAssertEqual(result.count, 0)
-        }
 
         func test_readResult_consecutiveCalls_identicalData() {
             let buf = emb_ring_buffer_create(1024 * 1024)!
@@ -755,42 +682,19 @@
                 emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
             }
 
-            var r1 = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            var r2 = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer {
-                emb_ring_read_result_free(&r1)
-                emb_ring_read_result_free(&r2)
-            }
+            let r1 = testReadRange(buf, 0, UINT64_MAX)
+            let r2 = testReadRange(buf, 0, UINT64_MAX)
 
             XCTAssertEqual(r1.count, r2.count)
             for i in 0..<r1.count {
-                XCTAssertEqual(r1.records[i].timestamp_ns, r2.records[i].timestamp_ns)
-                XCTAssertEqual(r1.records[i].frame_count, r2.records[i].frame_count)
-                for j in 0..<r1.records[i].frame_count {
+                XCTAssertEqual(r1[i].timestamp_ns, r2[i].timestamp_ns)
+                XCTAssertEqual(r1[i].frame_count, r2[i].frame_count)
+                for j in 0..<r1[i].frame_count {
                     XCTAssertEqual(
-                        r1.records[i].frames[j], r2.records[i].frames[j],
+                        r1[i].frames[j], r2[i].frames[j],
                         "record \(i) frame \(j)")
                 }
             }
-        }
-
-        func test_readResult_framesPointerWithinAllocation() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
-            defer { emb_ring_buffer_destroy(buf) }
-
-            let f: [UInt] = [0xA, 0xB, 0xC]
-            emb_ring_buffer_write(buf, 1_000, f, f.count)
-
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 1)
-            let recBase = Int(bitPattern: UnsafeRawPointer(result.records))
-            let framesPtr = Int(bitPattern: UnsafeRawPointer(result.records[0].frames))
-
-            // frames must lie after the record array, within a reasonable range.
-            XCTAssertGreaterThan(framesPtr, recBase)
-            XCTAssertLessThan(framesPtr - recBase, 65_536)
         }
 
         func test_readResult_timestampsMonotonicallyIncreasing() {
@@ -802,13 +706,12 @@
                 emb_ring_buffer_write(buf, UInt64(i) * 100_000_000, f, 1)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            for i in 1..<result.count {
+            for i in 1..<records.count {
                 XCTAssertGreaterThan(
-                    result.records[i].timestamp_ns,
-                    result.records[i - 1].timestamp_ns,
+                    records[i].timestamp_ns,
+                    records[i - 1].timestamp_ns,
                     "timestamps must be strictly increasing")
             }
         }
@@ -821,7 +724,6 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let capacity = Int(buf.pointee.capacity)
-            // 3-frame records = 40 bytes.  Fill until the next write would straddle.
             let rSize = RingBufferEdgeCaseTests.recordSize(3)
             var total = 0
             var ts: UInt64 = 0
@@ -833,7 +735,6 @@
                 total += rSize
             }
 
-            // Remaining space at end of buffer.
             let remaining = capacity - (total % capacity)
             let willStraddle = remaining > 0 && remaining < rSize
 
@@ -842,16 +743,14 @@
             let ok = emb_ring_buffer_write(buf, ts, straddle, 3)
             XCTAssertTrue(ok, "write straddling boundary must succeed")
 
-            var result = emb_ring_buffer_read_range(buf, ts, ts)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, ts, ts)
 
             if willStraddle {
-                XCTAssertEqual(result.count, 1, "straddling record must be readable")
-                XCTAssertEqual(result.records[0].frames[0], UInt(ts))
-                XCTAssertEqual(result.records[0].frames[1], UInt(ts + 1))
-                XCTAssertEqual(result.records[0].frames[2], UInt(ts + 2))
+                XCTAssertEqual(records.count, 1, "straddling record must be readable")
+                XCTAssertEqual(records[0].frames[0], UInt(ts))
+                XCTAssertEqual(records[0].frames[1], UInt(ts + 1))
+                XCTAssertEqual(records[0].frames[2], UInt(ts + 2))
             } else {
-                // Didn't straddle this time due to alignment, but write still succeeded.
                 XCTAssertTrue(ok)
             }
         }
@@ -870,27 +769,24 @@
                 emb_ring_buffer_write(buf, UInt64(i + 1), f, 5)
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertGreaterThan(result.count, 0)
-            XCTAssertLessThanOrEqual(result.count, perPage + 1)
+            XCTAssertGreaterThan(records.count, 0)
+            XCTAssertLessThanOrEqual(records.count, perPage + 1)
 
-            // Every surviving record's frames must match the write pattern: frame[j] = ts.
-            for i in 0..<result.count {
-                let ts = result.records[i].timestamp_ns
-                for j in 0..<result.records[i].frame_count {
+            for i in 0..<records.count {
+                let ts = records[i].timestamp_ns
+                for j in 0..<records[i].frame_count {
                     XCTAssertEqual(
-                        result.records[i].frames[j], UInt(ts),
+                        records[i].frames[j], UInt(ts),
                         "record \(i) frame \(j): expected \(ts)")
                 }
             }
 
-            // Timestamps are strictly ascending.
-            for i in 1..<result.count {
+            for i in 1..<records.count {
                 XCTAssertGreaterThan(
-                    result.records[i].timestamp_ns,
-                    result.records[i - 1].timestamp_ns)
+                    records[i].timestamp_ns,
+                    records[i - 1].timestamp_ns)
             }
         }
 
@@ -898,7 +794,6 @@
             let buf = emb_ring_buffer_create(4 * Int(getpagesize()))!
             defer { emb_ring_buffer_destroy(buf) }
 
-            // Write records with frame counts cycling 0,1,2,...,15,0,1,...
             let n = 200
             var defs: [(ts: UInt64, fc: Int, sentinel: UInt)] = []
             for i in 0..<n {
@@ -916,14 +811,12 @@
                 }
             }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertGreaterThan(result.count, 0)
+            XCTAssertGreaterThan(records.count, 0)
 
-            for i in 0..<result.count {
-                let rec = result.records[i]
-                // Find matching def by timestamp.
+            for i in 0..<records.count {
+                let rec = records[i]
                 guard let def = defs.first(where: { $0.ts == rec.timestamp_ns }) else {
                     XCTFail("unknown timestamp \(rec.timestamp_ns)")
                     continue
@@ -935,6 +828,351 @@
                         "ts=\(def.ts) frame \(j)")
                 }
             }
+        }
+
+        // MARK: - Record size vs capacity
+
+        func test_write_recordExceedingCapacity_returnsFalse() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // A record needs header(16) + frameCount*8 bytes.
+            // Choose enough frames to exceed one page.
+            let frameCount = (page / RingBufferEdgeCaseTests.frameSize) + 1
+            let frames = [UInt](repeating: 0xDEAD, count: frameCount)
+
+            let success = emb_ring_buffer_write(buf, 1_000, frames, frameCount)
+            XCTAssertFalse(success,
+                "Write should fail when record size exceeds buffer capacity")
+
+            // Buffer should remain empty and functional.
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 0)
+
+            // A smaller write should still succeed.
+            let small: [UInt] = [1]
+            XCTAssertTrue(emb_ring_buffer_write(buf, 2_000, small, 1))
+        }
+
+        func test_write_recordAtExactCapacity_succeeds() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Compute the frame count that makes record_size == capacity exactly.
+            let capacity = Int(buf.pointee.capacity)
+            let frameCount = (capacity - RingBufferEdgeCaseTests.headerSize)
+                / RingBufferEdgeCaseTests.frameSize
+
+            let frames = (0..<frameCount).map { UInt($0 + 1) }
+            let success = emb_ring_buffer_write(buf, 42_000, frames, frameCount)
+            XCTAssertTrue(success,
+                "Write should succeed when record exactly fills buffer")
+
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].frame_count, frameCount)
+            XCTAssertEqual(records[0].timestamp_ns, 42_000)
+        }
+
+        // MARK: - Output buffer edge cases
+
+        func test_readRange_smallOutputBuffer_doesNotCrash() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 1...20 {
+                let f: [UInt] = [UInt(i), UInt(i * 10)]
+                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
+            }
+
+            // Each record is header(16) + 2 frames(16) = 32 bytes.
+            // Provide a buffer that fits roughly 2 records.
+            let smallSize = 64
+            let output = UnsafeMutablePointer<UInt8>.allocate(capacity: smallSize)
+            defer { output.deallocate() }
+
+            let result = emb_ring_buffer_read_range(
+                buf, 0, UINT64_MAX, output, smallSize)
+
+            // total_bytes must not exceed the provided output size.
+            XCTAssertLessThanOrEqual(result.total_bytes, smallSize,
+                "Copied data must fit within the provided output buffer")
+        }
+
+        func test_readRange_smallOutputBuffer_recordsAreCorrect() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 1...20 {
+                let f: [UInt] = [UInt(i), UInt(i * 10)]
+                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
+            }
+
+            // Each record is header(16) + 2 frames(16) = 32 bytes.
+            // Provide a buffer that fits exactly 2 records.
+            let recordSize = RingBufferEdgeCaseTests.recordSize(2)
+            let smallSize = recordSize * 2
+            let output = UnsafeMutablePointer<UInt8>.allocate(capacity: smallSize)
+            defer { output.deallocate() }
+
+            let result = emb_ring_buffer_read_range(
+                buf, 0, UINT64_MAX, output, smallSize)
+
+            XCTAssertLessThanOrEqual(result.total_bytes, smallSize)
+            XCTAssertGreaterThan(result.record_count, 0,
+                "Should return at least one record in the truncated buffer")
+
+            // Parse and verify the records that fit are correct.
+            let records = parseRecords(output, result)
+            XCTAssertEqual(records.count, result.record_count)
+
+            for record in records {
+                // Timestamps should be from our original writes (multiples of 1000).
+                XCTAssertEqual(record.timestamp_ns % 1_000, 0,
+                    "Timestamp should be a multiple of 1000")
+                let i = Int(record.timestamp_ns / 1_000)
+                XCTAssertGreaterThanOrEqual(i, 1)
+                XCTAssertLessThanOrEqual(i, 20)
+                XCTAssertEqual(record.frame_count, 2)
+                XCTAssertEqual(record.frames[0], UInt(i))
+                XCTAssertEqual(record.frames[1], UInt(i * 10))
+            }
+        }
+
+        func test_readRange_zeroSizeOutput_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let f: [UInt] = [1]
+            emb_ring_buffer_write(buf, 1_000, f, 1)
+
+            // output_size = 0 triggers the NULL/empty guard in read_range.
+            let output = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
+            defer { output.deallocate() }
+
+            let result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX, output, 0)
+            XCTAssertEqual(result.record_count, 0)
+            XCTAssertEqual(result.total_bytes, 0)
+        }
+
+        func test_readRange_nilOutput_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let f: [UInt] = [1]
+            emb_ring_buffer_write(buf, 1_000, f, 1)
+
+            let result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX, nil, 1024)
+            XCTAssertEqual(result.record_count, 0)
+            XCTAssertEqual(result.total_bytes, 0)
+        }
+
+        // MARK: - Reset edge cases
+
+        func test_reset_nilBuffer_returnsFalse() {
+            XCTAssertFalse(emb_ring_buffer_reset(nil))
+        }
+
+        // MARK: - Write with NULL frames and zero frame_count
+
+        func test_write_nilFramesZeroCount_succeeds() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // The C guard is: frames == NULL && frame_count > 0 → false.
+            // NULL frames with 0 count should succeed and produce a zero-frame record.
+            let success = emb_ring_buffer_write(buf, 42_000, nil, 0)
+            XCTAssertTrue(success,
+                "write with NULL frames and 0 frame_count should succeed")
+
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].timestamp_ns, 42_000)
+            XCTAssertEqual(records[0].frame_count, 0)
+        }
+
+        // MARK: - Reset with concurrent readers
+
+        func test_reset_whileReadersActive_returnsFalse() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Fill with large records so reads take measurable time.
+            for i in 0..<100 {
+                let frames = [UInt](repeating: UInt(i + 1), count: 100)
+                emb_ring_buffer_write(buf, UInt64(i + 1) * 1_000, frames, 100)
+            }
+
+            let capacity = emb_ring_buffer_capacity(buf)
+
+            // Use a class wrapper so the closure captures a reference (not a copy),
+            // satisfying Sendable requirements without data races (protected by lock).
+            final class SharedState: @unchecked Sendable {
+                let lock = NSLock()
+                var shouldStop = false
+                var isSet: Bool {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    return shouldStop
+                }
+                func stop() {
+                    lock.lock()
+                    shouldStop = true
+                    lock.unlock()
+                }
+            }
+            let state = SharedState()
+
+            let readersDone = DispatchGroup()
+
+            // Start 8 readers doing continuous reads.
+            for _ in 0..<8 {
+                readersDone.enter()
+                DispatchQueue.global().async {
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
+                    while !state.isSet {
+                        _ = emb_ring_buffer_read_range(
+                            buf, 0, UINT64_MAX, output, capacity)
+                    }
+                    readersDone.leave()
+                }
+            }
+
+            // Try reset many times while readers are active.
+            // The reset checks active_readers and should return false
+            // when it catches a reader mid-read.
+            var sawResetFail = false
+            for _ in 0..<10_000 {
+                if !emb_ring_buffer_reset(buf) {
+                    sawResetFail = true
+                    break
+                }
+            }
+            _ = sawResetFail  // Probabilistic; primary goal is no-crash.
+
+            state.stop()
+            readersDone.wait()
+
+            // After all readers stop, reset must succeed.
+            XCTAssertTrue(emb_ring_buffer_reset(buf),
+                "reset should succeed once all readers finish")
+        }
+
+        func test_reset_withConcurrentReaderStarts_noCorruption() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Fill buffer with data.
+            for i in 0..<50 {
+                let frames = [UInt](repeating: UInt(i + 1), count: 20)
+                emb_ring_buffer_write(buf, UInt64(i + 1) * 1_000, frames, 20)
+            }
+
+            let capacity = emb_ring_buffer_capacity(buf)
+            let iterations = 1000
+
+            // Run many reset + concurrent reader start cycles.
+            // The resetting flag should prevent readers from seeing
+            // partially-reset data.
+            final class SharedState: @unchecked Sendable {
+                let lock = NSLock()
+                var shouldStop = false
+                var isSet: Bool {
+                    lock.lock()
+                    defer { lock.unlock() }
+                    return shouldStop
+                }
+                func stop() {
+                    lock.lock()
+                    shouldStop = true
+                    lock.unlock()
+                }
+            }
+            let state = SharedState()
+
+            let group = DispatchGroup()
+            var readerErrors = 0
+            let errLock = NSLock()
+
+            // Spawn readers that continuously try to read.
+            for _ in 0..<4 {
+                group.enter()
+                DispatchQueue.global().async {
+                    let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+                    defer { output.deallocate() }
+
+                    while !state.isSet {
+                        let result = emb_ring_buffer_read_range(
+                            buf, 0, UINT64_MAX, output, capacity)
+                        let records = parseRecords(output, result)
+                        // If we got records, timestamps must be ascending.
+                        if records.count > 1 {
+                            for i in 1..<records.count {
+                                if records[i].timestamp_ns < records[i - 1].timestamp_ns {
+                                    errLock.lock()
+                                    readerErrors += 1
+                                    errLock.unlock()
+                                }
+                            }
+                        }
+                    }
+                    group.leave()
+                }
+            }
+
+            // On the main thread, do reset + refill cycles.
+            for cycle in 0..<iterations {
+                let resetOk = emb_ring_buffer_reset(buf)
+                // Reset may return false if a reader is active; that's fine.
+                if resetOk {
+                    // Refill with fresh data.
+                    for j in 0..<10 {
+                        let ts = UInt64(cycle * 10000 + j + 1)
+                        let frames = [UInt](repeating: UInt(ts), count: 5)
+                        emb_ring_buffer_write(buf, ts, frames, 5)
+                    }
+                }
+            }
+
+            state.stop()
+            group.wait()
+
+            XCTAssertEqual(readerErrors, 0,
+                "Readers should never see corrupted timestamps during reset cycles")
+        }
+
+        // MARK: - Corruption guards
+
+        func test_readRange_corruptedPositions_totalDataExceedsCapacity_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Write some valid data first.
+            let f: [UInt] = [0xCAFE]
+            emb_ring_buffer_write(buf, 1_000, f, 1)
+
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 1, "Precondition: data should be readable")
+
+            // Corrupt the buffer by directly setting write_pos far ahead of oldest_pos,
+            // so that write_pos - oldest_pos > capacity. The read path should detect
+            // this and return empty rather than reading garbage.
+            //
+            // Struct layout: data(8) + capacity(8) + next_seq(8) + write_pos(8)
+            // write_pos is at byte offset 24 from the start of the struct.
+            let capacity = buf.pointee.capacity
+            let corruptWritePos = UInt64(capacity * 2)
+            let writePosOffset = 24  // data(8) + capacity(8) + next_seq(8)
+            UnsafeMutableRawPointer(buf).storeBytes(
+                of: corruptWritePos, toByteOffset: writePosOffset, as: UInt64.self)
+
+            let corruptRecords = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(corruptRecords.count, 0,
+                "read_range should return empty when total_data > capacity (corruption guard)")
         }
     }
 

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
@@ -263,7 +263,7 @@
         // MARK: - Eviction edge cases
 
         func test_eviction_exactFit_noEviction() {
-            // 1-frame records: 32 bytes each.  4096 / 32 = 128 fit exactly.
+            // 1-frame records: 24 bytes each (16 header + 8 frame).
             let page = Int(getpagesize())
             let buf = emb_ring_buffer_create(page)!
             defer { emb_ring_buffer_destroy(buf) }
@@ -406,7 +406,7 @@
             for i in 0..<result.count {
                 XCTAssertGreaterThan(
                     result.records[i].timestamp_ns, finalPassStart,
-                    "record \(i) should be from the last two passes")
+                    "record \(i) should be from the last pass")
             }
         }
 
@@ -478,6 +478,28 @@
             var evicted = emb_ring_buffer_read_range(buf, 1, 1)
             defer { emb_ring_read_result_free(&evicted) }
             XCTAssertEqual(evicted.count, 0, "evicted record should not appear in range query")
+        }
+
+        // MARK: - Non-monotonic timestamps
+
+        func test_readRange_nonMonotonicTimestamps_returnsContiguousBlock() {
+            // Timestamps go backwards mid-buffer: [100, 200, 50, 300].
+            // A range query starting at 100 enters the second loop at the first
+            // record (ts=100), advances through 200, then hits 50 < start_ns and
+            // stops, returning the contiguous in-range block [100, 200].
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 50, 300] {
+                let f: [UInt] = [UInt(ts)]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 100, 300)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 2,
+                           "non-monotonic timestamps should return the contiguous in-range block")
         }
 
         // MARK: - Timestamp range edge cases

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
@@ -1,0 +1,919 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import Darwin
+    import EmbraceProfilingSampler
+    import XCTest
+
+    /// Edge-case tests for emb_ring_buffer.
+    /// All scenarios assume one periodic writer and zero or more concurrent readers.
+    final class RingBufferEdgeCaseTests: XCTestCase {
+
+        // Record layout constants (64-bit):
+        //   _Atomic uint32_t seq       = 4 bytes
+        //   uint32_t frame_count       = 4 bytes
+        //   uint64_t timestamp_ns      = 8 bytes
+        //   + 8 bytes per frame
+        static let headerSize = 16
+        static let frameSize = 8
+
+        static func recordSize(_ frameCount: Int) -> Int {
+            headerSize + frameSize * frameCount
+        }
+
+        // MARK: - Lifecycle
+
+        func test_create_zeroCapacity_returnsNil() {
+            // round_size_up_to_page_boundary(0) == 0, implementation returns NULL.
+            let buf = emb_ring_buffer_create(0)
+            XCTAssertNil(buf)
+        }
+
+        func test_create_oneByte_roundsUpToOnePage() {
+            let buf = emb_ring_buffer_create(1)
+            guard let buf else { return XCTFail("create(1) should succeed") }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let page = Int(getpagesize())
+            XCTAssertEqual(buf.pointee.capacity, page)
+        }
+
+        func test_create_exactlyOnePage_noRounding() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)
+            guard let buf else { return XCTFail() }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            XCTAssertEqual(buf.pointee.capacity, page)
+        }
+
+        func test_create_pagePlusOne_roundsUpToTwoPages() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page + 1)
+            guard let buf else { return XCTFail() }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            XCTAssertEqual(buf.pointee.capacity, 2 * page)
+        }
+
+        func test_create_largeCapacity_succeeds() {
+            let buf = emb_ring_buffer_create(16 * 1024 * 1024)
+            guard let buf else { return XCTFail("16 MB buffer should succeed") }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            XCTAssertGreaterThanOrEqual(buf.pointee.capacity, 16 * 1024 * 1024)
+        }
+
+        func test_create_freshBuffer_isEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf else { return XCTFail() }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+            XCTAssertEqual(result.count, 0)
+            XCTAssertNil(result.records)
+        }
+
+        func test_destroy_nil_doesNotCrash() {
+            emb_ring_buffer_destroy(nil)
+        }
+
+        func test_create_destroy_repeatedCycles_noLeak() {
+            for i in 1...8 {
+                let size = i * 64 * 1024
+                let buf = emb_ring_buffer_create(size)
+                XCTAssertNotNil(buf, "cycle \(i): create should succeed")
+                emb_ring_buffer_destroy(buf)
+            }
+        }
+
+        // MARK: - next_seq progression
+
+        func test_nextSeq_startsAtZero() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+            XCTAssertEqual(buf.pointee.next_seq, 0)
+        }
+
+        func test_nextSeq_incrementsBy2PerSuccessfulWrite() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let frames: [UInt] = [0xCAFE]
+            for i in 1...10 {
+                emb_ring_buffer_write(buf, UInt64(i) * 1_000, frames, frames.count)
+                XCTAssertEqual(
+                    buf.pointee.next_seq, UInt64(i * 2),
+                    "next_seq after \(i) writes")
+            }
+        }
+
+        func test_nextSeq_unchangedOnNilBufferWrite() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            emb_ring_buffer_write(nil, 1_000, [UInt(1)], 1)
+            XCTAssertEqual(buf.pointee.next_seq, 0)
+        }
+
+        func test_nextSeq_unchangedOnNilFramesWrite() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            emb_ring_buffer_write(buf, 1_000, nil, 5)
+            XCTAssertEqual(buf.pointee.next_seq, 0)
+        }
+
+        func test_nextSeq_incrementsForZeroFrameRecords() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let empty: [UInt] = []
+            emb_ring_buffer_write(buf, 1_000, empty, 0)
+            XCTAssertEqual(buf.pointee.next_seq, 2)
+        }
+
+        // MARK: - Write returns false on bad inputs
+
+        func test_write_nilBuffer_returnsFalse() {
+            let frames: [UInt] = [1, 2, 3]
+            XCTAssertFalse(emb_ring_buffer_write(nil, 1_000, frames, frames.count))
+        }
+
+        func test_write_nilFrames_returnsFalse() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+            XCTAssertFalse(emb_ring_buffer_write(buf, 1_000, nil, 3))
+        }
+
+        func test_write_nilFrames_leavesBufferEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+            emb_ring_buffer_write(buf, 1_000, nil, 3)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+            XCTAssertEqual(result.count, 0)
+        }
+
+        // MARK: - Frame data preservation
+
+        func test_frameData_exactValuesPreserved() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let frames: [UInt] = [0xDEAD_BEEF, 0xCAFE_BABE, 0x1234_5678, 0xFFFF_FFFF]
+            emb_ring_buffer_write(buf, 42_000, frames, frames.count)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.records[0].frame_count, frames.count)
+            for i in 0..<frames.count {
+                XCTAssertEqual(result.records[0].frames[i], frames[i], "frame \(i)")
+            }
+        }
+
+        func test_frameData_allZeros_preserved() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let frames = [UInt](repeating: 0, count: 8)
+            emb_ring_buffer_write(buf, 1_000, frames, frames.count)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            for i in 0..<frames.count {
+                XCTAssertEqual(result.records[0].frames[i], 0, "frame \(i)")
+            }
+        }
+
+        func test_frameData_allMaxValue_preserved() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let frames = [UInt](repeating: UInt.max, count: 8)
+            emb_ring_buffer_write(buf, 2_000, frames, frames.count)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            for i in 0..<frames.count {
+                XCTAssertEqual(result.records[0].frames[i], UInt.max, "frame \(i)")
+            }
+        }
+
+        func test_frameData_largeFrameCount_preserved() {
+            let buf = emb_ring_buffer_create(4 * 1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let count = 512
+            let frames = (0..<count).map { UInt($0 + 1) }
+            emb_ring_buffer_write(buf, 99_000, frames, count)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.records[0].frame_count, count)
+            for i in 0..<count {
+                XCTAssertEqual(result.records[0].frames[i], UInt(i + 1), "frame \(i)")
+            }
+        }
+
+        func test_frameData_multipleRecords_eachCorrect() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let recordDefs: [(ts: UInt64, frames: [UInt])] = [
+                (1_000, [10, 20, 30]),
+                (2_000, [0xAAAA, 0xBBBB]),
+                (3_000, []),
+                (4_000, [UInt.max, 0, 1]),
+                (5_000, [42])
+            ]
+
+            for def in recordDefs {
+                emb_ring_buffer_write(buf, def.ts, def.frames, def.frames.count)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, recordDefs.count)
+            for i in 0..<result.count {
+                let rec = result.records[i]
+                let def = recordDefs[i]
+                XCTAssertEqual(rec.timestamp_ns, def.ts, "record \(i) timestamp")
+                XCTAssertEqual(rec.frame_count, def.frames.count, "record \(i) frame_count")
+                for j in 0..<def.frames.count {
+                    XCTAssertEqual(rec.frames[j], def.frames[j], "record \(i) frame \(j)")
+                }
+            }
+        }
+
+        // MARK: - Eviction edge cases
+
+        func test_eviction_exactFit_noEviction() {
+            // 1-frame records: 32 bytes each.  4096 / 32 = 128 fit exactly.
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let rSize = RingBufferEdgeCaseTests.recordSize(1)
+            let fits = page / rSize
+
+            for i in 0..<fits {
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, fits, "all \(fits) records must fit without eviction")
+            XCTAssertEqual(result.records[0].timestamp_ns, 1)
+            XCTAssertEqual(result.records[fits - 1].timestamp_ns, UInt64(fits))
+        }
+
+        func test_eviction_onePastCapacity_evictsOldest() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let rSize = RingBufferEdgeCaseTests.recordSize(1)
+            let fits = page / rSize
+
+            for i in 0..<fits {
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
+            }
+
+            // One more triggers eviction of record 1 (ts=1).
+            let f: [UInt] = [0xBEEF]
+            emb_ring_buffer_write(buf, UInt64(fits + 1), f, 1)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, fits)
+            XCTAssertEqual(
+                result.records[0].timestamp_ns, 2,
+                "record with ts=1 should be evicted")
+            XCTAssertEqual(result.records[fits - 1].timestamp_ns, UInt64(fits + 1))
+        }
+
+        func test_eviction_largeRecordEvictsMultipleSmallOnes() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Fill with 1-frame (24-byte) records.
+            let smallCount = page / RingBufferEdgeCaseTests.recordSize(1)
+            for i in 0..<smallCount {
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, UInt64(i + 1) * 100, f, 1)
+            }
+
+            var before = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            let cntBefore = before.count
+            emb_ring_read_result_free(&before)
+            XCTAssertEqual(cntBefore, smallCount)
+
+            // Write one large record (50 frames = 416 bytes).
+            // It must evict ceil(416/24) ≈ 18 small records before fitting.
+            let largeFC = 50
+            let largeFrames = [UInt](repeating: 0xDEAD, count: largeFC)
+            let largeTS: UInt64 = UInt64(smallCount + 1) * 100
+            emb_ring_buffer_write(buf, largeTS, largeFrames, largeFC)
+
+            var after = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&after) }
+
+            XCTAssertLessThan(
+                after.count, smallCount + 1,
+                "large write must have evicted some small records")
+
+            let last = after.records[after.count - 1]
+            XCTAssertEqual(last.timestamp_ns, largeTS)
+            XCTAssertEqual(last.frame_count, largeFC)
+            for j in 0..<largeFC {
+                XCTAssertEqual(last.frames[j], 0xDEAD, "frame \(j)")
+            }
+        }
+
+        func test_eviction_zeroFrameRecords_evictedCorrectly() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Zero-frame records are 16 bytes (header only). 4096/16 = 256 fit.
+            let zeroSize = RingBufferEdgeCaseTests.headerSize
+            let zeroCount = page / zeroSize
+
+            let empty: [UInt] = []
+            for i in 0..<zeroCount {
+                emb_ring_buffer_write(buf, UInt64(i + 1) * 100, empty, 0)
+            }
+
+            var before = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            let cntBefore = before.count
+            emb_ring_read_result_free(&before)
+            XCTAssertEqual(cntBefore, zeroCount)
+
+            // Write one more zero-frame record — evicts the oldest.
+            emb_ring_buffer_write(buf, UInt64(zeroCount + 1) * 100, empty, 0)
+
+            var after = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&after) }
+
+            XCTAssertEqual(after.count, zeroCount)
+            XCTAssertEqual(
+                after.records[0].timestamp_ns, 200,
+                "oldest (ts=100) should be evicted; next is ts=200")
+        }
+
+        func test_eviction_bufferRemainsFunctionalAfterManyPasses() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let rSize = RingBufferEdgeCaseTests.recordSize(10)
+            let perPage = page / rSize
+            let totalWrites = perPage * 5  // five complete passes
+
+            for i in 0..<totalWrites {
+                let f = [UInt](repeating: UInt(i + 1), count: 10)
+                emb_ring_buffer_write(buf, UInt64(i + 1), f, 10)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertGreaterThan(result.count, 0)
+            XCTAssertLessThanOrEqual(result.count, perPage + 1)
+
+            // All surviving timestamps come from the final pass.
+            let finalPassStart = UInt64(perPage * 4)
+            for i in 0..<result.count {
+                XCTAssertGreaterThan(
+                    result.records[i].timestamp_ns, finalPassStart,
+                    "record \(i) should be from the last two passes")
+            }
+        }
+
+        func test_eviction_mixedSizes_oldestEvictedFirst() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            var ts: UInt64 = 0
+
+            // Write alternating small (1 frame, 24 B) and large (20 frames, 176 B).
+            let smallFC = 1
+            let largeFC = 20
+            let smallSz = RingBufferEdgeCaseTests.recordSize(smallFC)
+            let largeSz = RingBufferEdgeCaseTests.recordSize(largeFC)
+
+            var totalBytes = 0
+            while totalBytes + smallSz <= page {
+                ts += 1
+                let f: [UInt] = [UInt(ts)]
+                emb_ring_buffer_write(buf, ts, f, smallFC)
+                totalBytes += smallSz
+
+                if totalBytes + largeSz <= page {
+                    ts += 1
+                    let lf = [UInt](repeating: UInt(ts), count: largeFC)
+                    emb_ring_buffer_write(buf, ts, lf, largeFC)
+                    totalBytes += largeSz
+                }
+            }
+
+            let firstTS: UInt64 = 1
+
+            // Trigger eviction.
+            ts += 1
+            let extra: [UInt] = [UInt(ts)]
+            emb_ring_buffer_write(buf, ts, extra, smallFC)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertGreaterThan(
+                result.records[0].timestamp_ns, firstTS,
+                "oldest record must be evicted")
+
+            for i in 1..<result.count {
+                XCTAssertGreaterThan(
+                    result.records[i].timestamp_ns,
+                    result.records[i - 1].timestamp_ns,
+                    "timestamps must be strictly ascending after eviction")
+            }
+        }
+
+        func test_eviction_evictedRecord_notVisibleInTimestampQuery() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let rSize = RingBufferEdgeCaseTests.recordSize(1)
+            let fits = page / rSize
+
+            // Fill, then write one more to evict ts=1.
+            for i in 0...fits {  // fits+1 writes
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
+            }
+
+            // Querying exactly for the evicted timestamp should return nothing.
+            var evicted = emb_ring_buffer_read_range(buf, 1, 1)
+            defer { emb_ring_read_result_free(&evicted) }
+            XCTAssertEqual(evicted.count, 0, "evicted record should not appear in range query")
+        }
+
+        // MARK: - Timestamp range edge cases
+
+        func test_readRange_exactStartBoundary_included() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 300, 400, 500] {
+                let f: [UInt] = [UInt(ts)]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 300, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 3)
+            XCTAssertEqual(result.records[0].timestamp_ns, 300)
+            XCTAssertEqual(result.records[1].timestamp_ns, 400)
+            XCTAssertEqual(result.records[2].timestamp_ns, 500)
+        }
+
+        func test_readRange_exactEndBoundary_included() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 300, 400, 500] {
+                let f: [UInt] = [UInt(ts)]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, 300)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 3)
+            XCTAssertEqual(result.records[0].timestamp_ns, 100)
+            XCTAssertEqual(result.records[1].timestamp_ns, 200)
+            XCTAssertEqual(result.records[2].timestamp_ns, 300)
+        }
+
+        func test_readRange_startEqualsEnd_matchingRecord_returnsOne() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 300] {
+                let f: [UInt] = [UInt(ts)]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 200, 200)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.records[0].timestamp_ns, 200)
+        }
+
+        func test_readRange_startEqualsEnd_noMatchingRecord_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 300] {
+                let f: [UInt] = [1]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 150, 150)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_readRange_startGreaterThanEnd_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 300] {
+                let f: [UInt] = [1]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 500, 100)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_readRange_allRecordsBeforeStart_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [100, 200, 300] {
+                let f: [UInt] = [1]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 400, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_readRange_allRecordsAfterEnd_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for ts: UInt64 in [400, 500, 600] {
+                let f: [UInt] = [1]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, 300)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_readRange_gapBetweenRecords_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Records at 100 and 300; query [150, 250] falls in the gap.
+            for ts: UInt64 in [100, 300] {
+                let f: [UInt] = [1]
+                emb_ring_buffer_write(buf, ts, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 150, 250)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_readRange_duplicateTimestamps_allReturned() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let sharedTS: UInt64 = 99_999
+            for i in 0..<7 {
+                let f: [UInt] = [UInt(i + 1)]
+                emb_ring_buffer_write(buf, sharedTS, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, sharedTS, sharedTS)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 7)
+            for i in 0..<result.count {
+                XCTAssertEqual(result.records[i].timestamp_ns, sharedTS)
+            }
+        }
+
+        func test_readRange_timestampZero_matchedByZeroStart() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let f: [UInt] = [0xABCD]
+            emb_ring_buffer_write(buf, 0, f, 1)
+
+            var result = emb_ring_buffer_read_range(buf, 0, 0)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.records[0].timestamp_ns, 0)
+            XCTAssertEqual(result.records[0].frames[0], 0xABCD)
+        }
+
+        func test_readRange_timestampMaxUInt64_matchedByMaxEnd() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let f: [UInt] = [0x1234]
+            emb_ring_buffer_write(buf, UINT64_MAX, f, 1)
+
+            var result = emb_ring_buffer_read_range(buf, UINT64_MAX, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.records[0].timestamp_ns, UINT64_MAX)
+        }
+
+        func test_readRange_singleRecordInLargeSet() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 1...20 {
+                let f: [UInt] = [UInt(i)]
+                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 1)
+            }
+
+            // Only timestamp 11_000 (i=11) is in range [11000, 11000].
+            var result = emb_ring_buffer_read_range(buf, 11_000, 11_000)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result.records[0].timestamp_ns, 11_000)
+            XCTAssertEqual(result.records[0].frames[0], 11)
+        }
+
+        func test_readRange_nilBuffer_returnsEmptyResult() {
+            let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX)
+            XCTAssertEqual(result.count, 0)
+            XCTAssertNil(result.records)
+        }
+
+        func test_readRange_subsetInMiddle() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 1...20 {
+                let f: [UInt] = [UInt(i)]
+                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 1)
+            }
+
+            // Range [5000, 10000] should return records at 5000..10000 inclusive.
+            var result = emb_ring_buffer_read_range(buf, 5_000, 10_000)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 6)
+            for i in 0..<result.count {
+                XCTAssertEqual(result.records[i].timestamp_ns, UInt64(i + 5) * 1_000)
+            }
+        }
+
+        // MARK: - Read result integrity
+
+        func test_readResult_freeNilRecords_doesNotCrash() {
+            var zero = emb_ring_read_result_t(records: nil, count: 0)
+            emb_ring_read_result_free(&zero)
+        }
+
+        func test_readResult_free_clearsFieldsToZero() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let f: [UInt] = [1, 2, 3]
+            emb_ring_buffer_write(buf, 1_000, f, f.count)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            XCTAssertNotNil(result.records)
+            XCTAssertGreaterThan(result.count, 0)
+
+            emb_ring_read_result_free(&result)
+            XCTAssertNil(result.records)
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_readResult_consecutiveCalls_identicalData() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 1...5 {
+                let f: [UInt] = [UInt(i * 10), UInt(i * 10 + 1)]
+                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
+            }
+
+            var r1 = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            var r2 = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer {
+                emb_ring_read_result_free(&r1)
+                emb_ring_read_result_free(&r2)
+            }
+
+            XCTAssertEqual(r1.count, r2.count)
+            for i in 0..<r1.count {
+                XCTAssertEqual(r1.records[i].timestamp_ns, r2.records[i].timestamp_ns)
+                XCTAssertEqual(r1.records[i].frame_count, r2.records[i].frame_count)
+                for j in 0..<r1.records[i].frame_count {
+                    XCTAssertEqual(
+                        r1.records[i].frames[j], r2.records[i].frames[j],
+                        "record \(i) frame \(j)")
+                }
+            }
+        }
+
+        func test_readResult_framesPointerWithinAllocation() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let f: [UInt] = [0xA, 0xB, 0xC]
+            emb_ring_buffer_write(buf, 1_000, f, f.count)
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            let recBase = Int(bitPattern: UnsafeRawPointer(result.records))
+            let framesPtr = Int(bitPattern: UnsafeRawPointer(result.records[0].frames))
+
+            // frames must lie after the record array, within a reasonable range.
+            XCTAssertGreaterThan(framesPtr, recBase)
+            XCTAssertLessThan(framesPtr - recBase, 65_536)
+        }
+
+        func test_readResult_timestampsMonotonicallyIncreasing() {
+            let buf = emb_ring_buffer_create(1024 * 1024)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            for i in 1...30 {
+                let f: [UInt] = [UInt(i)]
+                emb_ring_buffer_write(buf, UInt64(i) * 100_000_000, f, 1)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            for i in 1..<result.count {
+                XCTAssertGreaterThan(
+                    result.records[i].timestamp_ns,
+                    result.records[i - 1].timestamp_ns,
+                    "timestamps must be strictly increasing")
+            }
+        }
+
+        // MARK: - Wrap-around
+
+        func test_wrapAround_recordStraddlingCapacityBoundary_readableAndCorrect() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let capacity = Int(buf.pointee.capacity)
+            // 3-frame records = 40 bytes.  Fill until the next write would straddle.
+            let rSize = RingBufferEdgeCaseTests.recordSize(3)
+            var total = 0
+            var ts: UInt64 = 0
+
+            while total + rSize <= capacity {
+                ts += 1
+                let f: [UInt] = [UInt(ts), UInt(ts + 1), UInt(ts + 2)]
+                emb_ring_buffer_write(buf, ts, f, 3)
+                total += rSize
+            }
+
+            // Remaining space at end of buffer.
+            let remaining = capacity - (total % capacity)
+            let willStraddle = remaining > 0 && remaining < rSize
+
+            ts += 1
+            let straddle: [UInt] = [UInt(ts), UInt(ts + 1), UInt(ts + 2)]
+            let ok = emb_ring_buffer_write(buf, ts, straddle, 3)
+            XCTAssertTrue(ok, "write straddling boundary must succeed")
+
+            var result = emb_ring_buffer_read_range(buf, ts, ts)
+            defer { emb_ring_read_result_free(&result) }
+
+            if willStraddle {
+                XCTAssertEqual(result.count, 1, "straddling record must be readable")
+                XCTAssertEqual(result.records[0].frames[0], UInt(ts))
+                XCTAssertEqual(result.records[0].frames[1], UInt(ts + 1))
+                XCTAssertEqual(result.records[0].frames[2], UInt(ts + 2))
+            } else {
+                // Didn't straddle this time due to alignment, but write still succeeded.
+                XCTAssertTrue(ok)
+            }
+        }
+
+        func test_wrapAround_multiplePasses_onlyRecentRecordsVisible() {
+            let page = Int(getpagesize())
+            let buf = emb_ring_buffer_create(page)!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let rSize = RingBufferEdgeCaseTests.recordSize(5)
+            let perPage = page / rSize
+            let total = perPage * 5
+
+            for i in 0..<total {
+                let f = [UInt](repeating: UInt(i + 1), count: 5)
+                emb_ring_buffer_write(buf, UInt64(i + 1), f, 5)
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertGreaterThan(result.count, 0)
+            XCTAssertLessThanOrEqual(result.count, perPage + 1)
+
+            // Every surviving record's frames must match the write pattern: frame[j] = ts.
+            for i in 0..<result.count {
+                let ts = result.records[i].timestamp_ns
+                for j in 0..<result.records[i].frame_count {
+                    XCTAssertEqual(
+                        result.records[i].frames[j], UInt(ts),
+                        "record \(i) frame \(j): expected \(ts)")
+                }
+            }
+
+            // Timestamps are strictly ascending.
+            for i in 1..<result.count {
+                XCTAssertGreaterThan(
+                    result.records[i].timestamp_ns,
+                    result.records[i - 1].timestamp_ns)
+            }
+        }
+
+        func test_wrapAround_variableFrameCounts_frameDataCorrect() {
+            let buf = emb_ring_buffer_create(4 * Int(getpagesize()))!
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Write records with frame counts cycling 0,1,2,...,15,0,1,...
+            let n = 200
+            var defs: [(ts: UInt64, fc: Int, sentinel: UInt)] = []
+            for i in 0..<n {
+                let fc = i % 16
+                let ts = UInt64(i + 1) * 1_000
+                let sentinel = UInt(i + 1) * 0x10000
+                defs.append((ts, fc, sentinel))
+
+                if fc == 0 {
+                    let empty: [UInt] = []
+                    emb_ring_buffer_write(buf, ts, empty, 0)
+                } else {
+                    let f = (0..<fc).map { UInt(sentinel) + UInt($0) }
+                    emb_ring_buffer_write(buf, ts, f, fc)
+                }
+            }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertGreaterThan(result.count, 0)
+
+            for i in 0..<result.count {
+                let rec = result.records[i]
+                // Find matching def by timestamp.
+                guard let def = defs.first(where: { $0.ts == rec.timestamp_ns }) else {
+                    XCTFail("unknown timestamp \(rec.timestamp_ns)")
+                    continue
+                }
+                XCTAssertEqual(rec.frame_count, def.fc, "ts=\(def.ts) frame_count")
+                for j in 0..<def.fc {
+                    XCTAssertEqual(
+                        rec.frames[j], def.sentinel + UInt(j),
+                        "ts=\(def.ts) frame \(j)")
+                }
+            }
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
@@ -27,12 +27,12 @@
         // MARK: - Lifecycle
 
         func test_create_zeroCapacity_returnsNil() {
-            let buf = emb_ring_buffer_create(0)
+            let buf = emb_ring_buffer_create(0, nil)
             XCTAssertNil(buf)
         }
 
         func test_create_oneByte_roundsUpToOnePage() {
-            let buf = emb_ring_buffer_create(1)
+            let buf = emb_ring_buffer_create(1, nil)
             guard let buf else { return XCTFail("create(1) should succeed") }
             defer { emb_ring_buffer_destroy(buf) }
 
@@ -42,7 +42,7 @@
 
         func test_create_exactlyOnePage_noRounding() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)
+            let buf = emb_ring_buffer_create(page, nil)
             guard let buf else { return XCTFail() }
             defer { emb_ring_buffer_destroy(buf) }
 
@@ -51,7 +51,7 @@
 
         func test_create_pagePlusOne_roundsUpToTwoPages() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page + 1)
+            let buf = emb_ring_buffer_create(page + 1, nil)
             guard let buf else { return XCTFail() }
             defer { emb_ring_buffer_destroy(buf) }
 
@@ -59,7 +59,7 @@
         }
 
         func test_create_largeCapacity_succeeds() {
-            let buf = emb_ring_buffer_create(16 * 1024 * 1024)
+            let buf = emb_ring_buffer_create(16 * 1024 * 1024, nil)
             guard let buf else { return XCTFail("16 MB buffer should succeed") }
             defer { emb_ring_buffer_destroy(buf) }
 
@@ -67,7 +67,7 @@
         }
 
         func test_create_freshBuffer_isEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf else { return XCTFail() }
             defer { emb_ring_buffer_destroy(buf) }
 
@@ -86,7 +86,7 @@
         func test_create_destroy_repeatedCycles_noLeak() {
             for i in 1...8 {
                 let size = i * 64 * 1024
-                let buf = emb_ring_buffer_create(size)
+                let buf = emb_ring_buffer_create(size, nil)
                 XCTAssertNotNil(buf, "cycle \(i): create should succeed")
                 emb_ring_buffer_destroy(buf)
             }
@@ -95,13 +95,13 @@
         // MARK: - next_seq progression
 
         func test_nextSeq_startsAtZero() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
             XCTAssertEqual(buf.pointee.next_seq, 0)
         }
 
         func test_nextSeq_incrementsBy2PerSuccessfulWrite() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames: [UInt] = [0xCAFE]
@@ -114,7 +114,7 @@
         }
 
         func test_nextSeq_unchangedOnNilBufferWrite() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             emb_ring_buffer_write(nil, 1_000, [UInt(1)], 1)
@@ -122,7 +122,7 @@
         }
 
         func test_nextSeq_unchangedOnNilFramesWrite() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             emb_ring_buffer_write(buf, 1_000, nil, 5)
@@ -130,7 +130,7 @@
         }
 
         func test_nextSeq_incrementsForZeroFrameRecords() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let empty: [UInt] = []
@@ -140,19 +140,19 @@
 
         // MARK: - Write returns false on bad inputs
 
-        func test_write_nilBuffer_returnsFalse() {
+        func test_write_nilBuffer_returnsBadArgs() {
             let frames: [UInt] = [1, 2, 3]
-            XCTAssertFalse(emb_ring_buffer_write(nil, 1_000, frames, frames.count))
+            XCTAssertNotEqual(emb_ring_buffer_write(nil, 1_000, frames, frames.count), EMB_RING_WRITE_OK)
         }
 
-        func test_write_nilFrames_returnsFalse() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+        func test_write_nilFrames_returnsBadArgs() {
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
-            XCTAssertFalse(emb_ring_buffer_write(buf, 1_000, nil, 3))
+            XCTAssertNotEqual(emb_ring_buffer_write(buf, 1_000, nil, 3), EMB_RING_WRITE_OK)
         }
 
         func test_write_nilFrames_leavesBufferEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
             emb_ring_buffer_write(buf, 1_000, nil, 3)
 
@@ -163,7 +163,7 @@
         // MARK: - Frame data preservation
 
         func test_frameData_exactValuesPreserved() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames: [UInt] = [0xDEAD_BEEF, 0xCAFE_BABE, 0x1234_5678, 0xFFFF_FFFF]
@@ -179,7 +179,7 @@
         }
 
         func test_frameData_allZeros_preserved() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames = [UInt](repeating: 0, count: 8)
@@ -194,7 +194,7 @@
         }
 
         func test_frameData_allMaxValue_preserved() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames = [UInt](repeating: UInt.max, count: 8)
@@ -209,7 +209,7 @@
         }
 
         func test_frameData_largeFrameCount_preserved() {
-            let buf = emb_ring_buffer_create(4 * 1024 * 1024)!
+            let buf = emb_ring_buffer_create(4 * 1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let count = 512
@@ -226,7 +226,7 @@
         }
 
         func test_frameData_multipleRecords_eachCorrect() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let recordDefs: [(ts: UInt64, frames: [UInt])] = [
@@ -259,7 +259,7 @@
 
         func test_eviction_exactFit_noEviction() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let rSize = RingBufferEdgeCaseTests.recordSize(1)
@@ -279,7 +279,7 @@
 
         func test_eviction_onePastCapacity_evictsOldest() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let rSize = RingBufferEdgeCaseTests.recordSize(1)
@@ -304,7 +304,7 @@
 
         func test_eviction_largeRecordEvictsMultipleSmallOnes() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let smallCount = page / RingBufferEdgeCaseTests.recordSize(1)
@@ -337,7 +337,7 @@
 
         func test_eviction_zeroFrameRecords_evictedCorrectly() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let zeroSize = RingBufferEdgeCaseTests.headerSize
@@ -363,7 +363,7 @@
 
         func test_eviction_bufferRemainsFunctionalAfterManyPasses() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let rSize = RingBufferEdgeCaseTests.recordSize(10)
@@ -390,7 +390,7 @@
 
         func test_eviction_mixedSizes_oldestEvictedFirst() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             var ts: UInt64 = 0
@@ -437,7 +437,7 @@
 
         func test_eviction_evictedRecord_notVisibleInTimestampQuery() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let rSize = RingBufferEdgeCaseTests.recordSize(1)
@@ -455,7 +455,7 @@
         // MARK: - Prefix skip
 
         func test_readRange_skipsPrefix_returnsSuffix() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // Monotonic timestamps; query skips the first two.
@@ -474,7 +474,7 @@
         // MARK: - Timestamp range edge cases
 
         func test_readRange_exactStartBoundary_included() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 200, 300, 400, 500] {
@@ -491,7 +491,7 @@
         }
 
         func test_readRange_exactEndBoundary_included() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 200, 300, 400, 500] {
@@ -508,7 +508,7 @@
         }
 
         func test_readRange_startEqualsEnd_matchingRecord_returnsOne() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 200, 300] {
@@ -523,7 +523,7 @@
         }
 
         func test_readRange_startEqualsEnd_noMatchingRecord_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 200, 300] {
@@ -536,7 +536,7 @@
         }
 
         func test_readRange_startGreaterThanEnd_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 200, 300] {
@@ -549,7 +549,7 @@
         }
 
         func test_readRange_allRecordsBeforeStart_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 200, 300] {
@@ -562,7 +562,7 @@
         }
 
         func test_readRange_allRecordsAfterEnd_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [400, 500, 600] {
@@ -575,7 +575,7 @@
         }
 
         func test_readRange_gapBetweenRecords_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for ts: UInt64 in [100, 300] {
@@ -588,7 +588,7 @@
         }
 
         func test_readRange_duplicateTimestamps_allReturned() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let sharedTS: UInt64 = 99_999
@@ -606,7 +606,7 @@
         }
 
         func test_readRange_timestampZero_matchedByZeroStart() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [0xABCD]
@@ -620,7 +620,7 @@
         }
 
         func test_readRange_timestampMaxUInt64_matchedByMaxEnd() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [0x1234]
@@ -633,7 +633,7 @@
         }
 
         func test_readRange_singleRecordInLargeSet() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 1...20 {
@@ -655,7 +655,7 @@
         }
 
         func test_readRange_subsetInMiddle() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 1...20 {
@@ -674,7 +674,7 @@
         // MARK: - Read result integrity
 
         func test_readResult_consecutiveCalls_identicalData() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 1...5 {
@@ -698,7 +698,7 @@
         }
 
         func test_readResult_timestampsMonotonicallyIncreasing() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 1...30 {
@@ -720,7 +720,7 @@
 
         func test_wrapAround_recordStraddlingCapacityBoundary_readableAndCorrect() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let capacity = Int(buf.pointee.capacity)
@@ -741,7 +741,7 @@
             ts += 1
             let straddle: [UInt] = [UInt(ts), UInt(ts + 1), UInt(ts + 2)]
             let ok = emb_ring_buffer_write(buf, ts, straddle, 3)
-            XCTAssertTrue(ok, "write straddling boundary must succeed")
+            XCTAssertEqual(ok, EMB_RING_WRITE_OK, "write straddling boundary must succeed")
 
             let records = testReadRange(buf, ts, ts)
 
@@ -751,13 +751,13 @@
                 XCTAssertEqual(records[0].frames[1], UInt(ts + 1))
                 XCTAssertEqual(records[0].frames[2], UInt(ts + 2))
             } else {
-                XCTAssertTrue(ok)
+                XCTAssertEqual(ok, EMB_RING_WRITE_OK)
             }
         }
 
         func test_wrapAround_multiplePasses_onlyRecentRecordsVisible() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let rSize = RingBufferEdgeCaseTests.recordSize(5)
@@ -791,7 +791,7 @@
         }
 
         func test_wrapAround_variableFrameCounts_frameDataCorrect() {
-            let buf = emb_ring_buffer_create(4 * Int(getpagesize()))!
+            let buf = emb_ring_buffer_create(4 * Int(getpagesize()), nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let n = 200
@@ -834,7 +834,7 @@
 
         func test_write_recordExceedingCapacity_returnsFalse() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // A record needs header(16) + frameCount*8 bytes.
@@ -842,8 +842,7 @@
             let frameCount = (page / RingBufferEdgeCaseTests.frameSize) + 1
             let frames = [UInt](repeating: 0xDEAD, count: frameCount)
 
-            let success = emb_ring_buffer_write(buf, 1_000, frames, frameCount)
-            XCTAssertFalse(success,
+            XCTAssertNotEqual(emb_ring_buffer_write(buf, 1_000, frames, frameCount), EMB_RING_WRITE_OK,
                 "Write should fail when record size exceeds buffer capacity")
 
             // Buffer should remain empty and functional.
@@ -852,12 +851,12 @@
 
             // A smaller write should still succeed.
             let small: [UInt] = [1]
-            XCTAssertTrue(emb_ring_buffer_write(buf, 2_000, small, 1))
+            XCTAssertEqual(emb_ring_buffer_write(buf, 2_000, small, 1), EMB_RING_WRITE_OK)
         }
 
         func test_write_recordAtExactCapacity_succeeds() {
             let page = Int(getpagesize())
-            let buf = emb_ring_buffer_create(page)!
+            let buf = emb_ring_buffer_create(page, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // Compute the frame count that makes record_size == capacity exactly.
@@ -866,8 +865,7 @@
                 / RingBufferEdgeCaseTests.frameSize
 
             let frames = (0..<frameCount).map { UInt($0 + 1) }
-            let success = emb_ring_buffer_write(buf, 42_000, frames, frameCount)
-            XCTAssertTrue(success,
+            XCTAssertEqual(emb_ring_buffer_write(buf, 42_000, frames, frameCount), EMB_RING_WRITE_OK,
                 "Write should succeed when record exactly fills buffer")
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -879,7 +877,7 @@
         // MARK: - Output buffer edge cases
 
         func test_readRange_smallOutputBuffer_doesNotCrash() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 1...20 {
@@ -902,7 +900,7 @@
         }
 
         func test_readRange_smallOutputBuffer_recordsAreCorrect() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             for i in 1...20 {
@@ -942,7 +940,7 @@
         }
 
         func test_readRange_zeroSizeOutput_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [1]
@@ -958,7 +956,7 @@
         }
 
         func test_readRange_nilOutput_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [1]
@@ -978,13 +976,12 @@
         // MARK: - Write with NULL frames and zero frame_count
 
         func test_write_nilFramesZeroCount_succeeds() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // The C guard is: frames == NULL && frame_count > 0 → false.
             // NULL frames with 0 count should succeed and produce a zero-frame record.
-            let success = emb_ring_buffer_write(buf, 42_000, nil, 0)
-            XCTAssertTrue(success,
+            XCTAssertEqual(emb_ring_buffer_write(buf, 42_000, nil, 0), EMB_RING_WRITE_OK,
                 "write with NULL frames and 0 frame_count should succeed")
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -996,7 +993,7 @@
         // MARK: - Reset with concurrent readers
 
         func test_reset_whileReadersActive_returnsFalse() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // Fill with large records so reads take measurable time.
@@ -1063,7 +1060,7 @@
         }
 
         func test_reset_withConcurrentReaderStarts_noCorruption() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // Fill buffer with data.
@@ -1148,7 +1145,7 @@
         // MARK: - Corruption guards
 
         func test_readRange_corruptedPositions_totalDataExceedsCapacity_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)!
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
             // Write some valid data first.

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
@@ -1,0 +1,128 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import Darwin
+    import EmbraceProfilingSampler
+    import XCTest
+
+    /// Tests for `emb_ring_buffer_create` / `emb_ring_buffer_destroy` and the
+    /// VM double-mapping that eliminates wrap-around handling.
+    final class RingBufferLifecycleTests: XCTestCase {
+
+        // MARK: - Create / destroy lifecycle
+
+        func test_create_returnsNonNil_withValidParams() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            XCTAssertNotNil(buf)
+            emb_ring_buffer_destroy(buf)
+        }
+
+        func test_create_capacityIsPageAligned() {
+            // Requesting 1 byte should yield at least one full page.
+            let buf = emb_ring_buffer_create(1)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let pageSize = Int(getpagesize())
+            XCTAssertGreaterThanOrEqual(
+                buf.pointee.capacity, pageSize,
+                "capacity must be at least one page")
+            XCTAssertEqual(
+                buf.pointee.capacity % pageSize, 0,
+                "capacity must be page-aligned")
+        }
+
+        func test_create_dataPointerIsNonNil() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            XCTAssertNotNil(buf.pointee.data)
+        }
+
+        func test_destroy_withNil_doesNotCrash() {
+            // emb_ring_buffer_destroy(NULL) must be a no-op.
+            emb_ring_buffer_destroy(nil)
+        }
+
+        func test_create_canBeCalledMultipleTimes() {
+            for _ in 0..<4 {
+                let buf = emb_ring_buffer_create(512 * 1024)
+                XCTAssertNotNil(buf)
+                emb_ring_buffer_destroy(buf)
+            }
+        }
+
+        // MARK: - VM double-mapping
+
+        /// Writes 8 bytes straddling the end of the first mapping and verifies
+        /// that the 4 bytes written into the second mapping ([capacity, capacity+3])
+        /// are immediately visible at the start of the first mapping ([0, 3]).
+        func test_doubleMapping_writeStraddle_wrapsToStart() {
+            // Use a small capacity_bytes; it will be rounded up to one page.
+            let buf = emb_ring_buffer_create(1)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let capacity = Int(buf.pointee.capacity)
+            let data = buf.pointee.data!
+
+            // Write 8 bytes starting 4 bytes before the end of the first mapping.
+            // Bytes at offsets [capacity, capacity+3] land in the second mapping.
+            // Because both halves share physical pages, those bytes must also
+            // appear at offsets [0, 3] in the first mapping.
+            let writeStart = capacity - 4
+            for i in 0..<8 {
+                data[writeStart + i] = UInt8(i + 1)  // values 1 … 8
+            }
+
+            // Bytes written via the second mapping (offsets capacity … capacity+3)
+            // should be visible at the mirror offsets 0 … 3.
+            for i in 0..<4 {
+                XCTAssertEqual(
+                    data[i], UInt8(i + 5),
+                    "double-mapping wrap: data[\(i)] expected \(i + 5), got \(data[i])")
+            }
+        }
+
+        /// Verifies the mirror in the other direction: writing to the start of the
+        /// first mapping is immediately visible in the second mapping.
+        func test_doubleMapping_writeAtStart_visibleBeyondCapacity() {
+            let buf = emb_ring_buffer_create(1)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let capacity = Int(buf.pointee.capacity)
+            let data = buf.pointee.data!
+
+            // Write 4 bytes at the start of the first mapping.
+            let pattern: [UInt8] = [0xDE, 0xAD, 0xBE, 0xEF]
+            for (i, byte) in pattern.enumerated() {
+                data[i] = byte
+            }
+
+            // The same bytes must appear at capacity … capacity+3 (second mapping).
+            for (i, expected) in pattern.enumerated() {
+                XCTAssertEqual(
+                    data[capacity + i], expected,
+                    "second mapping mirror: data[\(capacity + i)] expected 0x\(String(expected, radix: 16)), got 0x\(String(data[capacity + i], radix: 16))")
+            }
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
@@ -15,14 +15,14 @@
         // MARK: - Create / destroy lifecycle
 
         func test_create_returnsNonNil_withValidParams() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             XCTAssertNotNil(buf)
             emb_ring_buffer_destroy(buf)
         }
 
         func test_create_capacityIsPageAligned() {
             // Requesting 1 byte should yield at least one full page.
-            let buf = emb_ring_buffer_create(1)
+            let buf = emb_ring_buffer_create(1, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -39,7 +39,7 @@
         }
 
         func test_create_dataPointerIsNonNil() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -56,7 +56,7 @@
 
         func test_create_canBeCalledMultipleTimes() {
             for _ in 0..<4 {
-                let buf = emb_ring_buffer_create(512 * 1024)
+                let buf = emb_ring_buffer_create(512 * 1024, nil)
                 XCTAssertNotNil(buf)
                 emb_ring_buffer_destroy(buf)
             }
@@ -69,7 +69,7 @@
         /// are immediately visible at the start of the first mapping ([0, 3]).
         func test_doubleMapping_writeStraddle_wrapsToStart() {
             // Use a small capacity_bytes; it will be rounded up to one page.
-            let buf = emb_ring_buffer_create(1)
+            let buf = emb_ring_buffer_create(1, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -100,7 +100,7 @@
         /// Verifies the mirror in the other direction: writing to the start of the
         /// first mapping is immediately visible in the second mapping.
         func test_doubleMapping_writeAtStart_visibleBeyondCapacity() {
-            let buf = emb_ring_buffer_create(1)
+            let buf = emb_ring_buffer_create(1, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferLifecycleTests.swift
@@ -97,6 +97,25 @@
             }
         }
 
+        // MARK: - kr_out error propagation
+
+        func test_create_withKrOut_setsKernSuccess_onSuccess() {
+            var kr = KERN_FAILURE  // pre-set to non-success to prove it is written
+            let buf = emb_ring_buffer_create(1024 * 1024, &kr)
+            XCTAssertNotNil(buf)
+            XCTAssertEqual(kr, KERN_SUCCESS)
+            emb_ring_buffer_destroy(buf)
+        }
+
+        func test_create_withKrOut_setsInvalidArgument_forZeroCapacity() {
+            var kr = KERN_SUCCESS  // pre-set to success to prove it is overwritten
+            let buf = emb_ring_buffer_create(0, &kr)
+            XCTAssertNil(buf)
+            XCTAssertEqual(kr, KERN_INVALID_ARGUMENT)
+        }
+
+        // MARK: - VM double-mapping
+
         /// Verifies the mirror in the other direction: writing to the start of the
         /// first mapping is immediately visible in the second mapping.
         func test_doubleMapping_writeAtStart_visibleBeyondCapacity() {

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
@@ -1,0 +1,336 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import Darwin
+    import EmbraceProfilingSampler
+    import XCTest
+
+    /// Tests for the ring buffer write path (reserve/commit) and read helper.
+    final class RingBufferWritePathTests: XCTestCase {
+
+        // MARK: - Basic write/read
+
+        func test_writeRead_singleRecord() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Write a record.
+            let testFrames: [UInt] = [0x1000, 0x2000, 0x3000]
+            let timestamp: UInt64 = 123_456_789
+            let success = emb_ring_buffer_write(buf, timestamp, testFrames, testFrames.count)
+            XCTAssertTrue(success, "write should succeed")
+
+            // Read back all records (from 0 to UINT64_MAX).
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1, "should have 1 record")
+            guard result.count == 1 else { return }
+
+            let record = result.records[0]
+            XCTAssertEqual(record.timestamp_ns, timestamp)
+            XCTAssertEqual(record.frame_count, testFrames.count)
+
+            // Verify frame data.
+            for i in 0..<testFrames.count {
+                XCTAssertEqual(record.frames[i], testFrames[i])
+            }
+        }
+
+        func test_writeRead_multipleRecords() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let recordCount = 10
+            var expectedTimestamps: [UInt64] = []
+
+            // Write multiple records with varying frame counts.
+            for i in 0..<recordCount {
+                let frameCount = (i % 5) + 1  // 1 to 5 frames
+                var frames: [UInt] = []
+
+                for j in 0..<frameCount {
+                    frames.append(UInt(0x1000 * (i + 1) + j))
+                }
+
+                let timestamp = UInt64(100_000 * (i + 1))
+                expectedTimestamps.append(timestamp)
+                let success = emb_ring_buffer_write(buf, timestamp, frames, frameCount)
+                XCTAssertTrue(success, "write \(i) should succeed")
+            }
+
+            // Read back all records.
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, recordCount)
+
+            for i in 0..<result.count {
+                let record = result.records[i]
+                XCTAssertEqual(record.timestamp_ns, expectedTimestamps[i])
+
+                let expectedFrameCount = (i % 5) + 1
+                XCTAssertEqual(Int(record.frame_count), expectedFrameCount)
+
+                // Verify frame data.
+                for j in 0..<expectedFrameCount {
+                    let expected = UInt(0x1000 * (i + 1) + j)
+                    XCTAssertEqual(record.frames[j], expected)
+                }
+            }
+        }
+
+        // MARK: - Zero-frame records
+
+        func test_writeRead_zeroFrames() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Write a zero-frame record.
+            let timestamp: UInt64 = 999_999
+            let frames: [UInt] = []
+            let success = emb_ring_buffer_write(buf, timestamp, frames, 0)
+            XCTAssertTrue(success, "write should succeed")
+
+            // Read back.
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 1)
+            guard result.count == 1 else { return }
+
+            let record = result.records[0]
+            XCTAssertEqual(record.timestamp_ns, timestamp)
+            XCTAssertEqual(record.frame_count, 0)
+        }
+
+        // MARK: - Variable-length records
+
+        func test_writeRead_variableLengths() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let frameCounts = [0, 1, 10, 50, 100, 200, 512]
+            var expectedData: [(timestamp: UInt64, frameCount: Int)] = []
+
+            for (idx, frameCount) in frameCounts.enumerated() {
+                // Create unique patterns.
+                var frames: [UInt] = []
+                for i in 0..<frameCount {
+                    frames.append(UInt(0x10000 * (idx + 1) + i))
+                }
+
+                let timestamp = UInt64(1_000_000 * (idx + 1))
+                expectedData.append((timestamp, frameCount))
+                let success = emb_ring_buffer_write(buf, timestamp, frames, frameCount)
+                XCTAssertTrue(success, "write \(idx) should succeed")
+            }
+
+            // Read back.
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, frameCounts.count)
+
+            for i in 0..<result.count {
+                let record = result.records[i]
+                XCTAssertEqual(record.timestamp_ns, expectedData[i].timestamp)
+                XCTAssertEqual(Int(record.frame_count), expectedData[i].frameCount)
+
+                // Verify frames.
+                for j in 0..<expectedData[i].frameCount {
+                    let expected = UInt(0x10000 * (i + 1) + j)
+                    XCTAssertEqual(record.frames[j], expected)
+                }
+            }
+        }
+
+        // MARK: - Wrap-around
+
+        func test_writeRead_wrapAround() {
+            // Use a small buffer to force wrap-around quickly.
+            let pageSize = Int(getpagesize())
+            let buf = emb_ring_buffer_create(pageSize)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let capacity = buf.pointee.capacity
+            let recordSize = 16 + 10 * 8  // Header + 10 frames
+            let recordsToFill = Int(capacity) / recordSize + 10  // Overfill to wrap
+
+            var lastTimestamps: [UInt64] = []
+
+            // Write enough records to wrap around multiple times.
+            for i in 0..<recordsToFill {
+                var frames: [UInt] = []
+                for j in 0..<10 {
+                    frames.append(UInt(0x1000 * i + j))
+                }
+
+                let timestamp = UInt64(i + 1)
+                lastTimestamps.append(timestamp)
+                let success = emb_ring_buffer_write(buf, timestamp, frames, 10)
+                XCTAssertTrue(success, "write \(i) should succeed")
+            }
+
+            // Read back. Should get only the records that fit in the buffer
+            // (oldest records evicted).
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertGreaterThan(result.count, 0, "should have some records")
+            XCTAssertLessThan(result.count, recordsToFill, "should have evicted old records")
+
+            // The timestamps should be from the most recent records.
+            let expectedStartIndex = recordsToFill - Int(result.count)
+            for i in 0..<result.count {
+                let record = result.records[i]
+                let expected = lastTimestamps[expectedStartIndex + Int(i)]
+                XCTAssertEqual(
+                    record.timestamp_ns, expected,
+                    "record \(i) timestamp mismatch")
+            }
+        }
+
+        // MARK: - Eviction correctness
+
+        func test_eviction_dropsOldRecords() {
+            let pageSize = Int(getpagesize())
+            let buf = emb_ring_buffer_create(pageSize)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let capacity = buf.pointee.capacity
+            let recordSize = 16 + 10 * 8
+            let recordsToFill = Int(capacity) / recordSize
+            let overwriteCount = 5
+
+            // Fill buffer then write more to evict.
+            for i in 0..<(recordsToFill + overwriteCount) {
+                var frames: [UInt] = []
+                for j in 0..<10 {
+                    frames.append(UInt(i * 100 + j))
+                }
+
+                let success = emb_ring_buffer_write(buf, UInt64(i), frames, 10)
+                XCTAssertTrue(success, "write \(i) should succeed")
+            }
+
+            // Read back.
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            // Should not contain the first `overwriteCount` records.
+            XCTAssertGreaterThan(result.count, 0)
+
+            if result.count > 0 {
+                let firstTimestamp = result.records[0].timestamp_ns
+                XCTAssertGreaterThanOrEqual(
+                    firstTimestamp, UInt64(overwriteCount),
+                    "oldest records should be evicted")
+            }
+        }
+
+        // MARK: - Edge cases
+
+        func test_write_withNilBuffer_returnsFalse() {
+            let frames: [UInt] = [0x1000, 0x2000]
+            let success = emb_ring_buffer_write(nil, 123, frames, 2)
+            XCTAssertFalse(success)
+        }
+
+        func test_write_withNilFrames_returnsFalse() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let success = emb_ring_buffer_write(buf, 123, nil, 10)
+            XCTAssertFalse(success)
+        }
+
+        func test_readRange_withNil_returnsEmpty() {
+            let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX)
+            XCTAssertEqual(result.count, 0)
+            XCTAssertNil(result.records)
+        }
+
+        func test_readRange_filtersOnTimestamp() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // Write 10 records with timestamps 1000, 2000, ..., 10000.
+            for i in 0..<10 {
+                let frames: [UInt] = [UInt(i)]
+                let timestamp = UInt64((i + 1) * 1000)
+                let success = emb_ring_buffer_write(buf, timestamp, frames, 1)
+                XCTAssertTrue(success)
+            }
+
+            // Read only records from 3000 to 7000 (inclusive).
+            var result = emb_ring_buffer_read_range(buf, 3000, 7000)
+            defer { emb_ring_read_result_free(&result) }
+
+            // Should get 5 records: timestamps 3000, 4000, 5000, 6000, 7000.
+            XCTAssertEqual(result.count, 5)
+
+            for i in 0..<result.count {
+                let record = result.records[i]
+                let expectedTimestamp = UInt64((i + 3) * 1000)
+                XCTAssertEqual(record.timestamp_ns, expectedTimestamp)
+                XCTAssertEqual(record.frame_count, 1)
+            }
+        }
+
+        func test_readAll_emptyBuffer_returnsEmpty() {
+            let buf = emb_ring_buffer_create(1024 * 1024)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
+            defer { emb_ring_read_result_free(&result) }
+
+            XCTAssertEqual(result.count, 0)
+        }
+
+        func test_resultFree_withNil_doesNotCrash() {
+            var result = emb_ring_read_result_t(records: nil, count: 0)
+            emb_ring_read_result_free(&result)
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
@@ -27,14 +27,13 @@
             let success = emb_ring_buffer_write(buf, timestamp, testFrames, testFrames.count)
             XCTAssertTrue(success, "write should succeed")
 
-            // Read back all records (from 0 to UINT64_MAX).
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            // Read back all records.
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1, "should have 1 record")
-            guard result.count == 1 else { return }
+            XCTAssertEqual(records.count, 1, "should have 1 record")
+            guard records.count == 1 else { return }
 
-            let record = result.records[0]
+            let record = records[0]
             XCTAssertEqual(record.timestamp_ns, timestamp)
             XCTAssertEqual(record.frame_count, testFrames.count)
 
@@ -71,17 +70,16 @@
             }
 
             // Read back all records.
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, recordCount)
+            XCTAssertEqual(records.count, recordCount)
 
-            for i in 0..<result.count {
-                let record = result.records[i]
+            for i in 0..<records.count {
+                let record = records[i]
                 XCTAssertEqual(record.timestamp_ns, expectedTimestamps[i])
 
                 let expectedFrameCount = (i % 5) + 1
-                XCTAssertEqual(Int(record.frame_count), expectedFrameCount)
+                XCTAssertEqual(record.frame_count, expectedFrameCount)
 
                 // Verify frame data.
                 for j in 0..<expectedFrameCount {
@@ -108,13 +106,12 @@
             XCTAssertTrue(success, "write should succeed")
 
             // Read back.
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, 1)
-            guard result.count == 1 else { return }
+            XCTAssertEqual(records.count, 1)
+            guard records.count == 1 else { return }
 
-            let record = result.records[0]
+            let record = records[0]
             XCTAssertEqual(record.timestamp_ns, timestamp)
             XCTAssertEqual(record.frame_count, 0)
         }
@@ -146,15 +143,14 @@
             }
 
             // Read back.
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertEqual(result.count, frameCounts.count)
+            XCTAssertEqual(records.count, frameCounts.count)
 
-            for i in 0..<result.count {
-                let record = result.records[i]
+            for i in 0..<records.count {
+                let record = records[i]
                 XCTAssertEqual(record.timestamp_ns, expectedData[i].timestamp)
-                XCTAssertEqual(Int(record.frame_count), expectedData[i].frameCount)
+                XCTAssertEqual(record.frame_count, expectedData[i].frameCount)
 
                 // Verify frames.
                 for j in 0..<expectedData[i].frameCount {
@@ -197,17 +193,16 @@
 
             // Read back. Should get only the records that fit in the buffer
             // (oldest records evicted).
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
-            XCTAssertGreaterThan(result.count, 0, "should have some records")
-            XCTAssertLessThan(result.count, recordsToFill, "should have evicted old records")
+            XCTAssertGreaterThan(records.count, 0, "should have some records")
+            XCTAssertLessThan(records.count, recordsToFill, "should have evicted old records")
 
             // The timestamps should be from the most recent records.
-            let expectedStartIndex = recordsToFill - Int(result.count)
-            for i in 0..<result.count {
-                let record = result.records[i]
-                let expected = lastTimestamps[expectedStartIndex + Int(i)]
+            let expectedStartIndex = recordsToFill - records.count
+            for i in 0..<records.count {
+                let record = records[i]
+                let expected = lastTimestamps[expectedStartIndex + i]
                 XCTAssertEqual(
                     record.timestamp_ns, expected,
                     "record \(i) timestamp mismatch")
@@ -242,14 +237,13 @@
             }
 
             // Read back.
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 0, UINT64_MAX)
 
             // Should not contain the first `overwriteCount` records.
-            XCTAssertGreaterThan(result.count, 0)
+            XCTAssertGreaterThan(records.count, 0)
 
-            if result.count > 0 {
-                let firstTimestamp = result.records[0].timestamp_ns
+            if records.count > 0 {
+                let firstTimestamp = records[0].timestamp_ns
                 XCTAssertGreaterThanOrEqual(
                     firstTimestamp, UInt64(overwriteCount),
                     "oldest records should be evicted")
@@ -276,10 +270,10 @@
             XCTAssertFalse(success)
         }
 
-        func test_readRange_withNil_returnsEmpty() {
-            let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX)
-            XCTAssertEqual(result.count, 0)
-            XCTAssertNil(result.records)
+        func test_readRange_withNilBuffer_returnsEmpty() {
+            var output = [UInt8](repeating: 0, count: 16)
+            let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX, &output, output.count)
+            XCTAssertEqual(result.record_count, 0)
         }
 
         func test_readRange_filtersOnTimestamp() {
@@ -299,14 +293,13 @@
             }
 
             // Read only records from 3000 to 7000 (inclusive).
-            var result = emb_ring_buffer_read_range(buf, 3000, 7000)
-            defer { emb_ring_read_result_free(&result) }
+            let records = testReadRange(buf, 3000, 7000)
 
             // Should get 5 records: timestamps 3000, 4000, 5000, 6000, 7000.
-            XCTAssertEqual(result.count, 5)
+            XCTAssertEqual(records.count, 5)
 
-            for i in 0..<result.count {
-                let record = result.records[i]
+            for i in 0..<records.count {
+                let record = records[i]
                 let expectedTimestamp = UInt64((i + 3) * 1000)
                 XCTAssertEqual(record.timestamp_ns, expectedTimestamp)
                 XCTAssertEqual(record.frame_count, 1)
@@ -321,15 +314,8 @@
             }
             defer { emb_ring_buffer_destroy(buf) }
 
-            var result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX)
-            defer { emb_ring_read_result_free(&result) }
-
-            XCTAssertEqual(result.count, 0)
-        }
-
-        func test_resultFree_withNil_doesNotCrash() {
-            var result = emb_ring_read_result_t(records: nil, count: 0)
-            emb_ring_read_result_free(&result)
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 0)
         }
     }
 

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS)

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
@@ -262,6 +262,43 @@
             XCTAssertNotEqual(emb_ring_buffer_write(buf, 123, nil, 10), EMB_RING_WRITE_OK)
         }
 
+        func test_write_recordTooLarge_returnsRecordTooLarge() {
+            // Minimum-size buffer (1 byte rounds up to one page).
+            // A record whose size exceeds capacity must be rejected.
+            let buf = emb_ring_buffer_create(1, nil)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            // capacity / stride + 1 guarantees the record exceeds capacity
+            // regardless of per-record header overhead or page size.
+            let frameCount = buf.pointee.capacity / MemoryLayout<UInt>.stride + 1
+            let frames = [UInt](repeating: 0, count: frameCount)
+            XCTAssertEqual(
+                emb_ring_buffer_write(buf, 1, frames, frameCount),
+                EMB_RING_WRITE_RECORD_TOO_LARGE)
+        }
+
+        #if arch(arm64) || arch(x86_64)
+        func test_write_frameCountExceedsUInt32Max_returnsBadArgs() {
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
+            guard let buf = buf else {
+                XCTFail("emb_ring_buffer_create should succeed")
+                return
+            }
+            defer { emb_ring_buffer_destroy(buf) }
+
+            let frames: [UInt] = [0x1000]
+            // The guard fires before any buffer access, so the frames array
+            // size doesn't need to match the claimed count.
+            XCTAssertEqual(
+                emb_ring_buffer_write(buf, 1, frames, Int(UInt32.max) + 1),
+                EMB_RING_WRITE_BAD_ARGS)
+        }
+        #endif
+
         func test_readRange_withNilBuffer_returnsEmpty() {
             var output = [UInt8](repeating: 0, count: 16)
             let result = emb_ring_buffer_read_range(nil, 0, UINT64_MAX, &output, output.count)

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
@@ -14,7 +14,7 @@
         // MARK: - Basic write/read
 
         func test_writeRead_singleRecord() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -24,8 +24,7 @@
             // Write a record.
             let testFrames: [UInt] = [0x1000, 0x2000, 0x3000]
             let timestamp: UInt64 = 123_456_789
-            let success = emb_ring_buffer_write(buf, timestamp, testFrames, testFrames.count)
-            XCTAssertTrue(success, "write should succeed")
+            XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, testFrames, testFrames.count), EMB_RING_WRITE_OK, "write should succeed")
 
             // Read back all records.
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -44,7 +43,7 @@
         }
 
         func test_writeRead_multipleRecords() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -65,8 +64,7 @@
 
                 let timestamp = UInt64(100_000 * (i + 1))
                 expectedTimestamps.append(timestamp)
-                let success = emb_ring_buffer_write(buf, timestamp, frames, frameCount)
-                XCTAssertTrue(success, "write \(i) should succeed")
+                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, frameCount), EMB_RING_WRITE_OK, "write \(i) should succeed")
             }
 
             // Read back all records.
@@ -92,7 +90,7 @@
         // MARK: - Zero-frame records
 
         func test_writeRead_zeroFrames() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -102,8 +100,7 @@
             // Write a zero-frame record.
             let timestamp: UInt64 = 999_999
             let frames: [UInt] = []
-            let success = emb_ring_buffer_write(buf, timestamp, frames, 0)
-            XCTAssertTrue(success, "write should succeed")
+            XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, 0), EMB_RING_WRITE_OK, "write should succeed")
 
             // Read back.
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -119,7 +116,7 @@
         // MARK: - Variable-length records
 
         func test_writeRead_variableLengths() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -138,8 +135,7 @@
 
                 let timestamp = UInt64(1_000_000 * (idx + 1))
                 expectedData.append((timestamp, frameCount))
-                let success = emb_ring_buffer_write(buf, timestamp, frames, frameCount)
-                XCTAssertTrue(success, "write \(idx) should succeed")
+                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, frameCount), EMB_RING_WRITE_OK, "write \(idx) should succeed")
             }
 
             // Read back.
@@ -165,7 +161,7 @@
         func test_writeRead_wrapAround() {
             // Use a small buffer to force wrap-around quickly.
             let pageSize = Int(getpagesize())
-            let buf = emb_ring_buffer_create(pageSize)
+            let buf = emb_ring_buffer_create(pageSize, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -187,8 +183,7 @@
 
                 let timestamp = UInt64(i + 1)
                 lastTimestamps.append(timestamp)
-                let success = emb_ring_buffer_write(buf, timestamp, frames, 10)
-                XCTAssertTrue(success, "write \(i) should succeed")
+                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, 10), EMB_RING_WRITE_OK, "write \(i) should succeed")
             }
 
             // Read back. Should get only the records that fit in the buffer
@@ -213,7 +208,7 @@
 
         func test_eviction_dropsOldRecords() {
             let pageSize = Int(getpagesize())
-            let buf = emb_ring_buffer_create(pageSize)
+            let buf = emb_ring_buffer_create(pageSize, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -232,8 +227,7 @@
                     frames.append(UInt(i * 100 + j))
                 }
 
-                let success = emb_ring_buffer_write(buf, UInt64(i), frames, 10)
-                XCTAssertTrue(success, "write \(i) should succeed")
+                XCTAssertEqual(emb_ring_buffer_write(buf, UInt64(i), frames, 10), EMB_RING_WRITE_OK, "write \(i) should succeed")
             }
 
             // Read back.
@@ -254,20 +248,18 @@
 
         func test_write_withNilBuffer_returnsFalse() {
             let frames: [UInt] = [0x1000, 0x2000]
-            let success = emb_ring_buffer_write(nil, 123, frames, 2)
-            XCTAssertFalse(success)
+            XCTAssertNotEqual(emb_ring_buffer_write(nil, 123, frames, 2), EMB_RING_WRITE_OK)
         }
 
         func test_write_withNilFrames_returnsFalse() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
             }
             defer { emb_ring_buffer_destroy(buf) }
 
-            let success = emb_ring_buffer_write(buf, 123, nil, 10)
-            XCTAssertFalse(success)
+            XCTAssertNotEqual(emb_ring_buffer_write(buf, 123, nil, 10), EMB_RING_WRITE_OK)
         }
 
         func test_readRange_withNilBuffer_returnsEmpty() {
@@ -277,7 +269,7 @@
         }
 
         func test_readRange_filtersOnTimestamp() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return
@@ -288,8 +280,7 @@
             for i in 0..<10 {
                 let frames: [UInt] = [UInt(i)]
                 let timestamp = UInt64((i + 1) * 1000)
-                let success = emb_ring_buffer_write(buf, timestamp, frames, 1)
-                XCTAssertTrue(success)
+                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, 1), EMB_RING_WRITE_OK)
             }
 
             // Read only records from 3000 to 7000 (inclusive).
@@ -307,7 +298,7 @@
         }
 
         func test_readAll_emptyBuffer_returnsEmpty() {
-            let buf = emb_ring_buffer_create(1024 * 1024)
+            let buf = emb_ring_buffer_create(1024 * 1024, nil)
             guard let buf = buf else {
                 XCTFail("emb_ring_buffer_create should succeed")
                 return

--- a/Tests/EmbraceProfilingSamplerTests/TestReadHelper.swift
+++ b/Tests/EmbraceProfilingSamplerTests/TestReadHelper.swift
@@ -1,0 +1,76 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import EmbraceProfilingSampler
+    import Foundation
+
+    /// Decoded ring buffer record for use in tests.
+    struct TestRecord {
+        let timestamp_ns: UInt64
+        let frame_count: Int
+        let frames: [UInt]
+    }
+
+    /// Read matching records from a ring buffer into Swift-friendly structs.
+    ///
+    /// Allocates a temporary output buffer of `capacity` bytes, reads into it,
+    /// parses the results, and deallocates.
+    func testReadRange(
+        _ buf: UnsafeMutablePointer<emb_ring_buffer_t>,
+        _ startNs: UInt64,
+        _ endNs: UInt64
+    ) -> [TestRecord] {
+        let capacity = emb_ring_buffer_capacity(buf)
+        let output = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+        defer { output.deallocate() }
+
+        let result = emb_ring_buffer_read_range(buf, startNs, endNs, output, capacity)
+        return parseRecords(output, result)
+    }
+
+    /// Parse records from a raw output buffer filled by `emb_ring_buffer_read_range`.
+    func parseRecords(
+        _ output: UnsafeMutablePointer<UInt8>,
+        _ result: emb_ring_read_result_t
+    ) -> [TestRecord] {
+        let headerSize = MemoryLayout<emb_ring_record_header_t>.size
+        let validEnd = Int(result.records_offset) + Int(result.total_bytes)
+
+        var records: [TestRecord] = []
+        var offset = Int(result.records_offset)
+        for _ in 0..<result.record_count {
+            guard offset + headerSize <= validEnd else { break }
+
+            let hdr = (output + offset).withMemoryRebound(
+                to: emb_ring_record_header_t.self, capacity: 1
+            ) { $0.pointee }
+
+            let fc = Int(hdr.frame_count)
+            let recordSize = Int(emb_ring_record_size(hdr.frame_count))
+            guard offset + recordSize <= validEnd else { break }
+
+            var frames: [UInt] = []
+            if fc > 0 {
+                let framesStart = output + offset + headerSize
+                framesStart.withMemoryRebound(to: UInt.self, capacity: fc) { ptr in
+                    for j in 0..<fc {
+                        frames.append(ptr[j])
+                    }
+                }
+            }
+
+            records.append(TestRecord(
+                timestamp_ns: hdr.timestamp_ns,
+                frame_count: fc,
+                frames: frames
+            ))
+
+            offset += recordSize
+        }
+        return records
+    }
+
+#endif

--- a/Tests/ProfilingBenchmarkRunner/main.swift
+++ b/Tests/ProfilingBenchmarkRunner/main.swift
@@ -43,9 +43,13 @@ func timeBlock(body: () -> Void) -> Double {
 }
 
 func walkFP(port: thread_t) -> Int {
+    guard let pth = pthread_from_mach_thread_np(port) else { return 0 }
+    let top = pthread_get_stackaddr_np(pth)
+    let size = pthread_get_stacksize_np(pth)
+    let bottom = UnsafeRawPointer(top - size)
     var frames = [UInt](repeating: 0, count: maxFrames)
     var count = 0
-    emb_stack_walk(port, &frames, maxFrames, &count)
+    emb_stack_walk(port, bottom, UnsafeRawPointer(top), &frames, maxFrames, &count)
     return count
 }
 


### PR DESCRIPTION
Single-writer, multiple-reader ring buffer using VM double-mapping for transparent wrapping.

The write path is async-safe (no locks, no heap allocation) to avoid deadlocks when threads are stopped during profiling.

Includes comprehensive test coverage for concurrency, edge cases, lifecycle, and write path scenarios.

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
