### PR TITLE
Remove redundant `addDependency` on serial upload queues

### DIFF
--- a/Sources/EmbraceUploadInternal/EmbraceUpload.swift
+++ b/Sources/EmbraceUploadInternal/EmbraceUpload.swift
@@ -38,11 +38,6 @@ public class EmbraceUpload: EmbraceLogUploader {
         .spans: [], .log: [], .attachment: []
     ]
 
-    /// Weak references to the most recently enqueued upload operation for ordered types.
-    /// Used to chain new operations against their predecessor.
-    private weak var lastSpansOperation: Operation?
-    private weak var lastLogsOperation: Operation?
-
     private let urlSession: URLSession
     let cache: EmbraceUploadCache
     private var reachabilityMonitor: EmbraceReachabilityMonitor?
@@ -238,19 +233,6 @@ public class EmbraceUpload: EmbraceLogUploader {
                 data: record.data,
                 payloadTypes: record.payloadTypes
             )
-
-            // Chain for ordered types
-            if type == .spans {
-                if let last = lastSpansOperation, !last.isFinished {
-                    operation.addDependency(last)
-                }
-                lastSpansOperation = operation
-            } else if type == .log {
-                if let last = lastLogsOperation, !last.isFinished {
-                    operation.addDependency(last)
-                }
-                lastLogsOperation = operation
-            }
 
             inFlightIDs[type]?.insert(record.id)
             queue.addOperation(operation)


### PR DESCRIPTION
## Summary

Removes the explicit `addDependency(last)` chain in `fillQueue(for:)` for spans and logs. Both queues are already configured with `maxConcurrentOperationCount = 1`, which guarantees FIFO ordering — the dependency chain is redundant and introduces a race in NSOperation's internal `_dependents`/`_dependencies` arrays.

## Evidence

After upgrading from SDK **6.16.0 → 6.18.0** (which includes PR #562, "Ordered uploads"), we're seeing a **~2,200× increase** in `__RELEASE_OBJECTS_IN_THE_ARRAY__` crashes per session:

| Embrace SDK | Crashes (7d) | Sessions | Per-session rate |
|---|---|---|---|
| **6.18.0** | **882** | 435,849 | **1 per ~494 sessions** |
| 6.16.0 | 19 | 21,157,889 | 1 per ~1,114,000 sessions |

**OS / device concentration:** iOS 26.4.2 is 2.8× over-represented; iPhone 17 / 17 Pro / iPhone Air hardware is 2.4–2.8× over-represented.

**Stack trace pattern** — all sampled crashes show the same recursive NSOperation dealloc cascade (EXC_BAD_ACCESS, no app frames):

```
0  CoreFoundation  __RELEASE_OBJECTS_IN_THE_ARRAY__
1  CoreFoundation  -[__NSArrayM dealloc]
2  Foundation      -[NSOperation dealloc]
3  CoreFoundation  __RELEASE_OBJECTS_IN_THE_ARRAY__
4  CoreFoundation  -[__NSArrayM dealloc]
5  Foundation      -[NSOperation dealloc]
…
```

## Root cause

In `fillQueue(for:)`, the new code chains each upload operation against its predecessor via `addDependency(last)`, where `last` is a `weak var` to the previous operation. There is a TOCTOU race between the `!last.isFinished` check (on the coordination queue) and the operation finishing/deallocating (on `_spansQueue` / `_logsQueue`). Combined with the `cancel() → finish()` lifecycle fix also in PR #562 (which shortens operation lifetimes), this produces concurrent mutation of NSOperation's internal `_dependents` array — triggering the dealloc cascade crash.

The `addDependency` chain is redundant because `maxConcurrentOperationCount = 1` on `spansQueue` and `logsQueue` already guarantees FIFO ordering.

## Validation

- **All 47 existing upload tests pass** after this change, including all 13 `EmbraceUploadOrderedDeliveryTests` (which verify span and log ordering, retry semantics, and queue capacity).

## Changes

- **`EmbraceUpload.swift`**: Deleted the `addDependency` block in `fillQueue(for:)` and the `lastSpansOperation` / `lastLogsOperation` weak properties (18 lines removed, 0 added).

## Notes for reviewers

If the dependency chain was load-bearing for cross-queue ordering or some scenario not covered by the serial queue guarantee, please flag — happy to refactor toward a synchronized approach instead. Our read of the architecture is that ordering is fully guaranteed by the serial queues alone, which the existing `EmbraceUploadOrderedDeliveryTests` confirm.
