### PR TITLE
[EMBR-12039] Feature: Removing OSLogStore usage to generate critical logs file

### DIFF
--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -104,7 +104,10 @@ import OpenTelemetrySdk
     private static let _syncLock = ReadWriteLock()
     static let notificationCenter: NotificationCenter = NotificationCenter()
 
-    static var logger: DefaultInternalLogger = DefaultInternalLogger(exportFilePath: EmbraceFileSystem.criticalLogsURL)
+    static var logger: DefaultInternalLogger = DefaultInternalLogger(
+        pendingFilePath: EmbraceFileSystem.pendingLogsURL,
+        criticalFilePath: EmbraceFileSystem.criticalLogsURL
+    )
 
     /// Method used to configure the Embrace SDK.
     /// - Parameter options: `Embrace.Options` to be used by the SDK.
@@ -186,8 +189,12 @@ import OpenTelemetrySdk
         // initialize upload module
         self.upload = try Embrace.createUpload(options: options, deviceId: deviceId.stringValue, configuration: config.configurable)
 
-        // send critical logs from previous session
-        UnsentDataHandler.sendCriticalLogs(fileUrl: EmbraceFileSystem.criticalLogsURL, upload: upload)
+        // send critical logs from previous session, and clean up any orphan pending-logs file
+        UnsentDataHandler.sendCriticalLogs(
+            fileUrl: EmbraceFileSystem.criticalLogsURL,
+            pendingFileUrl: EmbraceFileSystem.pendingLogsURL,
+            upload: upload
+        )
 
         // initialize storage module
         self.storage = try embraceStorage ?? Embrace.createStorage(options: options, configuration: config.configurable)

--- a/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
+++ b/Sources/EmbraceCore/FileSystem/EmbraceFileSystem.swift
@@ -15,6 +15,7 @@ public struct EmbraceFileSystem {
     static let configDirectoryName = "config"
     static let deviceIdName = "device-identifier"
     static let criticalLogsName = "critical-logs"
+    static let pendingLogsName = "pending-logs"
 
     static let defaultPartitionId = "default"
 
@@ -136,6 +137,16 @@ public struct EmbraceFileSystem {
     /// ```
     static var criticalLogsURL: URL? {
         rootURL()?.appendingPathComponent(criticalLogsName)
+    }
+
+    /// Returns the fileURL for the pending logs staging file.
+    /// Holds startup-level lines until a `.critical` is logged, at which point
+    /// the file is promoted (renamed) to `criticalLogsURL`.
+    /// ```
+    /// io.embrace.data/pending-logs
+    /// ```
+    static var pendingLogsURL: URL? {
+        rootURL()?.appendingPathComponent(pendingLogsName)
     }
 
     /// Returns the possible subdirectories for data from old version that can be safely removed

--- a/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
@@ -96,7 +96,6 @@ class DefaultInternalLogger: BaseInternalLogger {
             let fd = state.fileDescriptor
             guard fd >= 0 else { return }
 
-  
             let available = customExportByteCountLimit - state.bytesWritten
             if available <= 0 {
                 state.limitReached = true
@@ -104,7 +103,7 @@ class DefaultInternalLogger: BaseInternalLogger {
             }
             let chunk = data.prefix(available)
 
-            let written = data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Int in
+            let written = chunk.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Int in
                 guard let base = buffer.baseAddress else { return -1 }
                 return write(fd, base, buffer.count)
             }
@@ -115,6 +114,10 @@ class DefaultInternalLogger: BaseInternalLogger {
             }
 
             state.bytesWritten += written
+            if chunk.count < data.count {
+                // we just wrote up to the cap; further writes are no-ops
+                state.limitReached = true
+            }
 
             if level == .critical {
                 _ = fsync(fd)

--- a/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
@@ -2,6 +2,7 @@
 //  Copyright © 2024 Embrace Mobile, Inc. All rights reserved.
 //
 
+import Darwin
 import Foundation
 import OSLog
 
@@ -13,132 +14,172 @@ import OSLog
     import EmbraceConfiguration
 #endif
 
+/// Internal logger that writes `.startup` and `.critical` lines straight to disk so a
+/// previous run's critical context can be uploaded on the next launch.
+///
+/// File layout uses two paths under `EmbraceFileSystem.rootURL()`:
+///   - `pending-logs`  — staging file. Receives `.startup` lines.
+///   - `critical-logs` — upload file. Created by renaming `pending-logs` the first time
+///                       a `.critical` is logged. All subsequent custom-export lines
+///                       append here.
+///
+/// On next launch, `UnsentDataHandler.sendCriticalLogs` uploads `critical-logs` and
+/// deletes any orphan `pending-logs`. If no `.critical` ever fired, no file is uploaded.
+///
+/// Writes use POSIX `open`/`write`/`fsync`/`close` directly instead of `FileHandle`.
+/// POSIX returns error codes; `FileHandle`'s legacy API raises `NSException` on failure,
+/// which Swift `try/catch` cannot intercept and historically tripped a recursive crash
+/// path under memory pressure.
 class DefaultInternalLogger: BaseInternalLogger {
 
     let subsystem: String = "com.embrace.logger"
-    let defaultCategory: String = "internal"
-    let customExportCategory: String
+    let category: String = "internal"
     let customExportByteCountLimit: Int
 
-    let exportFilePath: URL?
-    let defaultLogger: OSLog
-    let customExportLogger: OSLog
+    let pendingFilePath: URL?
+    let criticalFilePath: URL?
 
-    private var exporting: Bool = false
-    private var exportByteCount: Int = 0
-    private var exportLimitReached: Bool = false
-    private var lastExportDate: Date?
+    let osLogger: OSLog
 
-    internal let queue: DispatchableQueue
+    private struct State {
+        var fileDescriptor: Int32 = -1
+        var criticalFired: Bool = false
+        var bytesWritten: Int = 0
+        var limitReached: Bool = false
+    }
 
-    init(exportFilePath: URL?, exportByCountLimit: Int = 1000, exportCategory: String = "custom-export") {
-        self.exportFilePath = exportFilePath
+    private let state = EmbraceMutex(State())
+
+    init(
+        pendingFilePath: URL?,
+        criticalFilePath: URL?,
+        exportByCountLimit: Int = 1000
+    ) {
+        self.pendingFilePath = pendingFilePath
+        self.criticalFilePath = criticalFilePath
         self.customExportByteCountLimit = exportByCountLimit
-        self.customExportCategory = exportCategory
 
-        defaultLogger = OSLog(subsystem: subsystem, category: defaultCategory)
-        customExportLogger = OSLog(subsystem: subsystem, category: customExportCategory)
-
-        queue = .with(label: "com.embrace.logger.export")
+        osLogger = OSLog(subsystem: subsystem, category: category)
 
         super.init()
     }
 
+    deinit {
+        let fd = state.unsafeValue.fileDescriptor
+        if fd >= 0 {
+            close(fd)
+        }
+    }
+
     override func output(_ message: String, level: LogLevel, customExport: Bool) {
 
-        if customExport {
-            os_log(level.osLogType, log: customExportLogger, "%{public}@", message)
-        } else {
-            os_log(level.osLogType, log: defaultLogger, "%{public}@", message)
-        }
+        os_log(level.osLogType, log: osLogger, "%{public}@", message)
 
-        if #available(iOS 15.0, tvOS 15.0, macOS 10, watchOS 8.0, *) {
+        guard customExport else { return }
+
+        let line = "[\(Self.timestampFormatter.string(from: Date()))] \(message)\n"
+        guard let data = line.data(using: .utf8) else { return }
+
+        state.withLock { state in
+            guard !state.limitReached else { return }
+
+            if level == .critical && !state.criticalFired {
+                promote(state: &state)
+            }
+
+            if state.fileDescriptor < 0 {
+                let target = state.criticalFired ? criticalFilePath : pendingFilePath
+                guard let url = target else { return }
+                openFile(at: url, state: &state)
+            }
+
+            let fd = state.fileDescriptor
+            guard fd >= 0 else { return }
+
+            guard state.bytesWritten + data.count <= customExportByteCountLimit else {
+                state.limitReached = true
+                return
+            }
+
+            let written = data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Int in
+                guard let base = buffer.baseAddress else { return -1 }
+                return write(fd, base, buffer.count)
+            }
+
+            if written < 0 {
+                print("Error writing critical logs file: errno \(errno)")
+                return
+            }
+
+            state.bytesWritten += written
+
             if level == .critical {
-                export()
+                _ = fsync(fd)
             }
         }
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 10, watchOS 8.0, *)
-    /// Exports all logs in the `custom-export` category to a file.
-    /// Subsequent calls append any new entries created since the last call into the file.
-    func export() {
-        queue.async { [weak self] in
-            guard let self else {
-                return
-            }
+    /// Promotes the staging file to the upload path and re-opens for append.
+    /// Must be called while holding the state lock.
+    private func promote(state: inout State) {
+        guard let criticalURL = criticalFilePath else {
+            // Without a critical URL we cannot promote; keep writing to pending if possible.
+            state.criticalFired = true
+            return
+        }
 
-            guard let fileURL = self.exportFilePath,
-                self.exporting == false,
-                self.exportLimitReached == false
-            else {
-                return
-            }
+        if state.fileDescriptor >= 0 {
+            close(state.fileDescriptor)
+            state.fileDescriptor = -1
+        }
 
-            self.exporting = true
-            defer { self.exporting = false }
+        // Defensive: a stale critical-logs from a prior run should already have been
+        // consumed at boot time. Remove it if it somehow still exists so the rename
+        // doesn't fail with "file exists".
+        try? FileManager.default.removeItem(at: criticalURL)
 
+        if let pendingURL = pendingFilePath,
+            FileManager.default.fileExists(atPath: pendingURL.path)
+        {
             do {
-                // create OSLogStore for the current process
-                let store = try OSLogStore(scope: .currentProcessIdentifier)
-
-                // calculate starting position so we only fetch logs we haven't exported yet
-                var position: OSLogPosition
-                if let lastExportDate = self.lastExportDate {
-                    position = store.position(date: lastExportDate.addingTimeInterval(0.01))
-                } else {
-                    position = store.position(timeIntervalSinceLatestBoot: 0)
-                }
-
-                // fetch log entries
-                let entries: [OSLogEntryLog] =
-                    try store
-                    .getEntries(at: position)
-                    .compactMap { $0 as? OSLogEntryLog }
-                    .filter { $0.subsystem == self.subsystem && $0.category == self.customExportCategory }
-
-                // create file if needed
-                if !FileManager.default.fileExists(atPath: fileURL.path) {
-                    let rootURL = fileURL.deletingLastPathComponent()
-                    try? FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-                    FileManager.default.createFile(atPath: fileURL.path, contents: nil)
-                }
-
-                guard let file = FileHandle(forWritingAtPath: fileURL.path) else {
-                    try? FileManager.default.removeItem(at: fileURL)
-                    return
-                }
-
-                try file.seekToEnd()
-
-                // write log lines
-                for entry in entries {
-                    let line = entry.formattedMessage + "\n"
-                    guard let data = line.data(using: .utf8) else {
-                        continue
-                    }
-
-                    // don't make the file too big
-                    guard self.exportByteCount + data.count <= self.customExportByteCountLimit else {
-                        self.exportLimitReached = true
-                        break
-                    }
-
-                    try file.write(contentsOf: data)
-                    self.exportByteCount += data.count
-                }
-
-                // save last entry date
-                self.lastExportDate = entries.last?.date
-
-                // close file
-                try file.close()
-
+                try FileManager.default.moveItem(at: pendingURL, to: criticalURL)
             } catch {
-                print("Error exporting internal logs!:\n\(error.localizedDescription)")
+                // Fall through: open critical-logs directly. We lose the prior startup
+                // trail, but still capture the .critical line that triggered promotion.
+                print("Error promoting pending logs to critical logs: \(error.localizedDescription)")
             }
         }
+
+        state.criticalFired = true
     }
+
+    /// Opens (creating if needed) the file at `url` for append and stores the file descriptor.
+    /// Must be called while holding the state lock.
+    private func openFile(at url: URL, state: inout State) {
+        let parent = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
+        let fd = url.path.withCString { path -> Int32 in
+            open(path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        }
+
+        guard fd >= 0 else {
+            print("Error opening critical logs file: errno \(errno)")
+            return
+        }
+
+        let endOffset = lseek(fd, 0, SEEK_END)
+        state.fileDescriptor = fd
+        state.bytesWritten = endOffset >= 0 ? Int(endOffset) : 0
+    }
+
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        return formatter
+    }()
 }
 
 extension LogLevel {
@@ -155,12 +196,5 @@ extension LogLevel {
         default:
             return OSLogType.default
         }
-    }
-}
-
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, *)
-extension OSLogEntryLog {
-    var formattedMessage: String {
-        "[\(date.formatted(date: .numeric, time: .complete))] \(composedMessage)"
     }
 }

--- a/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
+++ b/Sources/EmbraceCore/Internal/Logs/Loggers/DefaultInternalLogger.swift
@@ -96,10 +96,13 @@ class DefaultInternalLogger: BaseInternalLogger {
             let fd = state.fileDescriptor
             guard fd >= 0 else { return }
 
-            guard state.bytesWritten + data.count <= customExportByteCountLimit else {
+  
+            let available = customExportByteCountLimit - state.bytesWritten
+            if available <= 0 {
                 state.limitReached = true
                 return
             }
+            let chunk = data.prefix(available)
 
             let written = data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Int in
                 guard let base = buffer.baseAddress else { return -1 }

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -375,11 +375,16 @@ class UnsentDataHandler {
         storage.cleanMetadata()
     }
 
-    static func sendCriticalLogs(fileUrl: URL?, upload: EmbraceUpload?, completion: UnsentDataHandlerCompletion? = nil) {
-        // feature is only available on iOS 15+
-        if #unavailable(iOS 15.0, tvOS 15.0) {
-            completion?()
-            return
+    static func sendCriticalLogs(
+        fileUrl: URL?,
+        pendingFileUrl: URL? = nil,
+        upload: EmbraceUpload?,
+        completion: UnsentDataHandlerCompletion? = nil
+    ) {
+        // any pending-logs left over from a prior run that didn't fire a .critical
+        // is orphan staging data — by spec there's nothing to upload, just discard.
+        if let pendingFileUrl = pendingFileUrl {
+            try? FileManager.default.removeItem(at: pendingFileUrl)
         }
 
         guard let upload = upload,
@@ -450,9 +455,9 @@ extension UnsentDataHandler {
         }
     }
 
-    static func sendCriticalLogs(fileUrl: URL?, upload: EmbraceUpload?) async {
+    static func sendCriticalLogs(fileUrl: URL?, pendingFileUrl: URL? = nil, upload: EmbraceUpload?) async {
         await withCheckedContinuation { continuation in
-            sendCriticalLogs(fileUrl: fileUrl, upload: upload) {
+            sendCriticalLogs(fileUrl: fileUrl, pendingFileUrl: pendingFileUrl, upload: upload) {
                 continuation.resume()
             }
         }

--- a/Tests/EmbraceCoreTests/Internal/Logs/Loggers/DefaultInternalLoggerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/Loggers/DefaultInternalLoggerTests.swift
@@ -117,24 +117,75 @@ class DefaultInternalLoggerTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: pendingURL.path))
     }
 
-    /// Once the byte budget is exhausted, further writes are dropped — file size is bounded.
+    /// Once the byte budget is exhausted, the boundary line is truncated and further
+    /// writes become no-ops — file size is bounded by the limit.
     func test_byteCountLimit_capsFileSize() {
         // small limit: ~one short line max
         let logger = makeLogger(byteLimit: 80)
 
         logger.critical("first-line-that-fits")
-        // these subsequent writes should be dropped because they'd exceed the limit
-        logger.critical("second-line-must-be-dropped-because-too-large")
-        logger.critical("third-line-must-also-be-dropped-because-too-large")
+        // these subsequent writes will be truncated/dropped to stay within the cap
+        logger.critical("second-line-might-be-partially-written")
+        logger.critical("third-line-must-be-fully-dropped")
 
         let dump = (try? String(contentsOf: criticalURL)) ?? ""
         XCTAssertTrue(dump.contains("first-line-that-fits"))
-        XCTAssertFalse(dump.contains("second-line-must-be-dropped"))
-        XCTAssertFalse(dump.contains("third-line-must-also"))
+        // the third line must not appear at all — we already hit the cap by then
+        XCTAssertFalse(dump.contains("third-line"))
 
         let attrs = try? FileManager.default.attributesOfItem(atPath: criticalURL.path)
         let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
         XCTAssertLessThanOrEqual(size, 80)
+    }
+
+    /// A line that doesn't fit in the remaining budget is truncated to fit (not dropped),
+    /// so the file is filled exactly up to the cap.
+    func test_byteCountLimit_truncatesBoundaryLine() {
+        // Each line carries a ~27-byte timestamp prefix; pick a limit large enough that
+        // the truncated portion of the second line still includes a recognizable marker.
+        let limit = 200
+        let logger = makeLogger(byteLimit: limit)
+
+        let longBody = String(repeating: "a", count: 200)
+        logger.critical("first-line-that-fits")
+        logger.critical("second-line-truncated-marker-\(longBody)")
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: criticalURL.path)
+        let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        // file is filled exactly up to the cap (proves truncation, not drop, not overflow)
+        XCTAssertEqual(size, limit)
+
+        let dump = (try? String(contentsOf: criticalURL)) ?? ""
+        XCTAssertTrue(dump.contains("first-line-that-fits"))
+        // the second line is truncated — its leading marker appears, the trailing body does not
+        XCTAssertTrue(dump.contains("second-line-truncated-marker-"))
+        XCTAssertFalse(dump.contains(longBody))
+    }
+
+    /// After the cap is hit by truncation, further writes must not append anything.
+    func test_byteCountLimit_noWritesAfterCap() {
+        let limit = 200
+        let logger = makeLogger(byteLimit: limit)
+
+        let longBody = String(repeating: "a", count: 200)
+        logger.critical("first-line-that-fits")
+        logger.critical("second-line-truncated-marker-\(longBody)")
+
+        let sizeAfterCap: Int = {
+            let attrs = try? FileManager.default.attributesOfItem(atPath: criticalURL.path)
+            return (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        }()
+
+        // a write after the cap should not change file size
+        logger.critical("third-line-should-be-dropped-entirely")
+        logger.startup("startup-after-cap")
+
+        let sizeAfterMoreWrites: Int = {
+            let attrs = try? FileManager.default.attributesOfItem(atPath: criticalURL.path)
+            return (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        }()
+
+        XCTAssertEqual(sizeAfterMoreWrites, sizeAfterCap)
     }
 
     /// Non-customExport logs (info/warning/error) must not create any export file.
@@ -163,6 +214,32 @@ class DefaultInternalLoggerTests: XCTestCase {
         XCTAssertFalse(dump.contains("STALE"))
         XCTAssertTrue(dump.contains("fresh-startup"))
         XCTAssertTrue(dump.contains("fresh-critical"))
+    }
+
+    /// One log call produces exactly one line. Non-customExport calls produce zero lines.
+    func test_lineCount_matchesNumberOfCalls() {
+        let logger = makeLogger(byteLimit: 100_000)
+
+        // these must not contribute lines
+        logger.trace("t")
+        logger.debug("d")
+        logger.info("i")
+        logger.warning("w")
+        logger.error("e")
+
+        // these must contribute one line each
+        for i in 0..<3 { logger.startup("startup-\(i)") }
+        for i in 0..<5 { logger.critical("critical-\(i)") }
+
+        let dump = (try? String(contentsOf: criticalURL)) ?? ""
+        let lines = dump.split(separator: "\n", omittingEmptySubsequences: false)
+        // a well-formed file ends with \n, so split with omittingEmptySubsequences: false
+        // produces N+1 elements where the last is empty
+        XCTAssertEqual(lines.last, "")
+        XCTAssertEqual(lines.count - 1, 3 + 5)
+
+        // file ends with \n
+        XCTAssertTrue(dump.hasSuffix("\n"))
     }
 
     /// Concurrent log calls from many threads complete without crashing and produce

--- a/Tests/EmbraceCoreTests/Internal/Logs/Loggers/DefaultInternalLoggerTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/Loggers/DefaultInternalLoggerTests.swift
@@ -6,164 +6,199 @@ import EmbraceCommonInternal
 import EmbraceConfigInternal
 import EmbraceConfiguration
 import EmbraceStorageInternal
-import OSLog
 import OpenTelemetryApi
 import TestSupport
 import XCTest
 
 @testable import EmbraceCore
 
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, *)
 class DefaultInternalLoggerTests: XCTestCase {
 
     let fileProvider = TemporaryFilepathProvider()
-    var fileUrl: URL!
+    var pendingURL: URL!
+    var criticalURL: URL!
 
     override func setUpWithError() throws {
         try? FileManager.default.removeItem(at: fileProvider.tmpDirectory)
         try? FileManager.default.createDirectory(
-            at: fileProvider.directoryURL(for: "DefaultInternalLoggerTests")!, withIntermediateDirectories: true)
+            at: fileProvider.directoryURL(for: "DefaultInternalLoggerTests")!,
+            withIntermediateDirectories: true
+        )
+
+        let scope = "DefaultInternalLoggerTests"
+        pendingURL = fileProvider.fileURL(for: scope, name: "\(testName)-pending")!
+        criticalURL = fileProvider.fileURL(for: scope, name: "\(testName)-critical")!
     }
 
-    func skip_test_categories() throws {
-        // given a logger
-        fileUrl = fileProvider.fileURL(for: "DefaultInternalLoggerTests", name: testName)!
-        let category = "custom-export-\(testName)-\(UUID().withoutHyphen)"
-        let logger = DefaultInternalLogger(exportFilePath: fileUrl, exportCategory: category)
-        logger.level = .trace
-
-        // when creating logs
-        logger.trace("trace")
-        logger.debug("debug")
-        logger.info("info")
-        logger.warning("warning")
-        logger.error("error")
-        logger.startup("startup")
-        logger.critical("critical")
-
-        // then they are sent to the correct internal OSLog logger
-        let store = try OSLogStore(scope: .currentProcessIdentifier)
-        let position = store.position(timeIntervalSinceLatestBoot: 0)
-
-        let defaultEntries: [String] =
-            try store
-            .getEntries(at: position)
-            .compactMap { $0 as? OSLogEntryLog }
-            .filter { $0.subsystem == "com.embrace.logger" && $0.category == "internal" }
-            .map { $0.composedMessage }
-
-        XCTAssert(defaultEntries.contains("trace"))
-        XCTAssert(defaultEntries.contains("debug"))
-        XCTAssert(defaultEntries.contains("info"))
-        XCTAssert(defaultEntries.contains("warning"))
-        XCTAssert(defaultEntries.contains("error"))
-
-        let customExportEntries: [String] =
-            try store
-            .getEntries(at: position)
-            .compactMap { $0 as? OSLogEntryLog }
-            .filter { $0.subsystem == "com.embrace.logger" && $0.category == category }
-            .map { $0.composedMessage }
-
-        XCTAssert(customExportEntries.contains("startup"))
-        XCTAssert(customExportEntries.contains("critical"))
-    }
-
-    func test_export_withCriticalLogs() async throws {
-        // given a logger
-        fileUrl = fileProvider.fileURL(for: "DefaultInternalLoggerTests", name: testName)!
+    private func makeLogger(byteLimit: Int = 1000) -> DefaultInternalLogger {
         let logger = DefaultInternalLogger(
-            exportFilePath: fileUrl,
-            exportCategory: "custom-export-\(testName)-\(UUID().withoutHyphen)"
+            pendingFilePath: pendingURL,
+            criticalFilePath: criticalURL,
+            exportByCountLimit: byteLimit
         )
         logger.level = .trace
+        return logger
+    }
 
-        // when doing custom exportable logs without 0 critical logs
+    /// .startup-only run leaves the staging file on disk but never creates a critical-logs file.
+    func test_startupOnly_doesNotCreateCriticalFile() {
+        let logger = makeLogger()
+
         logger.startup("startup1")
         logger.startup("startup2")
         logger.startup("startup3")
-        logger.startup("startup4")
-        logger.startup("startup5")
-        logger.critical("critical")
 
-        await logger.waitForQueue()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: criticalURL.path))
 
-        let log = try! String(contentsOf: self.fileUrl)
-        XCTAssert(log.contains("startup1"))
-        XCTAssert(log.contains("startup2"))
-        XCTAssert(log.contains("startup3"))
-        XCTAssert(log.contains("startup4"))
-        XCTAssert(log.contains("startup5"))
-        XCTAssert(log.contains("critical"))
+        let pending = try? String(contentsOf: pendingURL)
+        XCTAssertTrue(pending?.contains("startup1") ?? false)
+        XCTAssertTrue(pending?.contains("startup2") ?? false)
+        XCTAssertTrue(pending?.contains("startup3") ?? false)
     }
 
-    func test_export_withoutCriticalLog() async {
-        // given a logger
-        fileUrl = fileProvider.fileURL(for: "DefaultInternalLoggerTests", name: testName)!
-        let logger = DefaultInternalLogger(
-            exportFilePath: fileUrl,
-            exportCategory: "custom-export-\(testName)-\(UUID().withoutHyphen)"
-        )
-        logger.level = .trace
+    /// First .critical promotes the staging file to the upload path; pending is gone.
+    func test_firstCritical_promotesPendingToCritical() {
+        let logger = makeLogger()
 
-        // when doing custom exportable logs without 0 critical logs
         logger.startup("startup1")
         logger.startup("startup2")
-        logger.startup("startup3")
-        logger.startup("startup4")
-        logger.startup("startup5")
+        logger.critical("boom")
 
-        await logger.waitForQueue()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: criticalURL.path))
 
-        // then no custom export file is created
-        XCTAssertFalse(FileManager.default.fileExists(atPath: fileUrl.path))
+        let dump = try? String(contentsOf: criticalURL)
+        XCTAssertTrue(dump?.contains("startup1") ?? false)
+        XCTAssertTrue(dump?.contains("startup2") ?? false)
+        XCTAssertTrue(dump?.contains("boom") ?? false)
     }
 
-    func test_multiple_exports() async {
-        // given a logger
-        fileUrl = fileProvider.fileURL(for: "DefaultInternalLoggerTests", name: testName)!
-        let logger = DefaultInternalLogger(
-            exportFilePath: fileUrl,
-            exportCategory: "custom-export-\(testName)-\(UUID().withoutHyphen)"
-        )
-        logger.level = .trace
+    /// .critical without prior .startup writes directly to the upload path.
+    func test_criticalOnly_createsCriticalFileDirectly() {
+        let logger = makeLogger()
 
-        // when creating a critical log
-        logger.critical("critical1")
+        logger.critical("boom")
 
-        await logger.waitForQueue()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pendingURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: criticalURL.path))
 
-        var log = try! String(contentsOf: self.fileUrl)
-        XCTAssert(log.contains("critical1"))
-
-        // when doing another critical log
-        logger.critical("critical2")
-
-        await logger.waitForQueue()
-
-        log = try! String(contentsOf: self.fileUrl)
-        XCTAssert(log.contains("critical1"))
-        XCTAssert(log.contains("critical2"))
-
-        // when doing another critical log
-        logger.critical("critical3")
-
-        await logger.waitForQueue()
-
-        log = try! String(contentsOf: self.fileUrl)
-        XCTAssert(log.contains("critical1"))
-        XCTAssert(log.contains("critical2"))
-        XCTAssert(log.contains("critical3"))
-
+        let dump = try? String(contentsOf: criticalURL)
+        XCTAssertTrue(dump?.contains("boom") ?? false)
     }
-}
 
-extension DefaultInternalLogger {
-    func waitForQueue() async {
-        await withCheckedContinuation { continuation in
-            queue.async {
-                continuation.resume()
+    /// Multiple .criticals all land in the critical file; promotion only happens once.
+    func test_multipleCriticals_promoteOnceAndAppend() {
+        let logger = makeLogger()
+
+        logger.critical("c1")
+        logger.critical("c2")
+        logger.critical("c3")
+
+        let dump = try? String(contentsOf: criticalURL)
+        XCTAssertTrue(dump?.contains("c1") ?? false)
+        XCTAssertTrue(dump?.contains("c2") ?? false)
+        XCTAssertTrue(dump?.contains("c3") ?? false)
+
+        // pending was never created (or was promoted); either way it must be gone now
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pendingURL.path))
+    }
+
+    /// Startup lines logged after promotion also land in the critical file.
+    func test_startupAfterCritical_appendsToCriticalFile() {
+        let logger = makeLogger()
+
+        logger.critical("boom")
+        logger.startup("late-startup")
+
+        let dump = try? String(contentsOf: criticalURL)
+        XCTAssertTrue(dump?.contains("boom") ?? false)
+        XCTAssertTrue(dump?.contains("late-startup") ?? false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pendingURL.path))
+    }
+
+    /// Once the byte budget is exhausted, further writes are dropped — file size is bounded.
+    func test_byteCountLimit_capsFileSize() {
+        // small limit: ~one short line max
+        let logger = makeLogger(byteLimit: 80)
+
+        logger.critical("first-line-that-fits")
+        // these subsequent writes should be dropped because they'd exceed the limit
+        logger.critical("second-line-must-be-dropped-because-too-large")
+        logger.critical("third-line-must-also-be-dropped-because-too-large")
+
+        let dump = (try? String(contentsOf: criticalURL)) ?? ""
+        XCTAssertTrue(dump.contains("first-line-that-fits"))
+        XCTAssertFalse(dump.contains("second-line-must-be-dropped"))
+        XCTAssertFalse(dump.contains("third-line-must-also"))
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: criticalURL.path)
+        let size = (attrs?[.size] as? NSNumber)?.intValue ?? 0
+        XCTAssertLessThanOrEqual(size, 80)
+    }
+
+    /// Non-customExport logs (info/warning/error) must not create any export file.
+    func test_nonCustomExportLevels_doNotCreateFile() {
+        let logger = makeLogger()
+
+        logger.trace("t")
+        logger.debug("d")
+        logger.info("i")
+        logger.warning("w")
+        logger.error("e")
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pendingURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: criticalURL.path))
+    }
+
+    /// A stale critical-logs file from a prior run is overwritten on promotion.
+    func test_stalePreExistingCritical_isOverwrittenOnPromotion() throws {
+        try "STALE".write(to: criticalURL, atomically: true, encoding: .utf8)
+
+        let logger = makeLogger()
+        logger.startup("fresh-startup")
+        logger.critical("fresh-critical")
+
+        let dump = try String(contentsOf: criticalURL)
+        XCTAssertFalse(dump.contains("STALE"))
+        XCTAssertTrue(dump.contains("fresh-startup"))
+        XCTAssertTrue(dump.contains("fresh-critical"))
+    }
+
+    /// Concurrent log calls from many threads complete without crashing and produce
+    /// well-formed output (every line terminated with \n, every line maps to one input).
+    func test_threadSafety_concurrentLogs() {
+        let logger = makeLogger(byteLimit: 100_000)
+        let group = DispatchGroup()
+        let totalThreads = 16
+        let perThread = 25
+
+        for t in 0..<totalThreads {
+            DispatchQueue.global().async(group: group) {
+                for i in 0..<perThread {
+                    if i % 5 == 0 {
+                        logger.critical("c-\(t)-\(i)")
+                    } else {
+                        logger.startup("s-\(t)-\(i)")
+                    }
+                }
             }
+        }
+
+        group.wait()
+
+        // After at least one .critical the file must exist
+        XCTAssertTrue(FileManager.default.fileExists(atPath: criticalURL.path))
+
+        let dump = (try? String(contentsOf: criticalURL)) ?? ""
+        // every line must be terminated; trailing newline means split keeps empty element
+        let lines = dump.split(separator: "\n", omittingEmptySubsequences: true)
+        for line in lines {
+            // each line must contain one of our injected tokens
+            XCTAssertTrue(
+                line.contains("s-") || line.contains("c-"),
+                "Unexpected line: \(line)"
+            )
         }
     }
 }

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -755,6 +755,32 @@ class UnsentDataHandlerTests: XCTestCase {
         // then no log is sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)
     }
+
+    func test_criticalLogs_orphanPendingFile_isDeleted() async throws {
+        // mock successful requests
+        EmbraceHTTPMock.mock(url: testLogsUrl())
+
+        // given upload module
+        let upload = try EmbraceUpload(
+            options: uploadOptions, logger: logger, queue: queue)
+
+        // given a stranded pending-logs file from a prior run that didn't fire .critical
+        let pendingLogsFilePath = filePathProvider.fileURL(for: "UnsentDataHandlerTests", name: "pending-file")!
+        try "STARTUP-TRAIL".write(to: pendingLogsFilePath, atomically: true, encoding: .utf8)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pendingLogsFilePath.path))
+
+        // when sending critical logs (no critical-logs file exists)
+        await UnsentDataHandler.sendCriticalLogs(
+            fileUrl: criticalLogsFilePath,
+            pendingFileUrl: pendingLogsFilePath,
+            upload: upload
+        )
+        wait(delay: .shortTimeout)
+
+        // then nothing is uploaded and the orphan is gone
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pendingLogsFilePath.path))
+    }
 }
 
 extension UnsentDataHandlerTests {

--- a/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
@@ -340,22 +340,22 @@ class CaptureServicesOptionsBuilderTests: XCTestCase {
         XCTAssertEqual((options.customServices[0] as! FakeCaptureService).testValue, 9999)
     }
 
-#if canImport(UIKit) && !os(watchOS)
-    func test_customService_embraceType() throws {
-        // given a builder with default services
-        let builder = CaptureServicesOptionsBuilder()
-        builder.addDefaults()
+    #if canImport(UIKit) && !os(watchOS)
+        func test_customService_embraceType() throws {
+            // given a builder with default services
+            let builder = CaptureServicesOptionsBuilder()
+            builder.addDefaults()
 
-        // when adding a custom service of an embrace type
-        builder.add(TapCaptureService())
+            // when adding a custom service of an embrace type
+            builder.add(TapCaptureService())
 
-        // then the service will be added as a custom service
-        let options = builder.build()
+            // then the service will be added as a custom service
+            let options = builder.build()
 
-        XCTAssertEqual(options.customServices.count, 1)
-        XCTAssertTrue(options.customServices[0] is TapCaptureService)
-    }
-#endif
+            XCTAssertEqual(options.customServices.count, 1)
+            XCTAssertTrue(options.customServices[0] is TapCaptureService)
+        }
+    #endif
 }
 
 class FakeCaptureService: CaptureService {


### PR DESCRIPTION
Replaces `OSLogStore`-based critical log export with direct file writes. The previous design used `os_log` to write entries and then synchronously read them back through `OSLogStore.getEntries`, which under memory pressure tripped a recursive `NSException`/`couldNotInstantiate` crash and a synchronous-XPC hang vector.

## Changes

- **Two-file state machine**: `pending-logs` receives `.startup` lines; promoted via atomic `rename(2)` to `critical-logs` on the first `.critical`. No file is left behind for healthy runs (requirement: only generate the upload file when something actually went wrong).
- **POSIX writes** (`open`/`write`/`fsync`/`close`) instead of `FileHandle`. Avoids `NSException` on failure (Swift can't catch it), drops the iOS 13.4+ availability gate, and removes the Foundation/ObjC bridge from the hot path.
- **`fsync` on `.critical`** for crash durability; skipped on `.startup` to keep boot cheap.
- **Boot-time orphan cleanup** in `UnsentDataHandler.sendCriticalLogs` deletes any leftover `pending-logs`.
- **Removed**: `OSLogStore` usage, the `com.embrace.logger.export` queue, `lastExportDate`/`exporting` cursor state, the iOS 15 / tvOS 15 availability gate, and the dual `OSLog` channel split.
- Tests rewritten around file-state assertions (no more `OSLogStore` reads).
