### PR TITLE
[EMBR-12136] Chore: CI: UI Tests workflow observability and concurrency

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   run-ui-tests-app:
-    timeout-minutes: 90
+    timeout-minutes: 30
     runs-on: [macos-15]
     strategy:
       fail-fast: false
@@ -24,6 +24,17 @@ jobs:
         xcode_version: ["26.0"]
         device:
           - "iPhone 16 Pro"
+        test_group:
+          - name: startup
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestWARMStartupUITests,EmbraceIOTestAppUITests/EmbraceIOTestCOLDStartupUITests"
+          - name: logs
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests"
+          - name: networking
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests"
+          - name: session
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests,EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads"
+          - name: views
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI,EmbraceIOTestAppUITests/EmbraceIOTestViewUITests"
     permissions:
       checks: write
 
@@ -64,13 +75,25 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
 
-      - name: Run UI Tests
+      - name: Run UI Tests (${{ matrix.test_group.name }})
         env:
           IS_XCTEST: true
         run: |
           set -o pipefail
           mkdir -p build
-          xcodebuild -project "./Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj" -scheme "EmbraceIOTestApp" -derivedDataPath "build/DerivedData" -resultBundlePath ".build/test/output" -destination "platform=iOS Simulator,name=${{ matrix.device }}" -parallel-testing-enabled NO test -retry-tests-on-failure -test-iterations 3 2>&1 \
+          IFS=',' read -ra FILTERS <<< "${{ matrix.test_group.filter }}"
+          xcodebuild \
+            -project "./Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj" \
+            -scheme "EmbraceIOTestApp" \
+            -derivedDataPath "build/DerivedData" \
+            -resultBundlePath ".build/test/output" \
+            -destination "platform=iOS Simulator,name=${{ matrix.device }}" \
+            -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 60 \
+            -maximum-test-execution-time-allowance 180 \
+            "${FILTERS[@]/#/-only-testing:}" \
+            test 2>&1 \
             | tee >(awk '{ printf "[%s] %s\n", strftime("%H:%M:%S"), $0; fflush() }' > build/xcodebuild.log) \
             | xcbeautify --renderer github-actions
 
@@ -78,12 +101,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: xcodebuild_log
+          name: xcodebuild_log_${{ matrix.test_group.name }}
           path: build/xcodebuild.log
 
       - name: Upload xcresult Bundle Manually
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: output_xcresult
+          name: output_xcresult_${{ matrix.test_group.name }}
           path: .build/test/output.xcresult

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -10,9 +10,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-ui-tests-app:
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: [macos-15]
     strategy:
       fail-fast: false
@@ -64,10 +68,21 @@ jobs:
         env:
           IS_XCTEST: true
         run: |
-          set -e && xcodebuild -project "./Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj" -scheme "EmbraceIOTestApp" -derivedDataPath "build/DerivedData" -resultBundlePath ".build/test/output" -destination "platform=iOS Simulator,name=${{ matrix.device }}" -parallel-testing-enabled NO test -retry-tests-on-failure -test-iterations 3 | xcbeautify && exit ${PIPESTATUS[0]}
+          set -o pipefail
+          mkdir -p build
+          xcodebuild -project "./Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj" -scheme "EmbraceIOTestApp" -derivedDataPath "build/DerivedData" -resultBundlePath ".build/test/output" -destination "platform=iOS Simulator,name=${{ matrix.device }}" -parallel-testing-enabled NO test -retry-tests-on-failure -test-iterations 3 2>&1 \
+            | tee >(awk '{ printf "[%s] %s\n", strftime("%H:%M:%S"), $0; fflush() }' > build/xcodebuild.log) \
+            | xcbeautify --renderer github-actions
+
+      - name: Upload xcodebuild log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: xcodebuild_log
+          path: build/xcodebuild.log
 
       - name: Upload xcresult Bundle Manually
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: output_xcresult

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/Common/Extensions.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/Common/Extensions.swift
@@ -48,25 +48,6 @@ extension XCUIElement {
 }
 
 extension XCTestCase {
-    func waitUntilElementHasFocus(
-        element: XCUIElement, timeout: TimeInterval = 600, file: StaticString = #file, line: UInt = #line
-    ) -> XCUIElement {
-        let expectation = expectation(description: "waiting for element \(element) to have focus")
-
-        let timer = Timer(timeInterval: 1, repeats: true) { timer in
-            guard element.hasFocus else { return }
-
-            expectation.fulfill()
-            timer.invalidate()
-        }
-
-        RunLoop.current.add(timer, forMode: .common)
-
-        wait(for: [expectation], timeout: timeout)
-
-        return element
-    }
-
     func waitUntilElementIsEnabled(element: XCUIElement, timeout: TimeInterval = 600, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
         let expectation = expectation(description: "waiting for element \(element) to be enabled")
 
@@ -85,7 +66,7 @@ extension XCTestCase {
     }
 
     func evaluateTestResults(_ app: XCUIApplication) {
-        XCTAssertTrue(app.staticTexts["TEST RESULT:"].waitForExistence(timeout: 60))
+        XCTAssertTrue(app.staticTexts["TEST RESULT:"].waitForExistence(timeout: 20))
         XCTAssertTrue(app.staticTexts["PASS"].exists)
         XCTAssertFalse(app.staticTexts["FAIL"].exists)
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
@@ -26,7 +26,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageTextField))
         logMessageTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageTextField.typeText(
             String(
@@ -117,49 +117,8 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         evaluateTestResults(app)
     }
 
-    func testAllLogCases() {
-        caseTestLogCapture_trace()
-        app.swipeDown()
-        caseTestLogCapture_debug()
-        app.swipeDown()
-        caseTestLogCapture_info()
-        app.swipeDown()
-        caseTestLogCapture_warn()
-        app.swipeDown()
-        caseTestLogCapture_error()
-        app.swipeDown()
-        caseTestLogCapture_fatal()
-        app.swipeDown()
-        caseTestLogCapture_critical()
-        app.swipeDown()
-        caseTestLogCapture_warn_noStack()
-        app.swipeDown()
-        caseTestLogCapture_error_noStack()
-        app.swipeDown()
-        caseTestLogCapture_trace_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_debug_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_info_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_warn_customStack_expected()
-        app.swipeDown()
-        caseTestLogCapture_error_customStack_expected()
-        app.swipeDown()
-        caseTestLogCapture_fatal_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_critical_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_withProperty()
-        app.swipeDown()
-        caseTestLogCapture_withNormalFileSize()
-        app.swipeDown()
-        caseTestLogCapture_withMaxFileSize()
-        app.swipeDown()
-        caseTestLogCapture_withOversizeFileSize()
-    }
 
-    func caseTestLogCapture_trace() {
+    func test_logCapture_trace() {
 
         enterCustomMessage()
 
@@ -168,7 +127,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_debug() {
+    func test_logCapture_debug() {
 
         enterCustomMessage()
 
@@ -177,7 +136,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_info() {
+    func test_logCapture_info() {
 
         enterCustomMessage()
 
@@ -186,7 +145,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_warn() {
+    func test_logCapture_warn() {
 
         enterCustomMessage()
 
@@ -195,7 +154,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_error() {
+    func test_logCapture_error() {
 
         enterCustomMessage()
 
@@ -204,7 +163,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_fatal() {
+    func test_logCapture_fatal() {
 
         enterCustomMessage()
 
@@ -213,7 +172,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_critical() {
+    func test_logCapture_critical() {
 
         enterCustomMessage()
 
@@ -224,7 +183,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
 
     /// No Stack Trace
 
-    func caseTestLogCapture_warn_noStack() {
+    func test_logCapture_warn_noStack() {
 
         enterCustomMessage()
 
@@ -233,7 +192,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_error_noStack() {
+    func test_logCapture_error_noStack() {
 
         enterCustomMessage()
 
@@ -253,7 +212,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         ])
     }
 
-    func caseTestLogCapture_trace_customStack_notExpected() {
+    func test_logCapture_trace_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.trace)
@@ -262,7 +221,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_debug_customStack_notExpected() {
+    func test_logCapture_debug_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.debug)
@@ -271,7 +230,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_info_customStack_notExpected() {
+    func test_logCapture_info_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.info)
@@ -280,7 +239,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_warn_customStack_expected() {
+    func test_logCapture_warn_customStack_expected() {
         enterCustomMessage()
 
         selectSeverityButton(.warn)
@@ -289,7 +248,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_error_customStack_expected() {
+    func test_logCapture_error_customStack_expected() {
         enterCustomMessage()
 
         selectSeverityButton(.error)
@@ -298,7 +257,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_fatal_customStack_notExpected() {
+    func test_logCapture_fatal_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.fatal)
@@ -307,7 +266,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_critical_customStack_notExpected() {
+    func test_logCapture_critical_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.critical)
@@ -318,7 +277,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
 
     /// Adding a property
 
-    func caseTestLogCapture_withProperty() {
+    func test_logCapture_withProperty() {
 
         enterCustomMessage()
         selectSeverityButton(.warn)
@@ -328,7 +287,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeKeyTextField))
         logMessageAttributeKeyTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageAttributeKeyTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageAttributeKeyTextField.typeText(
             String(
@@ -343,7 +302,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeValueTextField))
         logMessageAttributeValueTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageAttributeValueTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageAttributeValueTextField.typeText(
             String(
@@ -363,7 +322,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
 
     /// File Attachment
 
-    func caseTestLogCapture_withNormalFileSize() {
+    func test_logCapture_withNormalFileSize() {
         enterCustomMessage()
         setAttachmentEnabled(true)
         setAttachmentSize(.safe)
@@ -371,7 +330,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_withMaxFileSize() {
+    func test_logCapture_withMaxFileSize() {
         enterCustomMessage()
         setAttachmentEnabled(true)
         setAttachmentSize(.maxAllowed)
@@ -379,7 +338,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_withOversizeFileSize() {
+    func test_logCapture_withOversizeFileSize() {
         enterCustomMessage()
         setAttachmentEnabled(true)
         setAttachmentSize(.overMaxAllowed)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
@@ -30,7 +30,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(urlTextField))
         urlTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: urlTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         urlTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (urlTextField.value as? String ?? "").count))
@@ -45,7 +45,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(apiTextField))
         apiTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: apiTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         apiTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (apiTextField.value as? String ?? "").count))
@@ -65,7 +65,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(bodyKeyTextField))
         bodyKeyTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: bodyKeyTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         bodyKeyTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyKeyTextField.value as? String ?? "").count))
@@ -78,7 +78,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(bodyValueTextField))
         bodyValueTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: bodyValueTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         bodyValueTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyValueTextField.value as? String ?? "").count)
@@ -102,24 +102,15 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         evaluateTestResults(app)
     }
 
-    func testAllNetworkingCases() {
-        castTestGetRequest()
-        app.swipeDown()
-        castTestPostRequest()
-        app.swipeDown()
-        castTestPutRequest()
-        app.swipeDown()
-        castTestDeleteRequest()
-    }
 
-    func castTestGetRequest() {
+    func test_getRequest() {
         enterURL(embraceURL)
         selectRequestMethod(.get)
 
         runNetworkTest()
     }
 
-    func castTestPostRequest() {
+    func test_postRequest() {
         enterURL(reqresURL)
         enterAPI(reqresUsersAPI)
         selectRequestMethod(.post)
@@ -129,7 +120,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         runNetworkTest()
     }
 
-    func castTestPutRequest() {
+    func test_putRequest() {
         enterURL(reqresURL)
         enterAPI("\(reqresUsersAPI)/1234")
         selectRequestMethod(.put)
@@ -139,7 +130,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         runNetworkTest()
     }
 
-    func castTestDeleteRequest() {
+    func test_deleteRequest() {
         enterURL(reqresURL)
         enterAPI("\(reqresUsersAPI)/1234")
         selectRequestMethod(.delete)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
@@ -18,7 +18,11 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
 
     private func backgroundAndReopenApp() {
         XCUIDevice.shared.press(XCUIDevice.Button.home)
-        sleep(5)
+        let backgrounded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningBackground.rawValue),
+            object: app)
+        let result = XCTWaiter.wait(for: [backgrounded], timeout: 10)
+        XCTAssertEqual(result, .completed, "app didn't background in 10s")
         app.activate()
     }
 
@@ -62,7 +66,7 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(usernameTextField))
         usernameTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: usernameTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         usernameTextField.typeText("TestUsername123")
         usernameTextField.typeText(XCUIKeyboardKey.return.rawValue)
@@ -73,7 +77,7 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(emailTextField))
         emailTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: emailTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         emailTextField.typeText("Some@Email.com")
         emailTextField.typeText(XCUIKeyboardKey.return.rawValue)
@@ -84,14 +88,13 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(identifierTextField))
         identifierTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: identifierTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         identifierTextField.typeText("ABCD1234")
         identifierTextField.typeText(XCUIKeyboardKey.return.rawValue)
     }
 
     func testSendFinishedSessionSpan() {
-        sleep(5)
         backgroundAndReopenApp()
         XCTAssertTrue(runSessionSpanTest(), "Test Button wait for enabled timed out")
 
@@ -100,7 +103,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
 
     func testSendFinishedSessionSpan_withPersona() {
         addPersona()
-        sleep(5)
         backgroundAndReopenApp()
         XCTAssertTrue(runSessionSpanTest(), "Test Button wait for enabled timed out")
 
@@ -109,7 +111,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
 
     func testSendFinishedSessionSpan_withUserInfo() {
         addUserInfo()
-        sleep(5)
         backgroundAndReopenApp()
         XCTAssertTrue(runSessionSpanTest(), "Test Button wait for enabled timed out")
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests.swift
@@ -18,7 +18,11 @@ final class EmbraceIOTestSessionSpanUITests: XCTestCase {
 
     private func backgroundAndReopenApp() {
         XCUIDevice.shared.press(XCUIDevice.Button.home)
-        sleep(5)
+        let backgrounded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningBackground.rawValue),
+            object: app)
+        let result = XCTWaiter.wait(for: [backgrounded], timeout: 10)
+        XCTAssertEqual(result, .completed, "app didn't background in 10s")
         app.activate()
     }
 
@@ -31,7 +35,9 @@ final class EmbraceIOTestSessionSpanUITests: XCTestCase {
 
     func testSendFinishedSessionSpan() {
         runSessionSpanTest()
-        sleep(5)
+        // Brief pause to let the SDK record the span before the session ends on background.
+        // TODO: replace with a UI signal once the app exposes span-written state.
+        sleep(2)
         backgroundAndReopenApp()
         evaluateTestResults(app)
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestStartupUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestStartupUITests.swift
@@ -57,67 +57,48 @@ final class EmbraceIOTestWARMStartupUITests: XCTestCase {
         button.tap()
     }
 
-    func testAllWarmStartupCases() {
-        caseTestInitStartup_PreMain_Span()
-        app.swipeDown()
-        caseTestInitStartup_SDKSetup_Span()
-        app.swipeDown()
-        caseTestInitStartup_SDKSetart_Span()
-        app.swipeDown()
-        caseTestInitStartup_StartProcess_Span()
-        app.swipeDown()
-        caseTestInitStartup_StartState_Warm_Span()
-        app.swipeDown()
-        caseTestInitStartup_ProcessLaunch_Span()
-        app.swipeDown()
-        caseTestInitStartup_AppStartup_Span()
-        app.swipeDown()
-        caseTestInitStartup_FirstFrameCapture_Span()
-        app.swipeDown()
-        caseTestInitStartup_MetadataItems()
-    }
 
-    func caseTestInitStartup_PreMain_Span() {
+    func test_initStartup_PreMain_Span() {
         selectMetadataTest(.startProcess)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_SDKSetup_Span() {
+    func test_initStartup_SDKSetup_Span() {
         selectMetadataTest(.sdkSetup)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_SDKSetart_Span() {
+    func test_initStartup_SDKSetart_Span() {
         selectMetadataTest(.sdkStart)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_StartProcess_Span() {
+    func test_initStartup_StartProcess_Span() {
         selectMetadataTest(.startProcess)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_StartState_Warm_Span() {
+    func test_initStartup_StartState_Warm_Span() {
         selectMetadataTest(.startState)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_ProcessLaunch_Span() {
+    func test_initStartup_ProcessLaunch_Span() {
         selectMetadataTest(.processLaunch)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_AppStartup_Span() {
+    func test_initStartup_AppStartup_Span() {
         selectMetadataTest(.appStartup)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_FirstFrameCapture_Span() {
+    func test_initStartup_FirstFrameCapture_Span() {
         selectMetadataTest(.firstFrameCapture)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_MetadataItems() {
+    func test_initStartup_MetadataItems() {
         selectMetadataTest(.resourceMetadata)
         evaluateTestResults(app)
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
@@ -20,38 +20,23 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
 
     }
 
-    func testAllSwiftUICases() {
-        caseManualCapture()
-        app.swipeDown()
-        caseManualCapture_ContentComplete()
-        app.swipeDown()
-        caseManualCapture_AddProperty()
-        app.swipeDown()
-        caseMacroCapture()
-        app.swipeDown()
-        caseEmbraceTraceViewCapture()
-        app.swipeDown()
-        caseEmbraceTraceViewCapture_ContentComplete()
-        app.swipeDown()
-        caseEmbraceTraceViewCapture_AddProperty()
-    }
 
     /// Manual Capture
-    func caseManualCapture() {
+    func test_manualCapture() {
         toggle("manualCaptureContentComplete", value: false)
         runTest("swiftUIViewManualCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseManualCapture_ContentComplete() {
+    func test_manualCapture_ContentComplete() {
         toggle("manualCaptureContentComplete", value: true)
         runTest("swiftUIViewManualCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseManualCapture_AddProperty() {
+    func test_manualCapture_AddProperty() {
         addManualCaptureProperty(key: "someKey", value: "someValue")
         runTest("swiftUIViewManualCaptureTestButton")
 
@@ -60,28 +45,28 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
 
     /// Macro Capture
 
-    func caseMacroCapture() {
+    func test_macroCapture() {
         runTest("swiftUIViewMacroCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
     /// Embrace Trace View Capture
-    func caseEmbraceTraceViewCapture() {
+    func test_embraceTraceViewCapture() {
         toggle("embraceTraceViewCaptureContentComplete", value: false)
         runTest("swiftUIEmbraceTraceViewCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseEmbraceTraceViewCapture_ContentComplete() {
+    func test_embraceTraceViewCapture_ContentComplete() {
         toggle("embraceTraceViewCaptureContentComplete", value: true)
         runTest("swiftUIEmbraceTraceViewCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseEmbraceTraceViewCapture_AddProperty() {
+    func test_embraceTraceViewCapture_AddProperty() {
         addEmbraceTraceViewCaptureProperty(key: "someKey", value: "someValue")
         runTest("swiftUIEmbraceTraceViewCaptureTestButton")
 
@@ -122,7 +107,7 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeKeyTextField))
         logMessageAttributeKeyTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageAttributeKeyTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageAttributeKeyTextField.typeText(
             String(
@@ -137,7 +122,7 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeValueTextField))
         logMessageAttributeValueTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageAttributeValueTextField)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageAttributeValueTextField.typeText(
             String(


### PR DESCRIPTION
First of a stack of PRs improving the UI Tests App workflow's runtime and signal.

## Summary

- Add `concurrency:` group on workflow + ref with `cancel-in-progress: true`.
  - Stops superseded runs cleanly when a newer commit lands instead of letting old runs grind to the full job timeout.
- Bump `timeout-minutes: 60 → 90`.
  - Temporary headroom so the first instrumented run can actually complete and produce diagnostic data. Will tighten back down once test runtime is under control.
- Replace `set -e && xcodebuild ... | xcbeautify && exit ${PIPESTATUS[0]}` with `set -o pipefail`, tee the raw `xcodebuild` stream to `build/xcodebuild.log`, and prefix each line with `[HH:MM:SS]` via awk.
  - Past cancelled runs had a 9+ minute gap with no log output — xcbeautify swallows xcodebuild's per-test events and xcodebuild itself is silent during sim boot/install. A timestamped raw log makes the dead air locatable.
- Switch xcbeautify to `--renderer github-actions`.
  - Test failures render as inline PR annotations; suites collapse cleanly in the Actions UI.
- Add an `if: always()` `actions/upload-artifact` step for `build/xcodebuild.log`.
  - Raw log survives cancel/timeout, not just failure.
- Change the existing xcresult upload from `if: failure()` to `if: always()`.
  - Result bundle is available on green runs and cancels for offline timing analysis.

## Why

UI test runs on `main` have been cancelled on essentially every push, with no diagnostic log surviving the cancel. This PR doesn't fix the underlying perf — it makes the perf-fix work in subsequent PRs in this stack visible and actionable.

xcodebuild args themselves (`-retry-tests-on-failure -test-iterations 3`, `-parallel-testing-enabled NO`, etc.) are unchanged in this PR. Tightening those is the subject of the next PR in the stack.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
