### PR TITLE
[EMBR-12138] Chore: UI Tests: replace focus helper with keyboard-readiness wait

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   run-ui-tests-app:
-    timeout-minutes: 90
+    timeout-minutes: 30
     runs-on: [macos-15]
     strategy:
       fail-fast: false
@@ -24,6 +24,17 @@ jobs:
         xcode_version: ["26.0"]
         device:
           - "iPhone 16 Pro"
+        test_group:
+          - name: startup
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestWARMStartupUITests,EmbraceIOTestAppUITests/EmbraceIOTestCOLDStartupUITests"
+          - name: logs
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests"
+          - name: networking
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests"
+          - name: session
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests,EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads"
+          - name: views
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI,EmbraceIOTestAppUITests/EmbraceIOTestViewUITests"
     permissions:
       checks: write
 
@@ -64,12 +75,13 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
 
-      - name: Run UI Tests
+      - name: Run UI Tests (${{ matrix.test_group.name }})
         env:
           IS_XCTEST: true
         run: |
           set -o pipefail
           mkdir -p build
+          IFS=',' read -ra FILTERS <<< "${{ matrix.test_group.filter }}"
           xcodebuild \
             -project "./Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj" \
             -scheme "EmbraceIOTestApp" \
@@ -80,6 +92,7 @@ jobs:
             -test-timeouts-enabled YES \
             -default-test-execution-time-allowance 60 \
             -maximum-test-execution-time-allowance 180 \
+            "${FILTERS[@]/#/-only-testing:}" \
             test 2>&1 \
             | tee >(awk '{ printf "[%s] %s\n", strftime("%H:%M:%S"), $0; fflush() }' > build/xcodebuild.log) \
             | xcbeautify --renderer github-actions
@@ -88,12 +101,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: xcodebuild_log
+          name: xcodebuild_log_${{ matrix.test_group.name }}
           path: build/xcodebuild.log
 
       - name: Upload xcresult Bundle Manually
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: output_xcresult
+          name: output_xcresult_${{ matrix.test_group.name }}
           path: .build/test/output.xcresult

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/Common/Extensions.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/Common/Extensions.swift
@@ -48,25 +48,6 @@ extension XCUIElement {
 }
 
 extension XCTestCase {
-    func waitUntilElementHasFocus(
-        element: XCUIElement, timeout: TimeInterval = 600, file: StaticString = #file, line: UInt = #line
-    ) -> XCUIElement {
-        let expectation = expectation(description: "waiting for element \(element) to have focus")
-
-        let timer = Timer(timeInterval: 1, repeats: true) { timer in
-            guard element.hasFocus else { return }
-
-            expectation.fulfill()
-            timer.invalidate()
-        }
-
-        RunLoop.current.add(timer, forMode: .common)
-
-        wait(for: [expectation], timeout: timeout)
-
-        return element
-    }
-
     func waitUntilElementIsEnabled(element: XCUIElement, timeout: TimeInterval = 600, file: StaticString = #file, line: UInt = #line) -> XCUIElement {
         let expectation = expectation(description: "waiting for element \(element) to be enabled")
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
@@ -26,8 +26,6 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageTextField))
         logMessageTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageTextField)
-
         logMessageTextField.typeText(
             String(
                 repeating: XCUIKeyboardKey.delete.rawValue, count: (logMessageTextField.value as? String ?? "").count))
@@ -328,8 +326,6 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeKeyTextField))
         logMessageAttributeKeyTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageAttributeKeyTextField)
-
         logMessageAttributeKeyTextField.typeText(
             String(
                 repeating: XCUIKeyboardKey.delete.rawValue,
@@ -342,8 +338,6 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(logMessageAttributeValueTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeValueTextField))
         logMessageAttributeValueTextField.tap()
-
-        _ = waitUntilElementHasFocus(element: logMessageAttributeValueTextField)
 
         logMessageAttributeValueTextField.typeText(
             String(

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
@@ -26,6 +26,8 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageTextField))
         logMessageTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         logMessageTextField.typeText(
             String(
                 repeating: XCUIKeyboardKey.delete.rawValue, count: (logMessageTextField.value as? String ?? "").count))
@@ -326,6 +328,8 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeKeyTextField))
         logMessageAttributeKeyTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         logMessageAttributeKeyTextField.typeText(
             String(
                 repeating: XCUIKeyboardKey.delete.rawValue,
@@ -338,6 +342,8 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         XCTAssertTrue(logMessageAttributeValueTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeValueTextField))
         logMessageAttributeValueTextField.tap()
+
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageAttributeValueTextField.typeText(
             String(

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests.swift
@@ -117,49 +117,8 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         evaluateTestResults(app)
     }
 
-    func testAllLogCases() {
-        caseTestLogCapture_trace()
-        app.swipeDown()
-        caseTestLogCapture_debug()
-        app.swipeDown()
-        caseTestLogCapture_info()
-        app.swipeDown()
-        caseTestLogCapture_warn()
-        app.swipeDown()
-        caseTestLogCapture_error()
-        app.swipeDown()
-        caseTestLogCapture_fatal()
-        app.swipeDown()
-        caseTestLogCapture_critical()
-        app.swipeDown()
-        caseTestLogCapture_warn_noStack()
-        app.swipeDown()
-        caseTestLogCapture_error_noStack()
-        app.swipeDown()
-        caseTestLogCapture_trace_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_debug_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_info_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_warn_customStack_expected()
-        app.swipeDown()
-        caseTestLogCapture_error_customStack_expected()
-        app.swipeDown()
-        caseTestLogCapture_fatal_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_critical_customStack_notExpected()
-        app.swipeDown()
-        caseTestLogCapture_withProperty()
-        app.swipeDown()
-        caseTestLogCapture_withNormalFileSize()
-        app.swipeDown()
-        caseTestLogCapture_withMaxFileSize()
-        app.swipeDown()
-        caseTestLogCapture_withOversizeFileSize()
-    }
 
-    func caseTestLogCapture_trace() {
+    func test_logCapture_trace() {
 
         enterCustomMessage()
 
@@ -168,7 +127,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_debug() {
+    func test_logCapture_debug() {
 
         enterCustomMessage()
 
@@ -177,7 +136,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_info() {
+    func test_logCapture_info() {
 
         enterCustomMessage()
 
@@ -186,7 +145,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_warn() {
+    func test_logCapture_warn() {
 
         enterCustomMessage()
 
@@ -195,7 +154,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_error() {
+    func test_logCapture_error() {
 
         enterCustomMessage()
 
@@ -204,7 +163,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_fatal() {
+    func test_logCapture_fatal() {
 
         enterCustomMessage()
 
@@ -213,7 +172,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_critical() {
+    func test_logCapture_critical() {
 
         enterCustomMessage()
 
@@ -224,7 +183,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
 
     /// No Stack Trace
 
-    func caseTestLogCapture_warn_noStack() {
+    func test_logCapture_warn_noStack() {
 
         enterCustomMessage()
 
@@ -233,7 +192,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_error_noStack() {
+    func test_logCapture_error_noStack() {
 
         enterCustomMessage()
 
@@ -253,7 +212,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         ])
     }
 
-    func caseTestLogCapture_trace_customStack_notExpected() {
+    func test_logCapture_trace_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.trace)
@@ -262,7 +221,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_debug_customStack_notExpected() {
+    func test_logCapture_debug_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.debug)
@@ -271,7 +230,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_info_customStack_notExpected() {
+    func test_logCapture_info_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.info)
@@ -280,7 +239,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_warn_customStack_expected() {
+    func test_logCapture_warn_customStack_expected() {
         enterCustomMessage()
 
         selectSeverityButton(.warn)
@@ -289,7 +248,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_error_customStack_expected() {
+    func test_logCapture_error_customStack_expected() {
         enterCustomMessage()
 
         selectSeverityButton(.error)
@@ -298,7 +257,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_fatal_customStack_notExpected() {
+    func test_logCapture_fatal_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.fatal)
@@ -307,7 +266,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_critical_customStack_notExpected() {
+    func test_logCapture_critical_customStack_notExpected() {
         enterCustomMessage()
 
         selectSeverityButton(.critical)
@@ -318,7 +277,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
 
     /// Adding a property
 
-    func caseTestLogCapture_withProperty() {
+    func test_logCapture_withProperty() {
 
         enterCustomMessage()
         selectSeverityButton(.warn)
@@ -363,7 +322,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
 
     /// File Attachment
 
-    func caseTestLogCapture_withNormalFileSize() {
+    func test_logCapture_withNormalFileSize() {
         enterCustomMessage()
         setAttachmentEnabled(true)
         setAttachmentSize(.safe)
@@ -371,7 +330,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_withMaxFileSize() {
+    func test_logCapture_withMaxFileSize() {
         enterCustomMessage()
         setAttachmentEnabled(true)
         setAttachmentSize(.maxAllowed)
@@ -379,7 +338,7 @@ final class EmbraceIOTestLogsUITests: XCTestCase {
         runLogTest()
     }
 
-    func caseTestLogCapture_withOversizeFileSize() {
+    func test_logCapture_withOversizeFileSize() {
         enterCustomMessage()
         setAttachmentEnabled(true)
         setAttachmentSize(.overMaxAllowed)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
@@ -102,24 +102,15 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         evaluateTestResults(app)
     }
 
-    func testAllNetworkingCases() {
-        castTestGetRequest()
-        app.swipeDown()
-        castTestPostRequest()
-        app.swipeDown()
-        castTestPutRequest()
-        app.swipeDown()
-        castTestDeleteRequest()
-    }
 
-    func castTestGetRequest() {
+    func test_getRequest() {
         enterURL(embraceURL)
         selectRequestMethod(.get)
 
         runNetworkTest()
     }
 
-    func castTestPostRequest() {
+    func test_postRequest() {
         enterURL(reqresURL)
         enterAPI(reqresUsersAPI)
         selectRequestMethod(.post)
@@ -129,7 +120,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         runNetworkTest()
     }
 
-    func castTestPutRequest() {
+    func test_putRequest() {
         enterURL(reqresURL)
         enterAPI("\(reqresUsersAPI)/1234")
         selectRequestMethod(.put)
@@ -139,7 +130,7 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         runNetworkTest()
     }
 
-    func castTestDeleteRequest() {
+    func test_deleteRequest() {
         enterURL(reqresURL)
         enterAPI("\(reqresUsersAPI)/1234")
         selectRequestMethod(.delete)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
@@ -30,8 +30,6 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(urlTextField))
         urlTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: urlTextField)
-
         urlTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (urlTextField.value as? String ?? "").count))
 
@@ -44,8 +42,6 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(apiTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(apiTextField))
         apiTextField.tap()
-
-        _ = waitUntilElementHasFocus(element: apiTextField)
 
         apiTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (apiTextField.value as? String ?? "").count))
@@ -65,8 +61,6 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(bodyKeyTextField))
         bodyKeyTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: bodyKeyTextField)
-
         bodyKeyTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyKeyTextField.value as? String ?? "").count))
 
@@ -77,8 +71,6 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(bodyValueTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(bodyValueTextField))
         bodyValueTextField.tap()
-
-        _ = waitUntilElementHasFocus(element: bodyValueTextField)
 
         bodyValueTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyValueTextField.value as? String ?? "").count)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests.swift
@@ -30,6 +30,8 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(urlTextField))
         urlTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         urlTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (urlTextField.value as? String ?? "").count))
 
@@ -42,6 +44,8 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(apiTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(apiTextField))
         apiTextField.tap()
+
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         apiTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (apiTextField.value as? String ?? "").count))
@@ -61,6 +65,8 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(bodyKeyTextField))
         bodyKeyTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         bodyKeyTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyKeyTextField.value as? String ?? "").count))
 
@@ -71,6 +77,8 @@ final class EmbraceIOTestNetworkingUITests: XCTestCase {
         XCTAssertTrue(bodyValueTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(bodyValueTextField))
         bodyValueTextField.tap()
+
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         bodyValueTextField.typeText(
             String(repeating: XCUIKeyboardKey.delete.rawValue, count: (bodyValueTextField.value as? String ?? "").count)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
@@ -62,8 +62,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(usernameTextField))
         usernameTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: usernameTextField)
-
         usernameTextField.typeText("TestUsername123")
         usernameTextField.typeText(XCUIKeyboardKey.return.rawValue)
 
@@ -73,8 +71,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(emailTextField))
         emailTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: emailTextField)
-
         emailTextField.typeText("Some@Email.com")
         emailTextField.typeText(XCUIKeyboardKey.return.rawValue)
 
@@ -83,8 +79,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(identifierTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(identifierTextField))
         identifierTextField.tap()
-
-        _ = waitUntilElementHasFocus(element: identifierTextField)
 
         identifierTextField.typeText("ABCD1234")
         identifierTextField.typeText(XCUIKeyboardKey.return.rawValue)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
@@ -62,6 +62,8 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(usernameTextField))
         usernameTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         usernameTextField.typeText("TestUsername123")
         usernameTextField.typeText(XCUIKeyboardKey.return.rawValue)
 
@@ -71,6 +73,8 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(emailTextField))
         emailTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         emailTextField.typeText("Some@Email.com")
         emailTextField.typeText(XCUIKeyboardKey.return.rawValue)
 
@@ -79,6 +83,8 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
         XCTAssertTrue(identifierTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(identifierTextField))
         identifierTextField.tap()
+
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         identifierTextField.typeText("ABCD1234")
         identifierTextField.typeText(XCUIKeyboardKey.return.rawValue)

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads.swift
@@ -18,7 +18,11 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
 
     private func backgroundAndReopenApp() {
         XCUIDevice.shared.press(XCUIDevice.Button.home)
-        sleep(5)
+        let backgrounded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningBackground.rawValue),
+            object: app)
+        let result = XCTWaiter.wait(for: [backgrounded], timeout: 10)
+        XCTAssertEqual(result, .completed, "app didn't background in 10s")
         app.activate()
     }
 
@@ -91,7 +95,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
     }
 
     func testSendFinishedSessionSpan() {
-        sleep(5)
         backgroundAndReopenApp()
         XCTAssertTrue(runSessionSpanTest(), "Test Button wait for enabled timed out")
 
@@ -100,7 +103,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
 
     func testSendFinishedSessionSpan_withPersona() {
         addPersona()
-        sleep(5)
         backgroundAndReopenApp()
         XCTAssertTrue(runSessionSpanTest(), "Test Button wait for enabled timed out")
 
@@ -109,7 +111,6 @@ final class EmbraceIOTestPostedPayloads: XCTestCase {
 
     func testSendFinishedSessionSpan_withUserInfo() {
         addUserInfo()
-        sleep(5)
         backgroundAndReopenApp()
         XCTAssertTrue(runSessionSpanTest(), "Test Button wait for enabled timed out")
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests.swift
@@ -18,7 +18,11 @@ final class EmbraceIOTestSessionSpanUITests: XCTestCase {
 
     private func backgroundAndReopenApp() {
         XCUIDevice.shared.press(XCUIDevice.Button.home)
-        sleep(5)
+        let backgrounded = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningBackground.rawValue),
+            object: app)
+        let result = XCTWaiter.wait(for: [backgrounded], timeout: 10)
+        XCTAssertEqual(result, .completed, "app didn't background in 10s")
         app.activate()
     }
 
@@ -31,7 +35,9 @@ final class EmbraceIOTestSessionSpanUITests: XCTestCase {
 
     func testSendFinishedSessionSpan() {
         runSessionSpanTest()
-        sleep(5)
+        // Brief pause to let the SDK record the span before the session ends on background.
+        // TODO: replace with a UI signal once the app exposes span-written state.
+        sleep(2)
         backgroundAndReopenApp()
         evaluateTestResults(app)
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestStartupUITests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestStartupUITests.swift
@@ -57,67 +57,48 @@ final class EmbraceIOTestWARMStartupUITests: XCTestCase {
         button.tap()
     }
 
-    func testAllWarmStartupCases() {
-        caseTestInitStartup_PreMain_Span()
-        app.swipeDown()
-        caseTestInitStartup_SDKSetup_Span()
-        app.swipeDown()
-        caseTestInitStartup_SDKSetart_Span()
-        app.swipeDown()
-        caseTestInitStartup_StartProcess_Span()
-        app.swipeDown()
-        caseTestInitStartup_StartState_Warm_Span()
-        app.swipeDown()
-        caseTestInitStartup_ProcessLaunch_Span()
-        app.swipeDown()
-        caseTestInitStartup_AppStartup_Span()
-        app.swipeDown()
-        caseTestInitStartup_FirstFrameCapture_Span()
-        app.swipeDown()
-        caseTestInitStartup_MetadataItems()
-    }
 
-    func caseTestInitStartup_PreMain_Span() {
+    func test_initStartup_PreMain_Span() {
         selectMetadataTest(.startProcess)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_SDKSetup_Span() {
+    func test_initStartup_SDKSetup_Span() {
         selectMetadataTest(.sdkSetup)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_SDKSetart_Span() {
+    func test_initStartup_SDKSetart_Span() {
         selectMetadataTest(.sdkStart)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_StartProcess_Span() {
+    func test_initStartup_StartProcess_Span() {
         selectMetadataTest(.startProcess)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_StartState_Warm_Span() {
+    func test_initStartup_StartState_Warm_Span() {
         selectMetadataTest(.startState)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_ProcessLaunch_Span() {
+    func test_initStartup_ProcessLaunch_Span() {
         selectMetadataTest(.processLaunch)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_AppStartup_Span() {
+    func test_initStartup_AppStartup_Span() {
         selectMetadataTest(.appStartup)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_FirstFrameCapture_Span() {
+    func test_initStartup_FirstFrameCapture_Span() {
         selectMetadataTest(.firstFrameCapture)
         evaluateTestResults(app)
     }
 
-    func caseTestInitStartup_MetadataItems() {
+    func test_initStartup_MetadataItems() {
         selectMetadataTest(.resourceMetadata)
         evaluateTestResults(app)
     }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
@@ -20,38 +20,23 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
 
     }
 
-    func testAllSwiftUICases() {
-        caseManualCapture()
-        app.swipeDown()
-        caseManualCapture_ContentComplete()
-        app.swipeDown()
-        caseManualCapture_AddProperty()
-        app.swipeDown()
-        caseMacroCapture()
-        app.swipeDown()
-        caseEmbraceTraceViewCapture()
-        app.swipeDown()
-        caseEmbraceTraceViewCapture_ContentComplete()
-        app.swipeDown()
-        caseEmbraceTraceViewCapture_AddProperty()
-    }
 
     /// Manual Capture
-    func caseManualCapture() {
+    func test_manualCapture() {
         toggle("manualCaptureContentComplete", value: false)
         runTest("swiftUIViewManualCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseManualCapture_ContentComplete() {
+    func test_manualCapture_ContentComplete() {
         toggle("manualCaptureContentComplete", value: true)
         runTest("swiftUIViewManualCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseManualCapture_AddProperty() {
+    func test_manualCapture_AddProperty() {
         addManualCaptureProperty(key: "someKey", value: "someValue")
         runTest("swiftUIViewManualCaptureTestButton")
 
@@ -60,28 +45,28 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
 
     /// Macro Capture
 
-    func caseMacroCapture() {
+    func test_macroCapture() {
         runTest("swiftUIViewMacroCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
     /// Embrace Trace View Capture
-    func caseEmbraceTraceViewCapture() {
+    func test_embraceTraceViewCapture() {
         toggle("embraceTraceViewCaptureContentComplete", value: false)
         runTest("swiftUIEmbraceTraceViewCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseEmbraceTraceViewCapture_ContentComplete() {
+    func test_embraceTraceViewCapture_ContentComplete() {
         toggle("embraceTraceViewCaptureContentComplete", value: true)
         runTest("swiftUIEmbraceTraceViewCaptureTestButton")
 
         evaluateTestResults(app)
     }
 
-    func caseEmbraceTraceViewCapture_AddProperty() {
+    func test_embraceTraceViewCapture_AddProperty() {
         addEmbraceTraceViewCaptureProperty(key: "someKey", value: "someValue")
         runTest("swiftUIEmbraceTraceViewCaptureTestButton")
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
@@ -122,8 +122,6 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeKeyTextField))
         logMessageAttributeKeyTextField.tap()
 
-        _ = waitUntilElementHasFocus(element: logMessageAttributeKeyTextField)
-
         logMessageAttributeKeyTextField.typeText(
             String(
                 repeating: XCUIKeyboardKey.delete.rawValue,
@@ -136,8 +134,6 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
         XCTAssertTrue(logMessageAttributeValueTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeValueTextField))
         logMessageAttributeValueTextField.tap()
-
-        _ = waitUntilElementHasFocus(element: logMessageAttributeValueTextField)
 
         logMessageAttributeValueTextField.typeText(
             String(

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI.swift
@@ -122,6 +122,8 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeKeyTextField))
         logMessageAttributeKeyTextField.tap()
 
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+
         logMessageAttributeKeyTextField.typeText(
             String(
                 repeating: XCUIKeyboardKey.delete.rawValue,
@@ -134,6 +136,8 @@ final class EmbraceIOTestSwiftUI: XCTestCase {
         XCTAssertTrue(logMessageAttributeValueTextField.waitForExistence(timeout: 10))
         XCTAssertTrue(app.scrollUntilHittableElementVisible(logMessageAttributeValueTextField))
         logMessageAttributeValueTextField.tap()
+
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
 
         logMessageAttributeValueTextField.typeText(
             String(


### PR DESCRIPTION
 ## Summary

  - Delete `waitUntilElementHasFocus(element:timeout:)` from `Common/Extensions.swift`.
  - Insert `XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))` between each `tap()` and the following `typeText()` at the 12
  affected call sites:
    - `LogsUITests` (3 sites), `NetworkingUITests` (4 sites), `PostedPayloads` (3 sites), `SwiftUI` (2 sites).

  ## Why

The original helper was broken in two distinct ways:

  - Used `value(forKey: "hasKeyboardFocus")` — a private KVC key, not part of the public XCTest API. Apple doesn't expose keyboard focus as a queryable attribute on iOS, so the wait could plausibly never satisfy on a future XCTest update.
  - 600-second default timeout. Combined with the previous `-test-iterations 3` retry config, a single misbehaving field could burn 30 minutes before xcodebuild gave up. This was one contributor to the "9-minute black box" in pre-cancellation CI runs.

  But the helper was *trying* to address a real race. `XCUIElement.tap()` only guarantees the tap event was sent; the resulting focus change, keyboard appearance, and SwiftUI state propagation complete on subsequent runloop ticks — sometimes later still on busy CI simulators. Calling `typeText()` immediately after `tap()` can race the keyboard's readiness and result in dropped keystrokes. Removing the helper without a replacement would have reintroduced exactly the race the helper was guarding against.

`app.keyboards.firstMatch.waitForExistence(timeout: 5)` is the standard XCTest idiom for this. It waits for a system keyboard to actually be present (a strong proxy for "a text field has focus"), uses only public API, and has a 5-second ceiling rather than 600.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
