### PR TITLE
[EMBR-12072] Feature: CI: Surface xcresult failure summary in job log

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -69,3 +69,16 @@ jobs:
         code-coverage: false
         trust-plugins: false
         arch: arm64
+
+    # Dumps the xcresult build log into the job log so a compile error
+    # can be diagnosed without downloading the xcresult artifact.
+    - name: Surface failure summary from xcresult
+      if: failure()
+      run: |
+        if [ ! -d build.xcresult ]; then
+          echo "build.xcresult not found in $(pwd); skipping summary."
+          exit 0
+        fi
+        echo "::group::Build log"
+        xcrun xcresulttool get log --path build.xcresult --type build || true
+        echo "::endgroup::"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,6 +86,24 @@ jobs:
           arch: arm64
           sanitizer: ${{ matrix.sanitizer }}
 
+      # Dumps the human-readable failure summary and per-test failure tree
+      # (with file:line) into the job log so a failure can be diagnosed
+      # without downloading the ~75 MB xcresult artifact — especially
+      # relevant for TSan aborts.
+      - name: Surface failure summary from xcresult
+        if: failure()
+        run: |
+          if [ ! -d test.xcresult ]; then
+            echo "test.xcresult not found in $(pwd); skipping summary."
+            exit 0
+          fi
+          echo "::group::Test results summary"
+          xcrun xcresulttool get test-results summary --path test.xcresult || true
+          echo "::endgroup::"
+          echo "::group::Per-test failures (file:line)"
+          xcrun xcresulttool get test-results tests --path test.xcresult || true
+          echo "::endgroup::"
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         env:


### PR DESCRIPTION
## Summary

  - Adds a `Surface failure summary from xcresult` step to `run-tests.yml`, gated on `if: failure()`.
  - Dumps two `xcresulttool` views into collapsible `::group::` sections in the job log:
    - `get test-results summary` — counts + per-failure text/target.
    - `get test-results tests` — per-test tree with `file:line: failureText` for each failure.
  - No-op on green runs. Step is resilient (`exit 0` if `test.xcresult` is missing; `|| true` on each subcommand) so it never overrides the original failure status.

## Why

Diagnosing a TSan abort or build error past the streaming log buffer currently requires downloading the `xcresult` artifact (~75 MB on TSan jobs). A 200-line summary in the job log is enough for most investigations and saves the round-trip. 
   
## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
