### PR TITLE
fix: Removing unit test since TapCaptureService is only available in some platforms

### DIFF
--- a/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
@@ -340,6 +340,7 @@ class CaptureServicesOptionsBuilderTests: XCTestCase {
         XCTAssertEqual((options.customServices[0] as! FakeCaptureService).testValue, 9999)
     }
 
+#if canImport(UIKit) && !os(watchOS)
     func test_customService_embraceType() throws {
         // given a builder with default services
         let builder = CaptureServicesOptionsBuilder()
@@ -354,6 +355,7 @@ class CaptureServicesOptionsBuilderTests: XCTestCase {
         XCTAssertEqual(options.customServices.count, 1)
         XCTAssertTrue(options.customServices[0] is TapCaptureService)
     }
+#endif
 }
 
 class FakeCaptureService: CaptureService {


### PR DESCRIPTION
Removing unit test since TapCaptureService is only available in some platforms

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
