### PR TITLE
[EMBR-12085] Chore:   CI: Cache SwiftPM SourcePackages between runs

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -67,6 +67,13 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Cache SwiftPM packages
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/Library/Developer/Xcode/DerivedData/embrace-apple-sdk-*/SourcePackages
+        key: swiftpm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+        restore-keys: swiftpm-${{ runner.os }}-
+
     - name: Build
       uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5 # v3.6.0
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,6 +72,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache SwiftPM packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/embrace-apple-sdk-*/SourcePackages
+          key: swiftpm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: swiftpm-${{ runner.os }}-
+
       - name: Run Unit Tests
         uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5 # v3.6.0
         timeout-minutes: 80


### PR DESCRIPTION
  - Adds `actions/cache` keyed on `Package.resolved` to `run-tests.yml` and `build-platforms.yml`
  - On cache hit, xcodebuild skips resolving and recompiling KSCrash, SwiftSyntax, OpenTelemetryApi, OpenTelemetrySdk, and EmbraceCommonInternal from scratch
  - `restore-keys: swiftpm-${{ runner.os }}-` provides a partial hit when `Package.resolved` changes — xcodebuild resolves only what's new and writes a fresh cache entry
  - Cache is invalidated automatically when `Package.resolved` changes (i.e. on any real dependency version change); dependabot owns SHA bumps for `actions/cache` going forward

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
