### PR TITLE
CI: Predownload tvOS/watchOS platforms in Build Platforms

### DIFF
--- a/.github/matrices/builds.json
+++ b/.github/matrices/builds.json
@@ -31,30 +31,6 @@
     "include": [
       {
         "platform": "iOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "tvOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "macOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "watchOS",
-        "xcode_version": "16.4",
-        "macos-version": "15",
-        "sanitizer": "none"
-      },
-      {
-        "platform": "iOS",
         "xcode_version": "26.0",
         "macos-version": "15",
         "sanitizer": "none"

--- a/.github/workflows/build-example-apps.yml
+++ b/.github/workflows/build-example-apps.yml
@@ -12,11 +12,11 @@ jobs:
   build-brandgame-app:
     name: Build BrandGame App
     timeout-minutes: 20
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["15.4"]
+        xcode_version: ["26.0"]
     steps:
       - name: Select Xcode
         # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
@@ -51,11 +51,11 @@ jobs:
   build-demoobjc-app:
     name: Build Objc Demo App
     timeout-minutes: 20
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["15.4"]
+        xcode_version: ["26.0"]
     steps:
       - name: Select Xcode
         # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -56,6 +56,7 @@ jobs:
       if: ${{ matrix.platform != 'macOS' && matrix.platform != 'mac-catalyst' }}
       run: |
         xcodebuild -runFirstLaunch
+        xcrun simctl list
         xcodebuild -downloadPlatform ${MATRIX_PLATFORM}
         xcodebuild -runFirstLaunch
       env:

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -52,6 +52,15 @@ jobs:
       env:
         MATRIX_XCODE_VERSION: ${{ matrix.xcode_version }}
 
+    - name: Ensure the Platform is Downloaded
+      if: ${{ matrix.platform != 'macOS' && matrix.platform != 'mac-catalyst' }}
+      run: |
+        xcodebuild -runFirstLaunch
+        xcodebuild -downloadPlatform ${MATRIX_PLATFORM}
+        xcodebuild -runFirstLaunch
+      env:
+        MATRIX_PLATFORM: ${{ matrix.platform }}
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       timeout-minutes: 4
       with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -157,8 +157,8 @@ jobs:
           git pull --rebase
           git push
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+      - name: Select Xcode 26
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.app
 
       - name: Tag the release candidate version
         run: |
@@ -184,8 +184,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+      - name: Select Xcode 26
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.app
 
       - name: Install Ruby dependencies
         run: bundle install

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["16.4"]
+        xcode_version: ["26.0"]
         device:
           - "iPhone 16 Pro"
     permissions:


### PR DESCRIPTION
 - The `Build Platforms` workflow's tvOS and watchOS jobs were failing on the `macos-15` runner with `tvOS 26.0 is not installed. Please download and install the platform from Xcode > Settings > Components.`
 - `run-tests.yml` already runs `xcodebuild -downloadPlatform <platform>` to handle this, but `build-platforms.yml` was missing the same step. Adding it.


## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
