### PR TITLE
[EMBR-10912] Feature: Updated EmbraceTraceView to opt out evaluating body by default.

### DIFF
--- a/Sources/EmbraceCore/SwiftUI/EmbraceTraceView.swift
+++ b/Sources/EmbraceCore/SwiftUI/EmbraceTraceView.swift
@@ -49,6 +49,7 @@ public struct EmbraceTraceView<Content: View, Value: Equatable>: View {
     private let name: String
     private let attributes: [String: String]?
     private let contentCompleteValue: Value?
+    private let trackBodyEvaluations: Bool
 
     /// Creates a new `EmbraceTraceView` that wraps the given content for tracing.
     ///
@@ -61,12 +62,14 @@ public struct EmbraceTraceView<Content: View, Value: Equatable>: View {
         _ viewName: String,
         attributes: [String: String]? = nil,
         contentComplete: Value? = nil,
+        trackBodyEvaluations: Bool = false,
         content: @escaping () -> Content
     ) {
         self.name = viewName
         self.attributes = attributes
         self.content = content
         self.contentCompleteValue = contentComplete
+        self.trackBodyEvaluations = trackBodyEvaluations
 
         // Ensure counters are updated
         if self.state.initialize == 0 {
@@ -83,12 +86,14 @@ public struct EmbraceTraceView<Content: View, Value: Equatable>: View {
     public init(
         _ viewName: String,
         attributes: [String: String]? = nil,
+        trackBodyEvaluations: Bool = false,
         content: @escaping () -> Content
     ) where Value == Never {
         self.init(
             viewName,
             attributes: attributes,
             contentComplete: nil,
+            trackBodyEvaluations: trackBodyEvaluations,
             content: content
         )
     }
@@ -110,7 +115,7 @@ public struct EmbraceTraceView<Content: View, Value: Equatable>: View {
         state.body += 1
 
         // If no _RenderLoop_ span exists for this render tick, create one.
-        if context.firstCycleSpan == nil {
+        if trackBodyEvaluations && context.firstCycleSpan == nil {
             context.firstCycleSpan = logger.cycledSpan(
                 name,
                 semantics: SpanSemantics.SwiftUIView.renderLoopName,
@@ -124,13 +129,13 @@ public struct EmbraceTraceView<Content: View, Value: Equatable>: View {
         }
 
         // Start a span for this body evaluation
-        let bodySpan = logger.startSpan(
+        let bodySpan = trackBodyEvaluations ? logger.startSpan(
             name,
             semantics: SpanSemantics.SwiftUIView.bodyName,
             time: startTime,
             parent: context.firstCycleSpan,
             attributes: attributes
-        )
+        ) : nil
         defer {
             logger.endSpan(bodySpan)
         }

--- a/Sources/EmbraceCore/SwiftUI/EmbraceTraceViewModifier.swift
+++ b/Sources/EmbraceCore/SwiftUI/EmbraceTraceViewModifier.swift
@@ -44,23 +44,27 @@ import SwiftUI
 extension View {
     public func embraceTrace(
         _ viewName: String,
-        attributes: [String: String]? = nil
+        attributes: [String: String]? = nil,
+        trackBodyEvaluations: Bool = false
     ) -> some View {
         EmbraceTraceView(
             viewName,
-            attributes: attributes
+            attributes: attributes,
+            trackBodyEvaluations: trackBodyEvaluations
         ) { self }
     }
 
     public func embraceTrace<V: Equatable>(
         _ viewName: String,
         attributes: [String: String]? = nil,
-        contentComplete: V
+        contentComplete: V,
+        trackBodyEvaluations: Bool = false
     ) -> some View {
         EmbraceTraceView(
             viewName,
             attributes: attributes,
-            contentComplete: contentComplete
+            contentComplete: contentComplete,
+            trackBodyEvaluations: trackBodyEvaluations
         ) { self }
     }
 }

--- a/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewTests.swift
+++ b/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewTests.swift
@@ -171,11 +171,11 @@
 
         @MainActor
         func testEmbraceTraceViewSpanNaming() async {
-            // Given: tracing is enabled
+            // Given: tracing is enabled with body evaluation tracking opted in
             mockConfig.isSwiftUiViewInstrumentationEnabled = true
 
-            // When: we create and render an EmbraceTraceView
-            let traceView = EmbraceTraceView("ProfileScreen") {
+            // When: we create and render an EmbraceTraceView with trackBodyEvaluations: true
+            let traceView = EmbraceTraceView("ProfileScreen", trackBodyEvaluations: true) {
                 Text("User Profile")
             }
             .environment(\.embraceTraceViewLogger, traceViewLogger)
@@ -199,6 +199,74 @@
             XCTAssertTrue(spanNames.contains("emb-swiftui.view.ProfileScreen.body"))
             XCTAssertTrue(spanNames.contains("emb-swiftui.view.ProfileScreen.appear"))
             XCTAssertTrue(spanNames.contains("emb-swiftui.view.ProfileScreen.time-to-first-render"))
+
+            window.isHidden = true
+        }
+
+        @MainActor
+        func testBodySpansOffByDefault() async {
+            // Given: tracing is enabled, trackBodyEvaluations not specified (defaults to false)
+            mockConfig.isSwiftUiViewInstrumentationEnabled = true
+
+            // When: we render an EmbraceTraceView without opting in to body tracking
+            let traceView = EmbraceTraceView("DefaultScreen") {
+                Text("Content")
+            }
+            .environment(\.embraceTraceViewLogger, traceViewLogger)
+            .environment(\.embraceTraceViewContext, traceViewContext)
+
+            let hostingController = UIHostingController(rootView: traceView)
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 300, height: 600))
+            window.rootViewController = hostingController
+            window.makeKeyAndVisible()
+
+            hostingController.loadViewIfNeeded()
+            hostingController.view.layoutIfNeeded()
+
+            await RunLoop.main.waitForNextTick()
+
+            // Then: body and render-loop spans must not be created
+            let allSpans = spanProcessor.startedSpans + spanProcessor.endedSpans
+            let spanNames = allSpans.map { $0.name }
+
+            XCTAssertFalse(spanNames.contains("emb-swiftui.view.DefaultScreen.body"), "body span should be off by default")
+            XCTAssertFalse(spanNames.contains("emb-swiftui.view.DefaultScreen.render-loop"), "render-loop span should be off by default")
+
+            // Lifecycle spans must still be created
+            XCTAssertTrue(spanNames.contains("emb-swiftui.view.DefaultScreen.appear"))
+            XCTAssertTrue(spanNames.contains("emb-swiftui.view.DefaultScreen.time-to-first-render"))
+
+            window.isHidden = true
+        }
+
+        @MainActor
+        func testBodySpansOnWhenOptedIn() async {
+            // Given: tracing is enabled and body tracking is explicitly opted in
+            mockConfig.isSwiftUiViewInstrumentationEnabled = true
+
+            // When: we render an EmbraceTraceView with trackBodyEvaluations: true
+            let traceView = EmbraceTraceView("OptedInScreen", trackBodyEvaluations: true) {
+                Text("Content")
+            }
+            .environment(\.embraceTraceViewLogger, traceViewLogger)
+            .environment(\.embraceTraceViewContext, traceViewContext)
+
+            let hostingController = UIHostingController(rootView: traceView)
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 300, height: 600))
+            window.rootViewController = hostingController
+            window.makeKeyAndVisible()
+
+            hostingController.loadViewIfNeeded()
+            hostingController.view.layoutIfNeeded()
+
+            await RunLoop.main.waitForNextTick()
+
+            // Then: body and render-loop spans must be created
+            let allSpans = spanProcessor.startedSpans + spanProcessor.endedSpans
+            let spanNames = allSpans.map { $0.name }
+
+            XCTAssertTrue(spanNames.contains("emb-swiftui.view.OptedInScreen.body"), "body span should be created when opted in")
+            XCTAssertTrue(spanNames.contains("emb-swiftui.view.OptedInScreen.render-loop"), "render-loop span should be created when opted in")
 
             window.isHidden = true
         }


### PR DESCRIPTION
First commit to the Screen Tracking feature. 

This change intends to reduce noise on swiftui instrumentation by opting-out by default of every 'body' evaluation which creates a new span every time the property is evaluated. 
