### PR TITLE
[EMBR-12141] Chore: CI: UI Tests parallelize via test_group matrix

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   run-ui-tests-app:
-    timeout-minutes: 90
+    timeout-minutes: 30
     runs-on: [macos-15]
     strategy:
       fail-fast: false
@@ -24,6 +24,17 @@ jobs:
         xcode_version: ["26.0"]
         device:
           - "iPhone 16 Pro"
+        test_group:
+          - name: startup
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestWARMStartupUITests,EmbraceIOTestAppUITests/EmbraceIOTestCOLDStartupUITests"
+          - name: logs
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestLogsUITests"
+          - name: networking
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestNetworkingUITests"
+          - name: session
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestSessionSpanUITests,EmbraceIOTestAppUITests/EmbraceIOTestPostedPayloads"
+          - name: views
+            filter: "EmbraceIOTestAppUITests/EmbraceIOTestSwiftUI,EmbraceIOTestAppUITests/EmbraceIOTestViewUITests"
     permissions:
       checks: write
 
@@ -64,12 +75,13 @@ jobs:
       - name: Install xcbeautify
         run: brew install xcbeautify
 
-      - name: Run UI Tests
+      - name: Run UI Tests (${{ matrix.test_group.name }})
         env:
           IS_XCTEST: true
         run: |
           set -o pipefail
           mkdir -p build
+          IFS=',' read -ra FILTERS <<< "${{ matrix.test_group.filter }}"
           xcodebuild \
             -project "./Examples/EmbraceIOTestApp/EmbraceIOTestApp.xcodeproj" \
             -scheme "EmbraceIOTestApp" \
@@ -80,6 +92,7 @@ jobs:
             -test-timeouts-enabled YES \
             -default-test-execution-time-allowance 60 \
             -maximum-test-execution-time-allowance 180 \
+            "${FILTERS[@]/#/-only-testing:}" \
             test 2>&1 \
             | tee >(awk '{ printf "[%s] %s\n", strftime("%H:%M:%S"), $0; fflush() }' > build/xcodebuild.log) \
             | xcbeautify --renderer github-actions
@@ -88,12 +101,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: xcodebuild_log
+          name: xcodebuild_log_${{ matrix.test_group.name }}
           path: build/xcodebuild.log
 
       - name: Upload xcresult Bundle Manually
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: output_xcresult
+          name: output_xcresult_${{ matrix.test_group.name }}
           path: .build/test/output.xcresult


### PR DESCRIPTION
## Summary

  - Add `test_group` axis to the job matrix with 5 entries:
    - `startup`: `WARMStartupUITests` + `COLDStartupUITests`
    - `logs`: `LogsUITests`
    - `networking`: `NetworkingUITests`
    - `session`: `SessionSpanUITests` + `PostedPayloads`
    - `views`: `SwiftUI` + `ViewUITests`
  - `Run UI Tests` step:
    - Renamed to `Run UI Tests (${{ matrix.test_group.name }})` so each parallel job is identifiable in the Actions UI.
    - Splits the comma-separated filter on `,` into a bash array and expands `"${FILTERS[@]/#/-only-testing:}"` into one `-only-testing:` xcodebuild flag per identifier.
  - Suffix both `upload-artifact` step names with `_${{ matrix.test_group.name }}` — without this, matrix jobs collide on the artifact name and the second upload of each artifact fails.
  - Drop `timeout-minutes: 90 → 30`. No group should exceed ~15 min on a healthy simulator now that prior PRs have landed.

  ## Why

  #611  made each sub-case an individually-tracked XCTest method, but all 43 methods still ran serially in one job. The slowest class set the wall-clock for the entire run. Splitting into 5 parallel groups by class affinity:

  - Wall-clock drops from `sum(group_times)` to `max(group_times)`.
  - A failure in one group doesn't block visibility into other groups (`fail-fast: false` is already set).
  - The logs group — the historical hot spot — can be tightened or split further later without churning the other groups.

  `EmbraceIOTestCrashesUITests` is intentionally not in any group. All its test methods are prefixed `disabled_`, so xcodebuild doesn't discover any tests from it; adding it to a group would create an empty parallel job.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
