### PR TITLE
Default value on HangLimits for hangPerSession

### DIFF
--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -18,7 +18,7 @@ import Foundation
 
     public init(
         hangThreshold: TimeInterval = 0.249,
-        hangPerSession: UInt = 200,
+        hangPerSession: UInt = 20,
         reportsWatchdogEvents: Bool = false
     ) {
         self.hangThreshold = hangThreshold

--- a/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
+++ b/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
@@ -50,7 +50,7 @@
     "metrickit_v2_pct_enabled": 55,
     "metrickit_v2_reporters_enabled": "CRASH,HANG",
     "metrickit_v2_crash_signals_enabled": "SIGKILL,SIGINT",
-    "hang_limits": {
+    "hang_limits_v2": {
         "hang_threshold": 0.5,
         "hang_per_session": 100,
         "reports_watchdog_events": true


### PR DESCRIPTION
fixes default value on HangLimits constructor and fixes config key for mock config on unit tests