### PR TITLE
[EMBR-11398] Feature: Ordered uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ Examples/Benchmarks/Benchmarks.xcworkspace/xcuserdata
 #Don't ignore example apps project files
 !Examples/Embrace-tvOS-TestApp/*.xcodeproj
 !Examples/Embrace-watchOS-TestApp/*.xcodeproj
+
+# Claude
+.claude/
+claude/

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -157,8 +157,7 @@ class EmbraceUploadCache {
                 if let uploadData = try context.fetch(request).first {
                     uploadData.data = data
                     uploadData.payloadTypes = payloadTypes
-                    coreData.save()
-                    return true
+                    return coreData.saveIfNeeded()
                 }
             } catch {
                 logger.warning("Error upading upload data:\n\(error.localizedDescription)")
@@ -176,12 +175,10 @@ class EmbraceUploadCache {
                 payloadTypes: payloadTypes,
                 date: Date()
             ) {
-                coreData.performOperation { _ in
-                    if !coreData.saveIfNeeded() {
-                        context.delete(record)
-                    }
+                if coreData.saveIfNeeded() {
+                    return true
                 }
-                return true
+                context.delete(record)
             }
             return false
         }

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -78,6 +78,38 @@ class EmbraceUploadCache {
         return result
     }
 
+    /// Fetches cached records for the given type, excluding specific IDs, sorted by date ascending.
+    /// - Parameters:
+    ///   - type: Type of records to fetch
+    ///   - excludingIDs: Set of record IDs to exclude (typically in-flight operations)
+    ///   - limit: Maximum number of records to return
+    /// - Returns: An array of immutable records sorted by creation date
+    func fetchUploadData(
+        type: EmbraceUploadType,
+        excludingIDs: Set<String>,
+        limit: Int
+    ) -> [ImmutableUploadDataRecord] {
+        let request = NSFetchRequest<UploadDataRecord>(entityName: UploadDataRecord.entityName)
+        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true)]
+        request.fetchLimit = limit
+
+        if excludingIDs.isEmpty {
+            request.predicate = NSPredicate(format: "type == %i", type.rawValue)
+        } else {
+            request.predicate = NSPredicate(
+                format: "type == %i AND NOT (id IN %@)",
+                type.rawValue,
+                excludingIDs as NSSet
+            )
+        }
+
+        var result: [ImmutableUploadDataRecord] = []
+        coreData.fetchAndPerform(withRequest: request) { records in
+            result = records.map { $0.toImmutable() }
+        }
+        return result
+    }
+
     /// Removes stale data based on size or date, if they're limited in options.
     @discardableResult public func clearStaleDataIfNeeded() -> UInt {
         guard options.cacheDaysLimit > 0 else {
@@ -142,7 +174,6 @@ class EmbraceUploadCache {
                 type: type.rawValue,
                 data: data,
                 payloadTypes: payloadTypes,
-                attemptCount: 0,
                 date: Date()
             ) {
                 coreData.performOperation { _ in
@@ -190,31 +221,6 @@ class EmbraceUploadCache {
     func deleteUploadData(id: String, type: EmbraceUploadType) {
         let request = fetchUploadDataRequest(id: id, type: type)
         coreData.deleteRecords(withRequest: request)
-    }
-
-    /// Updates the attempt count of the upload data for the given identifier.
-    /// - Parameters:
-    ///   - id: Identifier of the data
-    ///   - type: Type of the data
-    ///   - attemptCount: New attempt count
-    /// - Returns: Returns the updated `UploadDataRecord`, if any
-    func updateAttemptCount(
-        id: String,
-        type: EmbraceUploadType,
-        attemptCount: Int
-    ) {
-
-        let request = fetchUploadDataRequest(id: id, type: type)
-        coreData.fetchFirstAndPerform(withRequest: request) { [weak self] record in
-
-            guard let uploadData = record else {
-                return
-            }
-
-            uploadData.attemptCount = attemptCount
-
-            self?.coreData.save()
-        }
     }
 
     /// Fetches all records that should be deleted based on them being older than the passed date

--- a/Sources/EmbraceUploadInternal/Cache/UploadDataRecord.swift
+++ b/Sources/EmbraceUploadInternal/Cache/UploadDataRecord.swift
@@ -12,7 +12,6 @@ public class UploadDataRecord: NSManagedObject {
     @NSManaged var type: Int
     @NSManaged var data: Data
     @NSManaged var payloadTypes: String?
-    @NSManaged var attemptCount: Int
     @NSManaged var date: Date
 
     class func create(
@@ -21,7 +20,6 @@ public class UploadDataRecord: NSManagedObject {
         type: Int,
         data: Data,
         payloadTypes: String?,
-        attemptCount: Int,
         date: Date
     ) -> UploadDataRecord? {
         var record: UploadDataRecord?
@@ -36,7 +34,6 @@ public class UploadDataRecord: NSManagedObject {
             record?.type = type
             record?.data = data
             record?.payloadTypes = payloadTypes
-            record?.attemptCount = attemptCount
             record?.date = date
         }
 
@@ -49,7 +46,6 @@ public class UploadDataRecord: NSManagedObject {
             type: type,
             data: data,
             payloadTypes: payloadTypes,
-            attemptCount: attemptCount,
             date: date
         )
     }
@@ -85,14 +81,6 @@ extension UploadDataRecord {
         payloadTypesAttribute.isOptional = true
         payloadTypesAttribute.defaultValue = nil
 
-        let attemptCountAttribute = NSAttributeDescription()
-        attemptCountAttribute.name = "attemptCount"
-        #if arch(arm64_32)
-            attemptCountAttribute.attributeType = .integer32AttributeType
-        #else
-            attemptCountAttribute.attributeType = .integer64AttributeType
-        #endif
-
         let dateAttribute = NSAttributeDescription()
         dateAttribute.name = "date"
         dateAttribute.attributeType = .dateAttributeType
@@ -102,7 +90,6 @@ extension UploadDataRecord {
             typeAttribute,
             dataAttribute,
             payloadTypesAttribute,
-            attemptCountAttribute,
             dateAttribute
         ]
 
@@ -115,6 +102,5 @@ struct ImmutableUploadDataRecord {
     let type: Int
     let data: Data
     let payloadTypes: String?
-    let attemptCount: Int
     let date: Date
 }

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -43,8 +43,6 @@ public class EmbraceUpload: EmbraceLogUploader {
     private weak var lastSpansOperation: Operation?
     private weak var lastLogsOperation: Operation?
 
-    private let isRetryingCache = EmbraceAtomic(false)
-
     private let urlSession: URLSession
     let cache: EmbraceUploadCache
     private var reachabilityMonitor: EmbraceReachabilityMonitor?
@@ -106,13 +104,6 @@ public class EmbraceUpload: EmbraceLogUploader {
                 completion?()
                 return
             }
-
-            guard self.isRetryingCache.compareExchange(expected: false, desired: true) else {
-                completion?()
-                return
-            }
-
-            defer { self.isRetryingCache.store(false) }
 
             // Clear stale data
             self.cache.clearStaleDataIfNeeded()

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -215,7 +215,7 @@ public class EmbraceUpload: EmbraceLogUploader {
     /// Must be called on the coordination queue.
     private func fillQueue(for type: EmbraceUploadType) {
         let queue = uploadQueue(for: type)
-        let currentCount = queue.operationCount
+        let currentCount = inFlightIDs[type]?.count ?? 0
         let limit = options.redundancy.queueLimit
 
         guard currentCount < limit else { return }

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -196,8 +196,10 @@ public class EmbraceUpload: EmbraceLogUploader {
 
         // Save to cache synchronously (we are on the coordination queue).
         // Data is durable after this call.
-        if !cache.saveUploadData(id: id, type: type, data: data, payloadTypes: payloadTypes) {
+        guard cache.saveUploadData(id: id, type: type, data: data, payloadTypes: payloadTypes) else {
             logger.debug("Error caching upload data!")
+            completion?(.failure(EmbraceUploadError.internalError(.cacheSaveFailed)))
+            return
         }
 
         // Signal durability to the caller

--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -18,21 +18,42 @@ public class EmbraceUpload: EmbraceLogUploader {
 
     public private(set) var options: Options
     public private(set) var logger: InternalLogger
-    public private(set) var queue: DispatchQueue
-    public private(set) var retryQueue: DispatchQueue
+
+    /// Coordination queue — serializes all state management: cache reads/writes,
+    /// in-flight tracking, last-operation references, and queue-fill decisions.
+    /// Never executes network requests. Never blocks on the operation queues.
+    public let queue: DispatchQueue
+
+    /// Upload queues — only contain upload operations (network work).
+    let spansQueue: OperationQueue
+    let _spansQueue: DispatchQueue
+    let logsQueue: OperationQueue
+    let _logsQueue: DispatchQueue
+    let attachmentsQueue: OperationQueue
+    let _attachmentsQueue: DispatchQueue
+
+    /// Per-type set of record IDs that currently have active upload operations.
+    /// Read and written exclusively on the coordination queue.
+    private var inFlightIDs: [EmbraceUploadType: Set<String>] = [
+        .spans: [], .log: [], .attachment: []
+    ]
+
+    /// Weak references to the most recently enqueued upload operation for ordered types.
+    /// Used to chain new operations against their predecessor.
+    private weak var lastSpansOperation: Operation?
+    private weak var lastLogsOperation: Operation?
 
     private let isRetryingCache = EmbraceAtomic(false)
 
     private let urlSession: URLSession
     let cache: EmbraceUploadCache
-    let operationQueue: OperationQueue
     private var reachabilityMonitor: EmbraceReachabilityMonitor?
 
     /// Returns an `EmbraceUpload` instance
     /// - Parameters:
     ///   - options: `EmbraceUpload.Options` instance
-    ///   - logger: `EmbraceConsoleLogger` instance
-    ///   - queue: `DispatchQueue` to be used for all upload operations
+    ///   - logger: `InternalLogger` instance
+    ///   - queue: `DispatchQueue` to be used as the coordination queue
     public init(
         options: Options,
         logger: InternalLogger,
@@ -42,14 +63,26 @@ public class EmbraceUpload: EmbraceLogUploader {
         self.options = options
         self.logger = logger
         self.queue = queue
-        self.retryQueue = DispatchQueue(label: "com.embrace.upload.retry", qos: .utility)
 
         cache = try EmbraceUploadCache(options: options.cache, logger: logger)
 
         urlSession = URLSession(configuration: options.urlSessionConfiguration)
 
-        operationQueue = OperationQueue()
-        operationQueue.underlyingQueue = queue
+        // Serial queues for ordered types
+        spansQueue = OperationQueue()
+        spansQueue.maxConcurrentOperationCount = 1
+        _spansQueue = DispatchQueue(label: "com.embrace.upload.spans", qos: .utility)
+        spansQueue.underlyingQueue = _spansQueue
+
+        logsQueue = OperationQueue()
+        logsQueue.maxConcurrentOperationCount = 1
+        _logsQueue = DispatchQueue(label: "com.embrace.upload.logs", qos: .utility)
+        logsQueue.underlyingQueue = _logsQueue
+
+        // Concurrent queue for attachments (no ordering constraint)
+        attachmentsQueue = OperationQueue()
+        _attachmentsQueue = DispatchQueue(label: "com.embrace.upload.attachments", qos: .utility)
+        attachmentsQueue.underlyingQueue = _attachmentsQueue
 
         // reachability monitor
         if options.redundancy.retryOnInternetConnected {
@@ -63,61 +96,35 @@ public class EmbraceUpload: EmbraceLogUploader {
         }
     }
 
+    // MARK: - Public API
+
     /// Attempts to upload all the available cached data.
+    /// Called at process launch and on internet reconnection.
     public func retryCachedData(_ completion: (() -> Void)? = nil) {
-
-        let group = DispatchGroup()
-        group.enter()
-
-        retryQueue.async { [weak self] in
-            guard let strongSelf = self else {
+        queue.async { [weak self] in
+            guard let self = self else {
+                completion?()
                 return
             }
 
-            defer {
-                // on finishing everything, allow to retry cache (i.e. reconnection)
-                strongSelf.isRetryingCache.store(false)
-                group.leave()
-            }
-
-            // in place mechanism to not retry sending cache data at the same time
-            guard strongSelf.isRetryingCache.compareExchange(expected: false, desired: true) else {
+            guard self.isRetryingCache.compareExchange(expected: false, desired: true) else {
+                completion?()
                 return
             }
 
-            // clear data from cache that shouldn't be retried as it's stale
-            strongSelf.clearCacheFromStaleData()
+            defer { self.isRetryingCache.store(false) }
 
-            // get all the data cached first, is the only thing that could throw
-            let cachedObjects = strongSelf.cache.fetchAllUploadData()
+            // Clear stale data
+            self.cache.clearStaleDataIfNeeded()
 
-            // create a sempahore to allow only to send two request at a time so we don't
-            // get throttled by the backend on cases where cache has many failed requests.
+            // Fill queues — records are fetched in date order.
+            // inFlightIDs is NOT reset here. On internet reconnection, queues may still
+            // have active operations whose IDs are correctly tracked.
+            // At process launch, the sets are already empty (freshly initialized).
+            self.fillQueue(for: .spans)
+            self.fillQueue(for: .log)
+            self.fillQueue(for: .attachment)
 
-            let sem = DispatchSemaphore(value: 2)
-
-            for uploadData in cachedObjects {
-                guard let type = EmbraceUploadType(rawValue: uploadData.type) else {
-                    continue
-                }
-
-                group.enter()
-                sem.wait()
-
-                strongSelf.reUploadData(
-                    id: uploadData.id,
-                    data: uploadData.data,
-                    type: type,
-                    payloadTypes: uploadData.payloadTypes,
-                    attemptCount: uploadData.attemptCount
-                ) {
-                    sem.signal()
-                    group.leave()
-                }
-            }
-        }
-
-        group.notify(queue: queue) {
             completion?()
         }
     }
@@ -160,7 +167,7 @@ public class EmbraceUpload: EmbraceLogUploader {
     /// - Parameters:
     ///   - id: Identifier of the attachment
     ///   - data: The attachment's data
-    ///   - completion: Completion block called when the data is successfully uploaded, or when an `Error` occurs
+    ///   - completion: Completion block called when the data is successfully cached, or when an `Error` occurs
     public func uploadAttachment(id: String, data: Data, completion: ((Result<(), Error>) -> Void)?) {
         queue.async { [weak self] in
             self?.uploadData(
@@ -172,183 +179,170 @@ public class EmbraceUpload: EmbraceLogUploader {
         }
     }
 
-    // MARK: - Internal
+    // MARK: - Internal: Upload Data (Cache-First)
+
+    /// Validates input, saves to cache synchronously, signals durability via completion,
+    /// then calls fillQueue to create upload operations if the queue has capacity.
     private func uploadData(
         id: String,
         data: Data,
         type: EmbraceUploadType,
         payloadTypes: String? = nil,
-        attemptCount: Int = 0,
         completion: ((Result<(), Error>) -> Void)?
     ) {
 
         // validate identifier
-        guard id.isEmpty == false else {
+        guard !id.isEmpty else {
             completion?(.failure(EmbraceUploadError.internalError(.invalidMetadata)))
             return
         }
 
         // validate data
-        guard data.isEmpty == false else {
+        guard !data.isEmpty else {
             completion?(.failure(EmbraceUploadError.internalError(.invalidData)))
             return
         }
 
-        // cache operation
-        let cacheOperation = BlockOperation { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-
-            if !strongSelf.cache.saveUploadData(id: id, type: type, data: data, payloadTypes: payloadTypes) {
-                strongSelf.logger.debug("Error caching upload data!")
-            }
+        // Save to cache synchronously (we are on the coordination queue).
+        // Data is durable after this call.
+        if !cache.saveUploadData(id: id, type: type, data: data, payloadTypes: payloadTypes) {
+            logger.debug("Error caching upload data!")
         }
 
-        // upload operation
-        let uploadOperation = createUploadOperation(
-            id: id,
+        // Signal durability to the caller
+        completion?(.success(()))
+
+        // Try to fill the queue (may create an operation for this record or leave it in cache)
+        fillQueue(for: type)
+    }
+
+    // MARK: - Internal: Queue Fill Mechanism
+
+    /// The single mechanism for creating upload operations. Called after every cache write
+    /// and after every operation completion.
+    ///
+    /// Must be called on the coordination queue.
+    private func fillQueue(for type: EmbraceUploadType) {
+        let queue = uploadQueue(for: type)
+        let currentCount = queue.operationCount
+        let limit = options.redundancy.queueLimit
+
+        guard currentCount < limit else { return }
+
+        let availableSlots = limit - currentCount
+        let excludedIDs = inFlightIDs[type] ?? []
+
+        let records = cache.fetchUploadData(
             type: type,
-            urlSession: urlSession,
-            data: data,
-            payloadTypes: payloadTypes,
-            retryCount: options.redundancy.automaticRetryCount,
-            attemptCount: attemptCount
-        ) { [weak self] (result, attemptCount) in
+            excludingIDs: excludedIDs,
+            limit: availableSlots
+        )
 
-            self?.queue.async { [weak self] in
+        for record in records {
+            let operation = createUploadOperation(
+                id: record.id,
+                type: type,
+                data: record.data,
+                payloadTypes: record.payloadTypes
+            )
 
-                self?.handleOperationFinished(
-                    id: id,
-                    type: type,
-                    result: result,
-                    attemptCount: attemptCount
-                )
-
-                self?.clearCacheFromStaleData()
-
-                completion?(.success(()))
+            // Chain for ordered types
+            if type == .spans {
+                if let last = lastSpansOperation, !last.isFinished {
+                    operation.addDependency(last)
+                }
+                lastSpansOperation = operation
+            } else if type == .log {
+                if let last = lastLogsOperation, !last.isFinished {
+                    operation.addDependency(last)
+                }
+                lastLogsOperation = operation
             }
-        }
 
-        // queue operations
-        uploadOperation.addDependency(cacheOperation)
-        operationQueue.addOperation(cacheOperation)
-        operationQueue.addOperation(uploadOperation)
+            inFlightIDs[type]?.insert(record.id)
+            queue.addOperation(operation)
+        }
     }
 
-    func reUploadData(
-        id: String,
-        data: Data,
-        type: EmbraceUploadType,
-        payloadTypes: String?,
-        attemptCount: Int,
-        completion: @escaping (() -> Void)
-    ) {
-        let totalPendingRetries = options.redundancy.maximumAmountOfRetries - attemptCount
-        let retries = min(options.redundancy.automaticRetryCount, totalPendingRetries)
-
-        let uploadOperation = EmbraceUploadOperation(
-            urlSession: urlSession,
-            queue: queue,
-            metadataOptions: options.metadata,
-            endpoint: endpoint(for: type),
-            identifier: id,
-            data: data,
-            payloadTypes: payloadTypes,
-            retryCount: retries,
-            exponentialBackoffBehavior: options.redundancy.exponentialBackoffBehavior,
-            attemptCount: attemptCount,
-            logger: logger
-        ) { [weak self] (result, attemptCount) in
-            self?.queue.async { [weak self] in
-                self?.handleOperationFinished(
-                    id: id,
-                    type: type,
-                    result: result,
-                    attemptCount: attemptCount
-                )
-                completion()
-            }
-        }
-
-        operationQueue.addOperation(uploadOperation)
-    }
+    // MARK: - Internal: Operation Factory
 
     private func createUploadOperation(
         id: String,
         type: EmbraceUploadType,
-        urlSession: URLSession,
         data: Data,
-        payloadTypes: String?,
-        retryCount: Int,
-        attemptCount: Int,
-        completion: @escaping EmbraceUploadOperationCompletion
+        payloadTypes: String?
     ) -> EmbraceUploadOperation {
+
+        let operationCompletion: EmbraceUploadOperationCompletion = { [weak self] result, _ in
+            self?.queue.async { [weak self] in
+                self?.handleOperationFinished(id: id, type: type, result: result)
+            }
+        }
+
+        let operationQueue = uploadQueue(for: type)
 
         if type == .attachment {
             return EmbraceAttachmentUploadOperation(
                 urlSession: urlSession,
-                queue: queue,
+                queue: operationQueue.underlyingQueue ?? .global(qos: .utility),
                 metadataOptions: options.metadata,
                 endpoint: endpoint(for: type),
                 identifier: id,
                 data: data,
                 payloadTypes: payloadTypes,
-                retryCount: retryCount,
+                retryCount: options.redundancy.automaticRetryCount,
                 exponentialBackoffBehavior: options.redundancy.exponentialBackoffBehavior,
-                attemptCount: attemptCount,
+                attemptCount: 0,
                 logger: logger,
-                completion: completion
+                completion: operationCompletion
             )
         }
 
         return EmbraceUploadOperation(
             urlSession: urlSession,
-            queue: queue,
+            queue: operationQueue.underlyingQueue ?? .global(qos: .utility),
             metadataOptions: options.metadata,
             endpoint: endpoint(for: type),
             identifier: id,
             data: data,
             payloadTypes: payloadTypes,
-            retryCount: retryCount,
+            retryCount: options.redundancy.automaticRetryCount,
             exponentialBackoffBehavior: options.redundancy.exponentialBackoffBehavior,
-            attemptCount: attemptCount,
+            attemptCount: 0,
             logger: logger,
-            completion: completion
+            completion: operationCompletion
         )
     }
+
+    // MARK: - Internal: Operation Completion
 
     private func handleOperationFinished(
         id: String,
         type: EmbraceUploadType,
-        result: EmbraceUploadOperationResult,
-        attemptCount: Int
+        result: EmbraceUploadOperationResult
     ) {
+        // Remove from in-flight tracking
+        inFlightIDs[type]?.remove(id)
+
+        // Delete from cache unless cancelled (cancelled records are replayed on next launch)
         switch result {
-        case .success:
-            addDeleteUploadDataOperation(id: id, type: type)
-        case .failure(let isRetriable):
-            if isRetriable, attemptCount < options.redundancy.maximumAmountOfRetries {
-                operationQueue.addOperation { [weak self] in
-                    self?.cache.updateAttemptCount(id: id, type: type, attemptCount: attemptCount)
-                }
-                return
-            }
-
-            addDeleteUploadDataOperation(id: id, type: type)
+        case .success, .failure:
+            cache.deleteUploadData(id: id, type: type)
+        case .cancelled:
+            break
         }
+
+        // Refill the queue
+        fillQueue(for: type)
     }
 
-    private func addDeleteUploadDataOperation(id: String, type: EmbraceUploadType) {
-        operationQueue.addOperation { [weak self] in
-            self?.cache.deleteUploadData(id: id, type: type)
-        }
-    }
+    // MARK: - Internal: Helpers
 
-    private func clearCacheFromStaleData() {
-        operationQueue.addOperation { [weak self] in
-            self?.cache.clearStaleDataIfNeeded()
+    private func uploadQueue(for type: EmbraceUploadType) -> OperationQueue {
+        switch type {
+        case .spans: return spansQueue
+        case .log: return logsQueue
+        case .attachment: return attachmentsQueue
         }
     }
 

--- a/Sources/EmbraceUploadInternal/ErrorManagement/EmbraceUploadError.swift
+++ b/Sources/EmbraceUploadInternal/ErrorManagement/EmbraceUploadError.swift
@@ -9,6 +9,7 @@ public enum EmbraceUploadErrorCode: Int {
     case invalidMetadata = 1000
     case invalidData = 1001
     case operationCancelled = 1002
+    case cacheSaveFailed = 1003
 }
 
 public enum EmbraceUploadError: Error, Equatable {

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -10,7 +10,8 @@ import Foundation
 
 enum EmbraceUploadOperationResult: Equatable {
     case success
-    case failure(retriable: Bool)
+    case failure
+    case cancelled
 }
 
 typealias EmbraceUploadOperationCompletion = (_ result: EmbraceUploadOperationResult, _ attemptCount: Int) -> Void
@@ -64,7 +65,8 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         task?.cancel()
         task = nil
 
-        completion?(.failure(retriable: true), attemptCount)
+        completion?(.cancelled, attemptCount)
+        finish()
     }
 
     override func execute() {
@@ -110,24 +112,31 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         request: URLRequest,
         retryCount: Int
     ) {
-        // retry?
-        if retryCount > 0 && shouldRetry(basedOn: response, error: error) {
-            // calculates the necessary delay before retrying the request
+        // If the operation was cancelled, cancel() already fired the completion and called finish().
+        // Just return to avoid double-completion and double-finish.
+        guard !isCancelled else {
+            return
+        }
+
+        // Check retry budget: -1 = unlimited, 0 = none, >0 = that many remaining
+        let hasRetryBudget = (retryCount != 0)
+        if hasRetryBudget && shouldRetry(basedOn: response, error: error) {
             let delay = exponentialBackoffBehavior.calculateDelay(
-                forRetryNumber: (self.retryCount - (retryCount - 1)),
-                appending: getSuggestedDelay(fromResponse: response)
+                forRetryNumber: attemptCount,
+                appending: TimeInterval(getSuggestedDelay(fromResponse: response))
             )
 
-            // retry request on the same queue after `delay`
+            let nextRetryCount = retryCount > 0 ? retryCount - 1 : retryCount
+
             queue.asyncAfter(
-                deadline: .now() + .seconds(delay),
+                deadline: .now() + delay,
                 execute: { [weak self] in
-                    self?.sendRequest(request, retryCount: retryCount - 1)
+                    self?.sendRequest(request, retryCount: nextRetryCount)
                 })
             return
         }
 
-        // check success
+        // No retries left or non-retriable — determine result
         if let response = response as? HTTPURLResponse {
             logger?.debug(
                 "Upload operation complete. Status: \(response.statusCode) URL: \(String(describing: response.url))"
@@ -135,14 +144,10 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
             if response.statusCode >= 200 && response.statusCode < 300 {
                 completion?(.success, attemptCount)
             } else {
-                let isRetriable = shouldRetry(basedOn: response, error: error)
-                completion?(.failure(retriable: isRetriable), attemptCount)
+                completion?(.failure, attemptCount)
             }
-
-            // no retries left, send completion
         } else {
-            let isRetriable = shouldRetry(basedOn: response, error: error)
-            completion?(.failure(retriable: isRetriable), attemptCount)
+            completion?(.failure, attemptCount)
         }
 
         finish()
@@ -153,36 +158,19 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         error: (any Error)?
     ) -> Bool {
         // handle network-related errors
-        if let nsError = error as? URLError {
-            switch nsError.code {
-            case .cancelled,
-                .unsupportedURL,
-                .badURL,
-                .userAuthenticationRequired,
-                .secureConnectionFailed,
-                .serverCertificateUntrusted,
-                .dnsLookupFailed:
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .unsupportedURL,
+                .badURL:
                 return false
             default:
                 return true
             }
         }
 
-        // handle HTTP status codes:
-        // retry only if is an error (client/server) and statusCode is not 429
+        // all 4xx and 5xx are retriable
         if let statusCode = (response as? HTTPURLResponse)?.statusCode, statusCode >= 400 {
-            switch statusCode {
-            // this status code ("Too Many Requests") indicates that the server has applied rate limiting to protect itself from excessive requests.
-            // instead of dropping the request, we should retry this operation at a later time.
-            case 429:
-                return true
-            // server-side errors (5xx): These indicate issues on the server side that may be temporary, so retrying is appropriate.
-            case 500...599:
-                return true
-            // default case for other 4xx errors: These typically indicate client-side issues (e.g. invalid requests) and should not be retried.
-            default:
-                return false
-            }
+            return true
         }
 
         // retry for all other non-handled cases with errors

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+ExponentialBackoff.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+ExponentialBackoff.swift
@@ -10,7 +10,7 @@ extension EmbraceUpload {
         let maxDelay: Double
 
         public init(
-            baseDelay: Double = 2.0,
+            baseDelay: Double = 0.25,
             maxDelay: Double = 32.0
         ) {
             self.baseDelay = baseDelay
@@ -21,26 +21,26 @@ extension EmbraceUpload {
 
         /// Calculates the exponential backoff delay based on the given `retryNumber`.
         ///
-        /// This function computes the delay for a retry attempt using an exponential backoff algorithm,
-        /// where the delay increases exponentially with each retry, using the `baseDelay` as the base factor.
+        /// This function computes the delay for a retry attempt using an exponential backoff algorithm.
+        /// The delay doubles with each retry, starting from `baseDelay`.
         /// The computed delay is capped by `maxDelay` to prevent excessive waiting times.
         ///
         /// ### Example:
         /// Given an `ExponentialBackoff` with:
-        /// - `baseDelay = 2.0 seconds`
-        /// - `maxDelay = 60.0 seconds`
+        /// - `baseDelay = 0.25 seconds`
+        /// - `maxDelay = 32.0 seconds`
         ///
-        /// For the first retry (retryNumber = 1), the delay would be: `pow(2.0, 1) = 2.0 seconds`.
-        /// For the second retry (retryNumber = 2), the delay would be: `pow(2.0, 2) = 4.0 seconds`.
+        /// For the first retry (retryNumber = 1), the delay would be: `0.25 * pow(2, 0) = 0.25 seconds`.
+        /// For the second retry (retryNumber = 2), the delay would be: `0.25 * pow(2, 1) = 0.5 seconds`.
         ///
-        /// For subsequent retries, the delay continues to grow exponentially, but will be capped at `maxDelay`.
+        /// For subsequent retries, the delay continues to double, but will be capped at `maxDelay`.
         ///
         /// - Parameters:
         ///    - retryNumber: The current retry attempt number (1-based).
-        ///    - extraDelay: An optional amount of delay that could appended to the final calculation. Default is 0.
-        /// - Returns: An integer representing the calculated delay (in seconds) before the next retry attempt.
-        func calculateDelay(forRetryNumber retryNumber: Int, appending extraDelay: Int = 0) -> Int {
-            return Int(min(pow(baseDelay, Double(retryNumber)), maxDelay)) + extraDelay
+        ///    - extraDelay: An optional amount of delay (in seconds) appended to the final calculation. Default is 0.
+        /// - Returns: The calculated delay (in seconds) before the next retry attempt.
+        func calculateDelay(forRetryNumber retryNumber: Int, appending extraDelay: TimeInterval = 0) -> TimeInterval {
+            return min(baseDelay * pow(2.0, Double(retryNumber - 1)), maxDelay) + extraDelay
         }
     }
 }

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+RedundancyOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+RedundancyOptions.swift
@@ -6,11 +6,14 @@ import Foundation
 
 extension EmbraceUpload {
     public class RedundancyOptions {
-        /// Total amount of times a request will be immediately retried in case of error. Use 0 to disable.
+        /// Retry budget per upload operation. -1 means unlimited.
+        /// A positive value causes the record to be permanently deleted from cache when exhausted.
+        /// Use 0 to disable retries entirely.
         public let automaticRetryCount: Int
 
-        /// Total amount of times a request could be retried.
-        public let maximumAmountOfRetries: Int
+        /// Maximum number of upload operations per queue.
+        /// When a queue is at capacity, new uploads are cached and picked up later via queue draining.
+        public let queueLimit: Int
 
         /// Enable to automatically try to send any unsent cached data when the phone regains internet connection.
         public let retryOnInternetConnected: Bool
@@ -19,13 +22,13 @@ extension EmbraceUpload {
         public let exponentialBackoffBehavior: ExponentialBackoff
 
         public init(
-            automaticRetryCount: Int = 3,
-            maximumAmountOfRetries: Int = 20,
+            automaticRetryCount: Int = -1,
+            queueLimit: Int = 10,
             retryOnInternetConnected: Bool = true,
             exponentialBackoffBehavior: ExponentialBackoff = .init()
         ) {
             self.automaticRetryCount = automaticRetryCount
-            self.maximumAmountOfRetries = maximumAmountOfRetries
+            self.queueLimit = queueLimit
             self.retryOnInternetConnected = retryOnInternetConnected
             self.exponentialBackoffBehavior = exponentialBackoffBehavior
         }

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -25,7 +25,7 @@ final class SessionControllerTests: XCTestCase {
         userAgent: "userAgent",
         deviceId: "12345678"
     )
-    static let testRedundancyOptions = EmbraceUpload.RedundancyOptions(automaticRetryCount: 0)
+    static let testRedundancyOptions = EmbraceUpload.RedundancyOptions(automaticRetryCount: -1)
 
     var uploadTestOptions: EmbraceUpload.Options!
 

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -114,12 +114,13 @@ class UnsentDataHandlerTests: XCTestCase {
         // mock error requests
         EmbraceHTTPMock.mock(url: testSpansUrl(), errorCode: 500)
 
-        // given a storage and upload modules
+        // given a storage and upload modules (no retries so request count is deterministic)
         let storage = try EmbraceStorage.createInMemoryDb()
         defer { storage.coreData.destroy() }
 
+        let noRetryOptions = uploadOptions(automaticRetryCount: 0)
         let upload = try EmbraceUpload(
-            options: uploadOptions, logger: logger, queue: queue)
+            options: noRetryOptions, logger: logger, queue: queue)
 
         let otel = MockEmbraceOpenTelemetry()
 
@@ -139,15 +140,14 @@ class UnsentDataHandlerTests: XCTestCase {
         wait(delay: .shortTimeout)
 
         // then a session request was attempted
-        XCTAssertGreaterThan(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
+
+        // then the total amount of requests is correct
+        XCTAssertEqual(EmbraceHTTPMock.totalRequestCount(), 1)
 
         // then the session is no longer on storage
         let session = storage.fetchSession(id: TestConstants.sessionId)
         XCTAssertNil(session)
-
-        // then the session upload data cached
-        let uploadData = upload.cache.fetchAllUploadData()
-        XCTAssertEqual(uploadData.count, 1)
 
         // then no log was sent
         XCTAssertEqual(otel.logs.count, 0)
@@ -231,12 +231,13 @@ class UnsentDataHandlerTests: XCTestCase {
         EmbraceHTTPMock.mock(url: testSpansUrl(), errorCode: 500)
         EmbraceHTTPMock.mock(url: testLogsUrl(), errorCode: 500)
 
-        // given a storage and upload modules
+        // given a storage and upload modules (no retries so request count is deterministic)
         let storage = try EmbraceStorage.createInMemoryDb()
         defer { storage.coreData.destroy() }
 
+        let noRetryOptions = uploadOptions(automaticRetryCount: 0)
         let upload = try EmbraceUpload(
-            options: uploadOptions, logger: logger, queue: queue)
+            options: noRetryOptions, logger: logger, queue: queue)
 
         let otel = MockEmbraceOpenTelemetry()
 
@@ -276,16 +277,15 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // then a crash report request was attempted
         // then a session request was attempted
-        XCTAssert(EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count > 0)
-        XCTAssert(EmbraceHTTPMock.requestsForUrl(self.testSpansUrl()).count > 0)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count, 1)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(self.testSpansUrl()).count, 1)
+
+        // then the total amount of requests is correct
+        XCTAssertEqual(EmbraceHTTPMock.totalRequestCount(), 2)
 
         // then the session is no longer on storage
         let session = storage.fetchSession(id: TestConstants.sessionId)
         XCTAssertNil(session)
-
-        // then the session and crash report upload data are still cached
-        let uploadData = upload.cache.fetchAllUploadData()
-        XCTAssertEqual(uploadData.count, 2)
 
         // then the crash is not longer stored
         let reports = await crashReporter.fetchUnsentCrashReports()
@@ -763,6 +763,21 @@ extension UnsentDataHandlerTests {
             spansURL: testSpansUrl(forTest: testName),
             logsURL: testLogsUrl(forTest: testName),
             attachmentsURL: testAttachmentsUrl(forTest: testName)
+        )
+    }
+
+    fileprivate func uploadOptions(automaticRetryCount: Int) -> EmbraceUpload.Options {
+        let urlSessionConfig = URLSessionConfiguration.ephemeral
+        urlSessionConfig.httpMaximumConnectionsPerHost = .max
+        urlSessionConfig.protocolClasses = [EmbraceHTTPMock.self]
+
+        return EmbraceUpload.Options(
+            endpoints: testEndpointOptions(forTest: testName),
+            cache: EmbraceUpload.CacheOptions(
+                storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false),
+            metadata: UnsentDataHandlerTests.testMetadataOptions,
+            redundancy: EmbraceUpload.RedundancyOptions(automaticRetryCount: automaticRetryCount),
+            urlSessionConfiguration: urlSessionConfig
         )
     }
 

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -20,7 +20,7 @@ class UnsentDataHandlerTests: XCTestCase {
     let sdkStateProvider = MockEmbraceSDKStateProvider()
     var criticalLogsFilePath: URL!
 
-    static let testRedundancyOptions = EmbraceUpload.RedundancyOptions(automaticRetryCount: 0)
+    static let testRedundancyOptions = EmbraceUpload.RedundancyOptions(automaticRetryCount: -1)
     static let testMetadataOptions = EmbraceUpload.MetadataOptions(
         apiKey: "apiKey",
         userAgent: "userAgent",
@@ -92,6 +92,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(storage: storage, upload: upload, otel: otel, crashReporter: nil)
+        wait(delay: .shortTimeout)
 
         // then a session request was sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
@@ -135,12 +136,10 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when failing to send unsent sessions
         await UnsentDataHandler.sendUnsentData(storage: storage, upload: upload, otel: otel, crashReporter: nil)
+        wait(delay: .shortTimeout)
 
         // then a session request was attempted
         XCTAssertGreaterThan(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
-
-        // then the total amount of requests is correct
-        XCTAssertEqual(EmbraceHTTPMock.totalRequestCount(), 1)
 
         // then the session is no longer on storage
         let session = storage.fetchSession(id: TestConstants.sessionId)
@@ -199,6 +198,7 @@ class UnsentDataHandlerTests: XCTestCase {
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(
             storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
+        wait(delay: .shortTimeout)
 
         // then a crash report was sent
         // then a session request was sent
@@ -272,14 +272,12 @@ class UnsentDataHandlerTests: XCTestCase {
             storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
 
         await fulfillment(of: [didSendCrashesExpectation], timeout: .defaultTimeout)
+        wait(delay: .shortTimeout)
 
         // then a crash report request was attempted
         // then a session request was attempted
         XCTAssert(EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count > 0)
         XCTAssert(EmbraceHTTPMock.requestsForUrl(self.testSpansUrl()).count > 0)
-
-        // then the total amount of requests is correct
-        XCTAssertEqual(EmbraceHTTPMock.totalRequestCount(), 2)
 
         // then the session is no longer on storage
         let session = storage.fetchSession(id: TestConstants.sessionId)
@@ -344,6 +342,7 @@ class UnsentDataHandlerTests: XCTestCase {
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(
             storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
+        wait(delay: .shortTimeout)
 
         // then a crash report was sent
         // then a session request was sent
@@ -407,6 +406,7 @@ class UnsentDataHandlerTests: XCTestCase {
             upload: upload,
             otel: otel
         )
+        wait(delay: .shortTimeout)
 
         // then a crash log was sent
         XCTAssert(EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count > 0)
@@ -479,6 +479,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(storage: storage, upload: upload, otel: otel)
+        wait(delay: .shortTimeout)
 
         // then the old closed span was removed
         // and the open span was closed
@@ -564,6 +565,7 @@ class UnsentDataHandlerTests: XCTestCase {
             otel: otel,
             currentSessionId: TestConstants.sessionId
         )
+        wait(delay: .shortTimeout)
 
         // then all metadata is cleaned up
         let records: [MetadataRecord] = storage.fetchAll()
@@ -609,6 +611,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when uploading the session
         await UnsentDataHandler.sendSession(session, storage: storage, upload: upload)
+        wait(delay: .shortTimeout)
 
         // then the old closed span was removed
         // and the session was removed
@@ -664,6 +667,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when uploading the session
         await UnsentDataHandler.sendSession(session, storage: storage, upload: upload)
+        wait(delay: .shortTimeout)
 
         // then metadata is correctly cleaned up
         let records: [MetadataRecord] = storage.fetchAll()
@@ -707,6 +711,7 @@ class UnsentDataHandlerTests: XCTestCase {
         // when sending unsent data
         await UnsentDataHandler.sendUnsentData(
             storage: storage, upload: upload, otel: otel, logController: logController)
+        wait(delay: .shortTimeout)
 
         // then no sessions were sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
@@ -729,6 +734,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending critical logs
         await UnsentDataHandler.sendCriticalLogs(fileUrl: criticalLogsFilePath, upload: upload)
+        wait(delay: .shortTimeout)
 
         // then a log is sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 1)
@@ -744,6 +750,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending critical logs without a file present
         await UnsentDataHandler.sendCriticalLogs(fileUrl: criticalLogsFilePath, upload: upload)
+        wait(delay: .shortTimeout)
 
         // then no log is sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests+ClearDataDate.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests+ClearDataDate.swift
@@ -24,7 +24,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1300, since: now)
         )
         _ = UploadDataRecord.create(
@@ -33,7 +32,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0,
             date: oldDate
         )
         _ = UploadDataRecord.create(
@@ -42,7 +40,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0,
             date: oldDate
         )
         _ = UploadDataRecord.create(
@@ -51,7 +48,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 300),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1200, since: now)
         )
         _ = UploadDataRecord.create(
@@ -60,7 +56,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 400),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1100, since: now)
         )
         _ = UploadDataRecord.create(
@@ -69,7 +64,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 100),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1000, since: now)
         )
 
@@ -118,7 +112,7 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0, date: Date(timeInterval: -1300, since: now)
+            date: Date(timeInterval: -1300, since: now)
         )
         _ = UploadDataRecord.create(
             context: cache.coreData.context,
@@ -126,7 +120,7 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0, date: oldDate
+            date: oldDate
         )
         _ = UploadDataRecord.create(
             context: cache.coreData.context,
@@ -134,7 +128,7 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0, date: oldDate
+            date: oldDate
         )
         _ = UploadDataRecord.create(
             context: cache.coreData.context,
@@ -142,7 +136,7 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 300),
             payloadTypes: "test",
-            attemptCount: 0, date: Date(timeInterval: -1200, since: now)
+            date: Date(timeInterval: -1200, since: now)
         )
         _ = UploadDataRecord.create(
             context: cache.coreData.context,
@@ -150,7 +144,7 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 400),
             payloadTypes: "test",
-            attemptCount: 0, date: Date(timeInterval: -1100, since: now)
+            date: Date(timeInterval: -1100, since: now)
         )
         _ = UploadDataRecord.create(
             context: cache.coreData.context,
@@ -158,7 +152,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 100),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1000, since: now)
         )
 
@@ -210,7 +203,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1300, since: now)
         )
         _ = UploadDataRecord.create(
@@ -219,7 +211,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0,
             date: oldDate
         )
         _ = UploadDataRecord.create(
@@ -228,7 +219,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 1),
             payloadTypes: "test",
-            attemptCount: 0,
             date: oldDate
         )
         _ = UploadDataRecord.create(
@@ -237,7 +227,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 300),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1200, since: now)
         )
         _ = UploadDataRecord.create(
@@ -246,7 +235,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 400),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1100, since: now)
         )
         _ = UploadDataRecord.create(
@@ -255,7 +243,6 @@ extension EmbraceUploadCacheTests {
             type: 0,
             data: Data(repeating: 3, count: 100),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date(timeInterval: -1000, since: now)
         )
 

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests.swift
@@ -57,7 +57,6 @@ class EmbraceUploadCacheTests: XCTestCase {
             type: EmbraceUploadType.spans.rawValue,
             data: Data(),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date()
         )
 
@@ -83,7 +82,6 @@ class EmbraceUploadCacheTests: XCTestCase {
             type: 0,
             data: Data(),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date()
         )
         _ = UploadDataRecord.create(
@@ -92,7 +90,6 @@ class EmbraceUploadCacheTests: XCTestCase {
             type: 0,
             data: Data(),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date()
         )
         _ = UploadDataRecord.create(
@@ -101,7 +98,6 @@ class EmbraceUploadCacheTests: XCTestCase {
             type: 0,
             data: Data(),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date()
         )
 
@@ -184,7 +180,6 @@ class EmbraceUploadCacheTests: XCTestCase {
             type: EmbraceUploadType.spans.rawValue,
             data: Data(),
             payloadTypes: "test",
-            attemptCount: 0,
             date: Date()
         )
 
@@ -210,44 +205,4 @@ class EmbraceUploadCacheTests: XCTestCase {
         wait(for: [expectation], timeout: .defaultTimeout)
     }
 
-    func test_updateAttemptCount() throws {
-        let options = EmbraceUpload.CacheOptions(
-            storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)
-        let cache = try EmbraceUploadCache(options: options, logger: logger)
-
-        // given inserted upload data
-        _ = UploadDataRecord.create(
-            context: cache.coreData.context,
-            id: "id",
-            type: EmbraceUploadType.spans.rawValue,
-            data: Data(),
-            payloadTypes: "test",
-            attemptCount: 0,
-            date: Date()
-        )
-
-        cache.coreData.save()
-
-        // when updating the attempt count
-        cache.updateAttemptCount(id: "id", type: .spans, attemptCount: 10)
-
-        // then the data is updated successfully
-        let expectation = XCTestExpectation()
-
-        let request = NSFetchRequest<UploadDataRecord>(entityName: UploadDataRecord.entityName)
-
-        cache.coreData.context.perform {
-            do {
-                let result = try cache.coreData.context.fetch(request)
-                if result.count == 1,
-                    result.first?.id == "id",
-                    result.first?.attemptCount == 10
-                {
-                    expectation.fulfill()
-                }
-            } catch {}
-        }
-
-        wait(for: [expectation], timeout: .defaultTimeout)
-    }
 }

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
@@ -140,7 +140,7 @@ class EmbraceUploadOperationTests: XCTestCase {
             attemptCount: 0
         ) { result, attemptCount in
 
-            XCTAssertEqual(result, .failure(retriable: false))
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 1)
 
             expectation.fulfill()
@@ -181,7 +181,7 @@ class EmbraceUploadOperationTests: XCTestCase {
             attemptCount: 0
         ) { result, attemptCount in
 
-            XCTAssertEqual(result, .failure(retriable: false))
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 1)
 
             expectation.fulfill()
@@ -212,7 +212,7 @@ class EmbraceUploadOperationTests: XCTestCase {
         ) { result, attemptCount in
 
             // then the operation should be canceled
-            XCTAssertEqual(result, .failure(retriable: true))
+            XCTAssertEqual(result, .cancelled)
             XCTAssertEqual(attemptCount, 0)
 
             expectation.fulfill()
@@ -226,8 +226,17 @@ class EmbraceUploadOperationTests: XCTestCase {
     func test_onExecuting_whenReceivingNonRetryableError_shouldntRetry() throws {
         try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on WatchOS")
 
-        // mock error response with error that cannot be fixed with retries
-        EmbraceHTTPMock.mock(url: TestConstants.url, response: .withData(Data(), statusCode: 404))
+        // mock error response with a non-retriable URLError (.badURL)
+        EmbraceHTTPMock.mock(
+            url: TestConstants.url,
+            response: .withError(
+                NSError(
+                    domain: NSURLErrorDomain,
+                    code: URLError.badURL.rawValue,
+                    userInfo: [:]
+                )
+            )
+        )
 
         // given an upload operation that errors
         let expectation = XCTestExpectation()
@@ -244,8 +253,8 @@ class EmbraceUploadOperationTests: XCTestCase {
             attemptCount: 0
         ) { result, attemptCount in
 
-            // then the operation should return the error
-            XCTAssertEqual(result, .failure(retriable: false))
+            // then the operation should not retry and return failure
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 1)
 
             expectation.fulfill()
@@ -277,7 +286,7 @@ class EmbraceUploadOperationTests: XCTestCase {
             attemptCount: 0
         ) { result, attemptCount in
 
-            XCTAssertEqual(result, .failure(retriable: true))
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 1)
 
             expectation.fulfill()
@@ -317,7 +326,7 @@ class EmbraceUploadOperationTests: XCTestCase {
         ) { result, attemptCount in
 
             // then the operation should return the error
-            XCTAssertEqual(result, .failure(retriable: true))
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 2)
 
             expectation.fulfill()
@@ -371,7 +380,7 @@ class EmbraceUploadOperationTests: XCTestCase {
         ) { result, attemptCount in
 
             // then the operation should return the error
-            XCTAssertEqual(result, .failure(retriable: true))
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 4)
 
             expectation.fulfill()
@@ -426,7 +435,7 @@ class EmbraceUploadOperationTests: XCTestCase {
         ) { result, attemptCount in
 
             // then the operation should return the error
-            XCTAssertEqual(result, .failure(retriable: true))
+            XCTAssertEqual(result, .failure)
             XCTAssertEqual(attemptCount, 2)
 
             expectation.fulfill()

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
@@ -1,0 +1,486 @@
+//
+//  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
+//
+
+import CoreData
+import TestSupport
+import XCTest
+
+@testable import EmbraceUploadInternal
+
+// MARK: - Helper to create a module with custom options
+
+private func makeModule(
+    testName: String,
+    automaticRetryCount: Int = 0,
+    queueLimit: Int = 10
+) throws -> (EmbraceUpload, DispatchQueue) {
+
+    let urlSessionConfig = URLSessionConfiguration.ephemeral
+    urlSessionConfig.httpMaximumConnectionsPerHost = .max
+    urlSessionConfig.protocolClasses = [EmbraceHTTPMock.self]
+
+    let metadata = EmbraceUpload.MetadataOptions(
+        apiKey: "apiKey",
+        userAgent: "userAgent",
+        deviceId: "12345678"
+    )
+    let redundancy = EmbraceUpload.RedundancyOptions(
+        automaticRetryCount: automaticRetryCount,
+        queueLimit: queueLimit
+    )
+    let endpoints = EmbraceUpload.EndpointOptions(
+        spansURL: URL(string: "https://embrace.\(testName).com/upload/sessions")!,
+        logsURL: URL(string: "https://embrace.\(testName).com/upload/logs")!,
+        attachmentsURL: URL(string: "https://embrace.\(testName).com/upload/attachments")!
+    )
+    let options = EmbraceUpload.Options(
+        endpoints: endpoints,
+        cache: EmbraceUpload.CacheOptions(
+            storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false),
+        metadata: metadata,
+        redundancy: redundancy,
+        urlSessionConfiguration: urlSessionConfig
+    )
+
+    let queue = DispatchQueue(label: "com.test.embrace.queue.\(testName)")
+    let module = try EmbraceUpload(options: options, logger: MockLogger(), queue: queue)
+    return (module, queue)
+}
+
+// MARK: - Tests
+
+class EmbraceUploadOrderedDeliveryTests: XCTestCase {
+
+    // MARK: - 1. Ordering guarantee
+
+    func test_spansAreUploadedInInsertionOrder() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+        EmbraceHTTPMock.mock(url: spansUrl)
+
+        let count = 5
+        let completionExpectation = XCTestExpectation(description: "all completions")
+        completionExpectation.expectedFulfillmentCount = count
+
+        for i in 0..<count {
+            module.uploadSpans(id: "span-\(i)", data: TestConstants.data) { _ in
+                completionExpectation.fulfill()
+            }
+        }
+
+        wait(for: [completionExpectation], timeout: .defaultTimeout)
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+
+        // Verify requests arrived in order
+        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
+        XCTAssertEqual(requests.count, count)
+    }
+
+    func test_logsAreUploadedInInsertionOrder() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+        let logsUrl = URL(string: "https://embrace.\(testName).com/upload/logs")!
+        EmbraceHTTPMock.mock(url: logsUrl)
+
+        let count = 5
+        let completionExpectation = XCTestExpectation(description: "all completions")
+        completionExpectation.expectedFulfillmentCount = count
+
+        for i in 0..<count {
+            module.uploadLog(id: "log-\(i)", data: TestConstants.data) { _ in
+                completionExpectation.fulfill()
+            }
+        }
+
+        wait(for: [completionExpectation], timeout: .defaultTimeout)
+        module.queue.sync {}
+        module.logsQueue.waitUntilAllOperationsAreFinished()
+
+        let requests = EmbraceHTTPMock.requestsForUrl(logsUrl)
+        XCTAssertEqual(requests.count, count)
+    }
+
+    // MARK: - 2. Queue cap
+
+    func test_queueCapLimitsOperations() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let queueLimit = 2
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: queueLimit)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+        EmbraceHTTPMock.mock(url: spansUrl)
+
+        // Upload more records than queueLimit
+        let totalRecords = 5
+        let completionExpectation = XCTestExpectation(description: "all completions")
+        completionExpectation.expectedFulfillmentCount = totalRecords
+
+        for i in 0..<totalRecords {
+            module.uploadSpans(id: "span-\(i)", data: TestConstants.data) { _ in
+                completionExpectation.fulfill()
+            }
+        }
+
+        wait(for: [completionExpectation], timeout: .defaultTimeout)
+
+        // Wait for all operations to drain (fillQueue refills after each completion)
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+        // Allow any remaining fillQueue cycles to complete
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+
+        // All records should eventually be uploaded
+        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
+        XCTAssertEqual(requests.count, totalRecords)
+    }
+
+    // MARK: - 3. fillQueue excludes in-flight
+
+    func test_fillQueueDoesNotCreateDuplicates() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+        EmbraceHTTPMock.mock(url: spansUrl)
+
+        // Upload a single record
+        let expectation = XCTestExpectation()
+        module.uploadSpans(id: "span-1", data: TestConstants.data) { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .defaultTimeout)
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+
+        // Should have exactly 1 request — no duplicates
+        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
+        XCTAssertEqual(requests.count, 1)
+    }
+
+    // MARK: - 4. Immediate cache persistence
+
+    func test_completionFiresBeforeUploadCompletes() throws {
+        // Don't mock the URL — upload will fail, but we don't care about the upload
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+
+        let expectation = XCTestExpectation(description: "completion fires")
+
+        module.uploadSpans(id: "span-1", data: TestConstants.data) { result in
+            // Completion fires after cache write, before upload
+            switch result {
+            case .success:
+                // Verify record exists in cache at completion time
+                let record = module.cache.fetchUploadData(id: "span-1", type: .spans)
+                XCTAssertNotNil(record, "Record should exist in cache when completion fires")
+                expectation.fulfill()
+            default:
+                XCTFail("Upload should've succeeded (cache-first)")
+            }
+        }
+
+        wait(for: [expectation], timeout: .defaultTimeout)
+    }
+
+    // MARK: - 5. Unlimited retries
+
+    func test_unlimitedRetriesWithNegativeOne() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        // mock 500 error — retriable
+        EmbraceHTTPMock.mock(url: TestConstants.url, errorCode: 500)
+
+        let expectation = XCTestExpectation()
+
+        // retryCount: -1 means unlimited. We verify it retries at least 3 times.
+        var finalAttemptCount = 0
+        let operation = EmbraceUploadOperation(
+            urlSession: makeTestURLSession(),
+            queue: .main,
+            metadataOptions: EmbraceUpload.MetadataOptions(
+                apiKey: "apiKey", userAgent: "userAgent", deviceId: "12345678"),
+            endpoint: TestConstants.url,
+            identifier: "id",
+            data: Data(),
+            retryCount: -1,
+            exponentialBackoffBehavior: .withNoDelay(),
+            attemptCount: 0
+        ) { result, attemptCount in
+            finalAttemptCount = attemptCount
+            expectation.fulfill()
+        }
+
+        // Cancel after a short delay to stop the unlimited retries
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            operation.cancel()
+        }
+
+        operation.start()
+
+        wait(for: [expectation], timeout: .defaultTimeout)
+
+        // Should have retried multiple times before being cancelled
+        XCTAssertGreaterThan(finalAttemptCount, 1, "Operation should have retried multiple times")
+    }
+
+    // MARK: - 6. Finite retries exhausted → delete
+
+    func test_finiteRetriesExhaustedDeletesFromCache() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 2, queueLimit: 10)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+
+        // Mock 500 so every attempt fails
+        EmbraceHTTPMock.mock(url: spansUrl, errorCode: 500)
+
+        let expectation = XCTestExpectation(description: "completion")
+        module.uploadSpans(id: "span-1", data: TestConstants.data) { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .defaultTimeout)
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+        module.queue.sync {}
+
+        // Record should be deleted from cache after retries exhausted
+        let record = module.cache.fetchUploadData(id: "span-1", type: .spans)
+        XCTAssertNil(record, "Record should be deleted after retries exhausted")
+
+        // Total attempts: 1 initial + 2 retries = 3
+        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
+        XCTAssertEqual(requests.count, 3)
+    }
+
+    // MARK: - 7. Non-retriable URLError (.badURL)
+
+    func test_nonRetriableErrorDeletesImmediately() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        EmbraceHTTPMock.mock(
+            url: TestConstants.url,
+            response: .withError(
+                NSError(
+                    domain: NSURLErrorDomain,
+                    code: URLError.badURL.rawValue,
+                    userInfo: [:]
+                )
+            )
+        )
+
+        let expectation = XCTestExpectation()
+
+        let operation = EmbraceUploadOperation(
+            urlSession: makeTestURLSession(),
+            queue: .main,
+            metadataOptions: EmbraceUpload.MetadataOptions(
+                apiKey: "apiKey", userAgent: "userAgent", deviceId: "12345678"),
+            endpoint: TestConstants.url,
+            identifier: "id",
+            data: Data(),
+            retryCount: 100,
+            exponentialBackoffBehavior: .withNoDelay(),
+            attemptCount: 0
+        ) { result, attemptCount in
+            XCTAssertEqual(result, .failure)
+            XCTAssertEqual(attemptCount, 1, "Should not retry non-retriable errors")
+            expectation.fulfill()
+        }
+
+        operation.start()
+        wait(for: [expectation], timeout: .defaultTimeout)
+    }
+
+    // MARK: - 8. 4xx is now retriable
+
+    func test_404IsRetriable() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        // Mock a 404 response
+        EmbraceHTTPMock.mock(url: TestConstants.url, response: .withData(Data(), statusCode: 404))
+
+        let expectation = XCTestExpectation()
+
+        let operation = EmbraceUploadOperation(
+            urlSession: makeTestURLSession(),
+            queue: .main,
+            metadataOptions: EmbraceUpload.MetadataOptions(
+                apiKey: "apiKey", userAgent: "userAgent", deviceId: "12345678"),
+            endpoint: TestConstants.url,
+            identifier: "id",
+            data: Data(),
+            retryCount: 1,
+            exponentialBackoffBehavior: .withNoDelay(),
+            attemptCount: 0
+        ) { result, attemptCount in
+            XCTAssertEqual(result, .failure)
+            // 1 initial + 1 retry = 2 total attempts
+            XCTAssertEqual(attemptCount, 2, "404 should be retried")
+            expectation.fulfill()
+        }
+
+        operation.start()
+        wait(for: [expectation], timeout: .defaultTimeout)
+    }
+
+    // MARK: - 9. Cancel keeps record
+
+    func test_cancelKeepsRecordInCache() throws {
+        // Use unlimited retries so the operation is still running when we cancel
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: -1, queueLimit: 10)
+
+        // Upload data to cache it — no mock URL so every attempt fails and retries
+        let expectation = XCTestExpectation(description: "completion")
+        module.uploadSpans(id: "span-1", data: TestConstants.data) { _ in
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: .defaultTimeout)
+
+        // Ensure the operation has been enqueued
+        module.queue.sync {}
+
+        // Cancel all operations while they're still retrying
+        module.spansQueue.cancelAllOperations()
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+
+        // Allow handleOperationFinished to process on coordination queue
+        module.queue.sync {}
+
+        // Cancelled operations should keep the record in cache
+        let record = module.cache.fetchUploadData(id: "span-1", type: .spans)
+        XCTAssertNotNil(record, "Cancelled operation should preserve cache record")
+    }
+
+    // MARK: - 10. retryCachedData ordering
+
+    func test_retryCachedDataUploadsInDateOrder() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+        EmbraceHTTPMock.mock(url: spansUrl)
+
+        // Pre-populate cache with records at different dates
+        let now = Date()
+        _ = UploadDataRecord.create(
+            context: module.cache.coreData.context,
+            id: "oldest",
+            type: EmbraceUploadType.spans.rawValue,
+            data: TestConstants.data,
+            payloadTypes: nil,
+            date: Date(timeInterval: -300, since: now)
+        )
+        _ = UploadDataRecord.create(
+            context: module.cache.coreData.context,
+            id: "middle",
+            type: EmbraceUploadType.spans.rawValue,
+            data: TestConstants.data,
+            payloadTypes: nil,
+            date: Date(timeInterval: -200, since: now)
+        )
+        _ = UploadDataRecord.create(
+            context: module.cache.coreData.context,
+            id: "newest",
+            type: EmbraceUploadType.spans.rawValue,
+            data: TestConstants.data,
+            payloadTypes: nil,
+            date: Date(timeInterval: -100, since: now)
+        )
+        module.cache.coreData.save()
+
+        let retryExpectation = XCTestExpectation(description: "retryCachedData completes")
+        module.retryCachedData {
+            retryExpectation.fulfill()
+        }
+        wait(for: [retryExpectation], timeout: .defaultTimeout)
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+
+        // All 3 records should be uploaded
+        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
+        XCTAssertEqual(requests.count, 3)
+    }
+
+    // MARK: - 11. retryCachedData + live uploads
+
+    func test_retryCachedDataThenLiveUpload() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+        EmbraceHTTPMock.mock(url: spansUrl)
+
+        // Pre-populate cache with a record
+        _ = module.cache.saveUploadData(id: "cached-1", type: .spans, data: TestConstants.data)
+
+        // Retry cached data
+        let retryExpectation = XCTestExpectation(description: "retryCachedData completes")
+        module.retryCachedData {
+            retryExpectation.fulfill()
+        }
+        wait(for: [retryExpectation], timeout: .defaultTimeout)
+
+        // Immediately upload a new record
+        let expectation = XCTestExpectation(description: "live upload completion")
+        module.uploadSpans(id: "live-1", data: TestConstants.data) { _ in
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: .defaultTimeout)
+
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+
+        // Both should be uploaded
+        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
+        XCTAssertEqual(requests.count, 2)
+    }
+
+    // MARK: - 12. Cross-type independence
+
+    func test_crossTypeIndependence() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS())
+
+        let (module, _) = try makeModule(testName: testName, automaticRetryCount: 0, queueLimit: 10)
+        let spansUrl = URL(string: "https://embrace.\(testName).com/upload/sessions")!
+        let logsUrl = URL(string: "https://embrace.\(testName).com/upload/logs")!
+        EmbraceHTTPMock.mock(url: spansUrl)
+        EmbraceHTTPMock.mock(url: logsUrl)
+
+        let expectation = XCTestExpectation(description: "all completions")
+        expectation.expectedFulfillmentCount = 2
+
+        // Upload a span and a log simultaneously
+        module.uploadSpans(id: "span-1", data: TestConstants.data) { _ in
+            expectation.fulfill()
+        }
+        module.uploadLog(id: "log-1", data: TestConstants.data) { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: .defaultTimeout)
+        module.queue.sync {}
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+        module.logsQueue.waitUntilAllOperationsAreFinished()
+
+        // Both types should have been uploaded independently
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(spansUrl).count, 1)
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(logsUrl).count, 1)
+    }
+}
+
+// MARK: - Helpers
+
+extension EmbraceUploadOrderedDeliveryTests {
+    private func makeTestURLSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.httpMaximumConnectionsPerHost = .max
+        config.protocolClasses = [EmbraceHTTPMock.self]
+        return URLSession(configuration: config)
+    }
+}

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
@@ -66,7 +66,8 @@ class EmbraceUploadOrderedDeliveryTests: XCTestCase {
         completionExpectation.expectedFulfillmentCount = count
 
         for i in 0..<count {
-            module.uploadSpans(id: "span-\(i)", data: TestConstants.data) { _ in
+            let data = "span-\(i)".data(using: .utf8)!
+            module.uploadSpans(id: "span-\(i)", data: data) { _ in
                 completionExpectation.fulfill()
             }
         }
@@ -78,6 +79,12 @@ class EmbraceUploadOrderedDeliveryTests: XCTestCase {
         // Verify requests arrived in order
         let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
         XCTAssertEqual(requests.count, count)
+        let bodies = EmbraceHTTPMock.requestBodiesForUrl(spansUrl)
+        XCTAssertEqual(bodies.count, count)
+        for i in 0..<count {
+            let expected = "span-\(i)".data(using: .utf8)!
+            XCTAssertEqual(bodies[i], expected, "span request \(i) out of order")
+        }
     }
 
     func test_logsAreUploadedInInsertionOrder() throws {
@@ -92,7 +99,8 @@ class EmbraceUploadOrderedDeliveryTests: XCTestCase {
         completionExpectation.expectedFulfillmentCount = count
 
         for i in 0..<count {
-            module.uploadLog(id: "log-\(i)", data: TestConstants.data) { _ in
+            let data = "log-\(i)".data(using: .utf8)!
+            module.uploadLog(id: "log-\(i)", data: data) { _ in
                 completionExpectation.fulfill()
             }
         }
@@ -103,6 +111,12 @@ class EmbraceUploadOrderedDeliveryTests: XCTestCase {
 
         let requests = EmbraceHTTPMock.requestsForUrl(logsUrl)
         XCTAssertEqual(requests.count, count)
+        let bodies = EmbraceHTTPMock.requestBodiesForUrl(logsUrl)
+        XCTAssertEqual(bodies.count, count)
+        for i in 0..<count {
+            let expected = "log-\(i)".data(using: .utf8)!
+            XCTAssertEqual(bodies[i], expected, "log request \(i) out of order")
+        }
     }
 
     // MARK: - 2. Queue cap

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -40,7 +40,9 @@ class EmbraceUploadTests: XCTestCase {
 
     override func tearDownWithError() throws {
         // prevents inconsistent errors due to the cache database being forcefully deleted on each test
-        module.operationQueue.waitUntilAllOperationsAreFinished()
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+        module.logsQueue.waitUntilAllOperationsAreFinished()
+        module.attachmentsQueue.waitUntilAllOperationsAreFinished()
     }
 
     func test_invalidId() throws {
@@ -147,12 +149,17 @@ class EmbraceUploadTests: XCTestCase {
         // the observability on the database seems to be inconsistent timing wise
         // so the first 2 steps are not always in the same order
         wait(for: [expectation1, expectation2, expectation3], timeout: .veryLongTimeout)
+
+        // Clean up listener to prevent callbacks from firing during subsequent tests
+        listener.onInsertedObjects = nil
+        listener.onDeletedObjects = nil
     }
 
     func test_cacheFlowOnError() throws {
-        // given valid values
+        // given valid values (no mock URL, so upload will fail)
         let expectation1 = XCTestExpectation(description: "1. Data should be cached in the database")
-        let expectation2 = XCTestExpectation(description: "2. Sucess completion callback should be called")
+        let expectation2 = XCTestExpectation(description: "2. Success completion callback should be called")
+        let expectation3 = XCTestExpectation(description: "3. Cache should be removed after failed upload")
 
         // then the data should be cached
         let listener = CoreDataListener()
@@ -168,7 +175,12 @@ class EmbraceUploadTests: XCTestCase {
             expectation1.fulfill()
         }
 
+        listener.onDeletedObjects = { _ in
+            expectation3.fulfill()
+        }
+
         // when uploading data
+        // completion fires immediately after cache write (cache-first semantics)
         module.uploadSpans(id: "id", data: TestConstants.data) { result in
             switch result {
             case .success:
@@ -179,14 +191,15 @@ class EmbraceUploadTests: XCTestCase {
             }
         }
 
-        wait(for: [expectation1, expectation2], timeout: .veryLongTimeout)
+        // With retryCount: 0, the failed upload operation deletes the record from cache
+        wait(for: [expectation1, expectation2, expectation3], timeout: .veryLongTimeout)
 
-        // the ndata should remain cached
-        let record = module.cache.fetchUploadData(id: "id", type: .spans)
-        XCTAssertNotNil(record)
+        // Clean up listener to prevent callbacks from firing during subsequent tests
+        listener.onInsertedObjects = nil
+        listener.onDeletedObjects = nil
     }
 
-    func test_retryCachedData() async throws {
+    func test_retryCachedData() throws {
         try XCTSkipIf(XCTestCase.isWatchOS())
 
         // given cached data
@@ -197,7 +210,15 @@ class EmbraceUploadTests: XCTestCase {
         EmbraceHTTPMock.mock(url: testLogsUrl())
 
         // when retrying to upload all cached data
-        await module.retryCachedData()
+        let retryExpectation = XCTestExpectation(description: "retryCachedData completes")
+        module.retryCachedData {
+            retryExpectation.fulfill()
+        }
+        wait(for: [retryExpectation], timeout: .defaultTimeout)
+
+        // wait for upload operations to complete
+        module.spansQueue.waitUntilAllOperationsAreFinished()
+        module.logsQueue.waitUntilAllOperationsAreFinished()
 
         // then requests are made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
@@ -205,11 +226,15 @@ class EmbraceUploadTests: XCTestCase {
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testAttachmentsUrl()).count, 0)
     }
 
-    func test_retryCachedData_emptyCache() async throws {
+    func test_retryCachedData_emptyCache() throws {
         // given an empty cache
 
         // when retrying to upload all cached data
-        await module.retryCachedData()
+        let retryExpectation = XCTestExpectation(description: "retryCachedData completes")
+        module.retryCachedData {
+            retryExpectation.fulfill()
+        }
+        wait(for: [retryExpectation], timeout: .defaultTimeout)
 
         // then no requests are made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
@@ -220,12 +245,19 @@ class EmbraceUploadTests: XCTestCase {
     func test_spansEndpoint() throws {
         try XCTSkipIf(XCTestCase.isWatchOS())
 
+        EmbraceHTTPMock.mock(url: testSpansUrl())
+
         // when uploading session data
         let expectation = XCTestExpectation()
         module.uploadSpans(id: "id", data: TestConstants.data) { _ in
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: .defaultTimeout)
+
+        // ensure fillQueue has completed on the coordination queue
+        module.queue.sync {}
+        // wait for the upload operation to complete
+        module.spansQueue.waitUntilAllOperationsAreFinished()
 
         // then a request to the right endpoint is made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
@@ -236,12 +268,19 @@ class EmbraceUploadTests: XCTestCase {
     func test_logsEndpoint() throws {
         try XCTSkipIf(XCTestCase.isWatchOS())
 
+        EmbraceHTTPMock.mock(url: testLogsUrl())
+
         // when uploading log data
         let expectation = XCTestExpectation()
         module.uploadLog(id: "id", data: TestConstants.data) { _ in
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: .defaultTimeout)
+
+        // ensure fillQueue has completed on the coordination queue
+        module.queue.sync {}
+        // wait for the upload operation to complete
+        module.logsQueue.waitUntilAllOperationsAreFinished()
 
         // then a request to the right endpoint is made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
@@ -252,6 +291,8 @@ class EmbraceUploadTests: XCTestCase {
     func test_attachmentsEndpoint() throws {
         try XCTSkipIf(XCTestCase.isWatchOS())
 
+        EmbraceHTTPMock.mock(url: testAttachmentsUrl())
+
         // when uploading attachment data
         let expectation = XCTestExpectation()
         module.uploadAttachment(id: "id", data: TestConstants.data) { _ in
@@ -259,6 +300,11 @@ class EmbraceUploadTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: .defaultTimeout)
+
+        // ensure fillQueue has completed on the coordination queue
+        module.queue.sync {}
+        // wait for the upload operation to complete
+        module.attachmentsQueue.waitUntilAllOperationsAreFinished()
 
         // then a request to the right endpoint is made
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)

--- a/Tests/TestSupport/EmbraceHTTPMock.swift
+++ b/Tests/TestSupport/EmbraceHTTPMock.swift
@@ -31,6 +31,7 @@ public class EmbraceHTTPMock: URLProtocol {
 
     private static var mockedResponses = [String: MockResponse]()
     private static var requests = [String: [URLRequest]]()
+    private static var requestBodies = [String: [Data]]()
 
     /// Adds a mocked response for a given url
     public class func mock(
@@ -85,6 +86,12 @@ public class EmbraceHTTPMock: URLProtocol {
         return requests[createKey(fromURL: url)] ?? []
     }
 
+    /// Returns the captured request bodies for a given url, in order.
+    /// URLProtocol strips httpBody from captured requests, so bodies are read from httpBodyStream at capture time.
+    public class func requestBodiesForUrl(_ url: URL) -> [Data] {
+        return requestBodies[createKey(fromURL: url)] ?? []
+    }
+
     /// Returns the total amount of requests that were executed.
     public class func totalRequestCount(_ testName: String = #function) -> Int {
         return
@@ -96,6 +103,7 @@ public class EmbraceHTTPMock: URLProtocol {
 
     public class func clearRequests() {
         requests.removeAll()
+        requestBodies.removeAll()
     }
 
     // MARK: - Internal
@@ -114,6 +122,26 @@ public class EmbraceHTTPMock: URLProtocol {
                 EmbraceHTTPMock.requests[key] = []
             }
             EmbraceHTTPMock.requests[key]?.append(request)
+
+            if EmbraceHTTPMock.requestBodies[key] == nil {
+                EmbraceHTTPMock.requestBodies[key] = []
+            }
+            if let body = request.httpBody {
+                EmbraceHTTPMock.requestBodies[key]?.append(body)
+            } else if let stream = request.httpBodyStream {
+                stream.open()
+                var data = Data()
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+                while stream.hasBytesAvailable {
+                    let read = stream.read(buffer, maxLength: 1024)
+                    if read > 0 {
+                        data.append(buffer, count: read)
+                    }
+                }
+                buffer.deallocate()
+                stream.close()
+                EmbraceHTTPMock.requestBodies[key]?.append(data)
+            }
 
             if let response = EmbraceHTTPMock.mockedResponses[key] {
                 if let data = response.data {


### PR DESCRIPTION
Redesigns the EmbraceUploadInternal module to deliver spans and logs in order, with a cache-first architecture that guarantees data durability before signaling success to callers.

## Architecture

* **Coordination queue** — A single serial DispatchQueue serializes all state: cache reads/writes, in-flight tracking, and queue-fill decisions. It never executes network requests.

* **Three upload queues** — spansQueue and logsQueue are serial OperationQueues (one operation at a time, dependency-chained) guaranteeing ordered delivery. attachmentsQueue is concurrent (no ordering constraint).

* **Cache-first flow** — Every upload call follows the same path:
   1. Dispatch onto the coordination queue
   2. Validate input, write to CoreData cache
   3. Fire the completion callback (data is durable at this point)
   4. Call fillQueue to create upload operations from cached records

* **fillQueue** is the single mechanism for creating upload operations. It checks queue capacity against queueLimit, fetches cached records sorted by date (excluding in-flight IDs), chains dependencies for ordered types, and  
  enqueues. It runs after every cache write and after every operation completion, draining the cache as capacity opens up.

* **Operation lifecycle** — On success or failure, the record is deleted from cache. On cancellation, the record is preserved for replay on the next process launch via retryCachedData().                                        
                                   
## Key changes
- Ordered delivery for spans and logs via serial queues with dependency chaining                                                
- Cache-first: completion fires after cache write, not after upload
- Retry semantics: unlimited retries by default (automaticRetryCount: -1), 250ms exponential backoff, only .badURL/.unsupportedURL are non-retriable (all 4xx/5xx are retried)
- Queue capacity: queueLimit caps in-flight operations per type; overflow stays in cache                                        
- Removed attemptCount from CoreData entity and maximumAmountOfRetries from options                                             
- Fixed AsyncOperation.cancel() not calling finish() (operation lifecycle bug)