### PR TITLE
[EMBR-12073] Fix: Tests: fix CI timeout flakes in span processor tests

### DIFF
--- a/Tests/EmbraceCoreTests/Internal/EmbraceSpanProcessorExporterTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/EmbraceSpanProcessorExporterTests.swift
@@ -64,13 +64,9 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // When spans are exported
-        let expectation = XCTestExpectation()
         processor.processCompletedSpanData(closedSpanData, sync: true)
         processor.processCompletedSpanData(updated_closedSpanData, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .longTimeout)
+        processor.waitUntilDrained()
 
         let exportedSpans: [SpanRecord] = storage.fetchAll()
         XCTAssertTrue(exportedSpans.count == 1)
@@ -120,13 +116,9 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // When spans are exported
-        let expectation = XCTestExpectation()
         processor.processIncompletedSpanData(openSpanData, span: nil, sync: true)
         processor.processIncompletedSpanData(updated_openSpanData, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .longTimeout)
+        processor.waitUntilDrained()
 
         let exportedSpans: [SpanRecord] = storage.fetchAll()
         XCTAssertTrue(exportedSpans.count == 1)
@@ -178,12 +170,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // when an open session span is exported
-        let expectation = XCTestExpectation()
         processor.processIncompletedSpanData(openSessionSpan, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then the data is exported
         var exportedSpans: [SpanRecord] = storage.fetchAll()
@@ -193,12 +181,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         XCTAssertNil(exportedSpans[0].endTime)
 
         // when a closed session span is exported
-        let expectation1 = XCTestExpectation()
         processor.processCompletedSpanData(closedSessionSpan, sync: true)
-        processor.processorQueue.async {
-            expectation1.fulfill()
-        }
-        wait(for: [expectation1], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then the data is NOT exported
         exportedSpans = storage.fetchAll()
@@ -241,12 +225,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // when the span is exported
-        let expectation = XCTestExpectation()
         processor.processCompletedSpanData(spanData)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then the span is stored
         let exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)
@@ -299,12 +279,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // when the span is exported first time
-        let expectation1 = XCTestExpectation()
         processor.processIncompletedSpanData(spanData1, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation1.fulfill()
-        }
-        wait(for: [expectation1], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then one event is stored
         var exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)
@@ -326,12 +302,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // when the span is exported again
-        let expectation2 = XCTestExpectation()
         processor.processIncompletedSpanData(spanData2, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation2.fulfill()
-        }
-        wait(for: [expectation2], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then only the new event is added (no duplicate of event1)
         exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)
@@ -373,12 +345,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // when the span is exported
-        let expectation = XCTestExpectation()
         processor.processCompletedSpanData(spanData)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then the span is stored
         let exportedSpans: [SpanRecord] = storage.fetchAll()
@@ -446,12 +414,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
         )
 
         // when the span is exported through the processor
-        let expectation = XCTestExpectation()
         processor.processCompletedSpanData(spanData, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then the span is stored with events in separate storage
         let exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)
@@ -528,12 +492,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
             hasEnded: false
         )
 
-        var expectation = XCTestExpectation()
         processor.processIncompletedSpanData(spanData, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // verify 1 event stored
         var exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)
@@ -553,12 +513,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
             hasEnded: false
         )
 
-        expectation = XCTestExpectation()
         processor.processIncompletedSpanData(spanData, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // verify 2 events stored (no duplicate of event1)
         exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)
@@ -578,12 +534,8 @@ final class EmbraceSpanProcessorExporterTests: XCTestCase {
             hasEnded: false
         )
 
-        expectation = XCTestExpectation()
         processor.processIncompletedSpanData(spanData, span: nil, sync: true)
-        processor.processorQueue.async {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: .shortTimeout)
+        processor.waitUntilDrained()
 
         // then all 3 events are stored without duplicates
         exportedSpan = storage.fetchSpan(id: spanId.hexString, traceId: traceId.hexString)

--- a/Tests/TestSupport/Extensions/EmbraceSpanProcessor+Extension.swift
+++ b/Tests/TestSupport/Extensions/EmbraceSpanProcessor+Extension.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceOTelInternal
+
+extension EmbraceSpanProcessor {
+    /// Test-only barrier that blocks until every prior async work item on `processorQueue` has run.
+    /// Use this in tests instead of an `XCTestExpectation` fulfilled from `processorQueue.async { }`.
+    public func waitUntilDrained() {
+        processorQueue.sync {}
+    }
+}


### PR DESCRIPTION
## Summary 

 - 12 storage-related tests in `EmbraceSpanProcessorExporterTests.swift` have been shown to be flaky during `Run Swift Tests`  — most recently in run  [25527850307](https://github.com/embrace-io/embrace-apple-sdk/actions/runs/25527850307) on 2026-05-07, where they tripped the 0.5s and 5s expectation timeouts .

  ## Why these tests were flaking

  `StorageSpanExporter.export(spans:)` is synchronous all the way down to `context.performAndWait`. By the time `processCompletedSpanData(_, sync: true)` returns, the row is  committed and visible.

  The flakes were in the test scaffolding, not the storage code:

  ```swift
  // before
  let exp = XCTestExpectation()
  processor.processCompletedSpanData(spanData, sync: true)
  processor.processorQueue.async { exp.fulfill() }
  wait(for: [exp], timeout: .shortTimeout)   // 0.5s
  ```

Two issues:

  1. The `processorQueue.async { fulfill() }` hop is redundant when the export is already `sync: true` — the data is in storage before the barrier is even posted.
  2. `.shortTimeout = 0.5s` is within ordinary CI variance on parallel-testing-enabled, shared macOS runners; even `.longTimeout` (5s) was hitting timeouts on contended jobs.

## What this PR does

Adds no-op closure submitted synchronously to the serial queue. Because the queue is FIFO and serial, "the empty closure has run" implies "everything submitted before it has also run." No expectation, no timeout, no flake surface.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
