### PR TITLE
CI: Drop pre-Xcode 26 from build/test matrices

### DIFF
--- a/.github/matrices/builds.json
+++ b/.github/matrices/builds.json
@@ -31,30 +31,6 @@
     "include": [
       {
         "platform": "iOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "tvOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "macOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "watchOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "iOS",
         "xcode_version": "26.0",
         "macos-version": "15",
         "sanitizer": "none"

--- a/.github/workflows/build-example-apps.yml
+++ b/.github/workflows/build-example-apps.yml
@@ -12,11 +12,11 @@ jobs:
   build-brandgame-app:
     name: Build BrandGame App
     timeout-minutes: 20
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["15.4"]
+        xcode_version: ["26.0"]
     steps:
       - name: Select Xcode
         # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
@@ -51,11 +51,11 @@ jobs:
   build-demoobjc-app:
     name: Build Objc Demo App
     timeout-minutes: 20
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["15.4"]
+        xcode_version: ["26.0"]
     steps:
       - name: Select Xcode
         # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -157,8 +157,8 @@ jobs:
           git pull --rebase
           git push
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+      - name: Select Xcode 26
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.app
 
       - name: Tag the release candidate version
         run: |
@@ -184,8 +184,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+      - name: Select Xcode 26
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.app
 
       - name: Install Ruby dependencies
         run: bundle install

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["16.4"]
+        xcode_version: ["26.0"]
         device:
           - "iPhone 16 Pro"
     permissions:


### PR DESCRIPTION
  - Apple no longer accepts App Store submissions built with older Xcode versions ([announcement](https://developer.apple.com/news/?id=ueeok6yw)), so CI jobs on those toolchains add no signal.
  - Removes Xcode 16.4 from `main`'s build/test matrix and from the UI tests workflow.
  - Bumps the example-app builds from Xcode 15.4 / `macos-14` to Xcode 26.0 / `macos-15` (Xcode 26 isn't on the macos-14 image).
  - Moves the release workflow's RC-tag and XCFramework-build steps to Xcode 26.0.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
