### PR TITLE
[EMBR-11729] Fix: urlsession delegate crash

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.h
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EMBURLSessionLegacyDelegateProxy : NSProxy <EMBURLSessionDelegateProxy>
 
-@property(nonatomic, strong, nullable) id originalDelegate;
+@property(atomic, strong, nullable) id originalDelegate;
 @property(nonatomic, weak, nullable) id<NSURLSessionDelegate> swizzledDelegate;
 @property(nonatomic, strong, nullable) id<URLSessionTaskHandler> handler;
 

--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -15,6 +15,7 @@
 #define DID_RECEIVE_RESPONSE @selector(URLSession:dataTask:didReceiveResponse:completionHandler:)
 #define WILL_PERFORM_REDIRECTION @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)
 #define DID_RECEIVE_CHALLENGE @selector(URLSession:didReceiveChallenge:completionHandler:)
+#define DID_RECEIVE_TASK_CHALLENGE @selector(URLSession:task:didReceiveChallenge:completionHandler:)
 
 @interface EMBURLSessionLegacyDelegateProxy ()
 
@@ -36,7 +37,7 @@
     if (sel_isEqual(aSelector, DID_FINISH_COLLECTING_METRICS) || sel_isEqual(aSelector, DID_RECEIVE_DATA_SELECTOR) ||
         sel_isEqual(aSelector, DID_FINISH_DOWNLOADING) || sel_isEqual(aSelector, DID_COMPLETE_WITH_ERROR) ||
         sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION) ||
-        sel_isEqual(aSelector, DID_RECEIVE_CHALLENGE)) {
+        sel_isEqual(aSelector, DID_RECEIVE_CHALLENGE) || sel_isEqual(aSelector, DID_RECEIVE_TASK_CHALLENGE)) {
         return YES;
     }
     return [self.originalDelegate respondsToSelector:aSelector];
@@ -118,6 +119,22 @@
         [(id<NSURLSessionDelegate>)delegate URLSession:session
                                    didReceiveChallenge:challenge
                                     completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
+                                                     task:task
+                                      didReceiveChallenge:challenge
+                                       completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }

--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -14,6 +14,7 @@
 #define DID_BECOME_INVALID_WITH_ERROR @selector(URLSession:didBecomeInvalidWithError:)
 #define DID_RECEIVE_RESPONSE @selector(URLSession:dataTask:didReceiveResponse:completionHandler:)
 #define WILL_PERFORM_REDIRECTION @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)
+#define DID_RECEIVE_CHALLENGE @selector(URLSession:didReceiveChallenge:completionHandler:)
 
 @interface EMBURLSessionLegacyDelegateProxy ()
 
@@ -34,7 +35,8 @@
 {
     if (sel_isEqual(aSelector, DID_FINISH_COLLECTING_METRICS) || sel_isEqual(aSelector, DID_RECEIVE_DATA_SELECTOR) ||
         sel_isEqual(aSelector, DID_FINISH_DOWNLOADING) || sel_isEqual(aSelector, DID_COMPLETE_WITH_ERROR) ||
-        sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION)) {
+        sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION) ||
+        sel_isEqual(aSelector, DID_RECEIVE_CHALLENGE)) {
         return YES;
     }
     return [self.originalDelegate respondsToSelector:aSelector];
@@ -42,7 +44,10 @@
 
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
-    return self.originalDelegate;
+    if (self.originalDelegate && [self.originalDelegate respondsToSelector:aSelector]) {
+        return self.originalDelegate;
+    }
+    return nil;
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)selector
@@ -99,9 +104,23 @@
     if ([self.originalDelegate respondsToSelector:@selector(URLSession:didBecomeInvalidWithError:)]) {
         [self.originalDelegate URLSession:session didBecomeInvalidWithError:error];
     }
-    
+
     self.originalDelegate = nil;
     self.handler = nil;
+}
+
+- (void)URLSession:(NSURLSession *)session
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionDelegate>)delegate URLSession:session
+                                   didReceiveChallenge:challenge
+                                    completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
 }
 
 #pragma mark - NSURLSessionTaskDelegate Methods

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.h
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EMBURLSessionNewDelegateProxy : NSObject <EMBURLSessionDelegateProxy>
 
-@property(nonatomic, strong, nullable) id originalDelegate;
+@property(atomic, strong, nullable) id originalDelegate;
 @property(nonatomic, weak, nullable) id<NSURLSessionDelegate> swizzledDelegate;
 @property(nonatomic, strong, nullable) id<URLSessionTaskHandler> handler;
 

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -51,7 +51,8 @@
         sel == @selector(URLSession:task:didFinishCollectingMetrics:) ||
         sel == @selector(URLSession:dataTask:didReceiveData:) ||
         sel == @selector(URLSession:didBecomeInvalidWithError:) ||
-        sel == @selector(URLSession:didReceiveChallenge:completionHandler:)) {
+        sel == @selector(URLSession:didReceiveChallenge:completionHandler:) ||
+        sel == @selector(URLSession:task:didReceiveChallenge:completionHandler:)) {
 
         return nil;
     }
@@ -101,6 +102,22 @@
         [(id<NSURLSessionDelegate>)delegate URLSession:session
                                    didReceiveChallenge:challenge
                                     completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+ completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
+                                                     task:task
+                                      didReceiveChallenge:challenge
+                                       completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -50,7 +50,8 @@
     if (sel == @selector(URLSession:task:didCompleteWithError:) ||
         sel == @selector(URLSession:task:didFinishCollectingMetrics:) ||
         sel == @selector(URLSession:dataTask:didReceiveData:) ||
-        sel == @selector(URLSession:didBecomeInvalidWithError:)) {
+        sel == @selector(URLSession:didBecomeInvalidWithError:) ||
+        sel == @selector(URLSession:didReceiveChallenge:completionHandler:)) {
 
         return nil;
     }
@@ -89,6 +90,20 @@
     }
     self.originalDelegate = nil;
     self.handler = nil;
+}
+
+- (void)URLSession:(NSURLSession *)session
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionDelegate>)delegate URLSession:session
+                                   didReceiveChallenge:challenge
+                                    completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    }
 }
 
 #pragma mark - NSURLSessionTaskDelegate

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -52,7 +52,10 @@
         sel == @selector(URLSession:dataTask:didReceiveData:) ||
         sel == @selector(URLSession:didBecomeInvalidWithError:) ||
         sel == @selector(URLSession:didReceiveChallenge:completionHandler:) ||
-        sel == @selector(URLSession:task:didReceiveChallenge:completionHandler:)) {
+        sel == @selector(URLSession:task:didReceiveChallenge:completionHandler:) ||
+        sel == @selector(URLSession:dataTask:didReceiveResponse:completionHandler:) ||
+        sel == @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:) ||
+        sel == @selector(URLSession:downloadTask:didFinishDownloadingToURL:)) {
 
         return nil;
     }
@@ -151,6 +154,26 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 }
 
+#pragma mark - NSURLSessionTaskDelegate (redirection)
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+        newRequest:(NSURLRequest *)request
+ completionHandler:(void (^)(NSURLRequest *))completionHandler
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
+                                                     task:task
+                               willPerformHTTPRedirection:response
+                                               newRequest:request
+                                        completionHandler:completionHandler];
+    } else {
+        completionHandler(request);  // follow the redirect — URLSession's built-in default
+    }
+}
+
 #pragma mark - NSURLSessionDataDelegate
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
@@ -159,6 +182,36 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 
     if ([self.originalDelegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionDataDelegate>)self.originalDelegate URLSession:session dataTask:dataTask didReceiveData:data];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+didReceiveResponse:(NSURLResponse *)response
+ completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionDataDelegate>)delegate URLSession:session
+                                                 dataTask:dataTask
+                                       didReceiveResponse:response
+                                        completionHandler:completionHandler];
+    } else {
+        completionHandler(NSURLSessionResponseAllow);
+    }
+}
+
+#pragma mark - NSURLSessionDownloadDelegate
+
+- (void)URLSession:(NSURLSession *)session
+      downloadTask:(NSURLSessionDownloadTask *)downloadTask
+didFinishDownloadingToURL:(NSURL *)location
+{
+    id delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:_cmd]) {
+        [(id<NSURLSessionDownloadDelegate>)delegate URLSession:session
+                                                 downloadTask:downloadTask
+                                    didFinishDownloadingToURL:location];
     }
 }
 


### PR DESCRIPTION
Fixes crashes on URLSession caused by missing proxy methods and property atomicity after explicitly nulling it on 6.17.0
