### PR TITLE
[EMBR-12007] Feature: Linking SesssionController with UserSessionController

### DIFF
--- a/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
+++ b/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
@@ -23,8 +23,14 @@ public enum LastRunState: Int {
 /// These keys are intended for use with `CrashReporter.appendCrashInfo(key:value:)`
 /// and retrieval via `CrashReporter.getCrashInfo(key:)`.
 public struct CrashReporterInfoKey {
-    /// Session identifier (e.g., Embrace session id). Value should be a stable string for the lifetime of the session.
+    /// Session-part identifier. Value is the UUID of the current Embrace session part.
     static public let sessionId = "emb-sid"
+
+    /// User-session identifier. Value is the UUID of the current Embrace user session — the
+    /// logical grouping of one or more parts. Stable across foreground/background transitions
+    /// within a user session; rolls when a new user session begins.
+    static public let userSessionId = "emb-usi"
+
     /// SDK version string (e.g., "5.2.1"). Use to correlate reports with the runtime SDK build.
     static public let sdkVersion = "emb-sdk"
 }

--- a/Sources/EmbraceCommonInternal/Models/EmbraceUserSession.swift
+++ b/Sources/EmbraceCommonInternal/Models/EmbraceUserSession.swift
@@ -31,6 +31,12 @@ public protocol EmbraceUserSession {
     var id: EmbraceIdentifier { get }
     var startTime: Date { get }
     var maxDuration: TimeInterval { get }
+
+    /// Wall-clock instant at which this user session reaches its max-duration cutoff,
+    /// i.e. `startTime + maxDuration`. Stored once at construction so the comparison is a
+    /// single field read on every part-start / heartbeat check.
+    var maxEnd: Date { get }
+
     var inactivityTimeout: TimeInterval { get }
     var lastForegroundPartEnd: Date? { get }
     var partIndex: EMBInt { get }
@@ -43,6 +49,7 @@ public struct ImmutableUserSession: EmbraceUserSession {
     public let id: EmbraceIdentifier
     public let startTime: Date
     public let maxDuration: TimeInterval
+    public let maxEnd: Date
     public let inactivityTimeout: TimeInterval
     public let lastForegroundPartEnd: Date?
     public let partIndex: EMBInt
@@ -62,6 +69,7 @@ public struct ImmutableUserSession: EmbraceUserSession {
         self.id = id
         self.startTime = startTime
         self.maxDuration = maxDuration
+        self.maxEnd = startTime.addingTimeInterval(maxDuration)
         self.inactivityTimeout = inactivityTimeout
         self.lastForegroundPartEnd = lastForegroundPartEnd
         self.partIndex = partIndex

--- a/Sources/EmbraceCommonInternal/OTelBridge/EmbraceMetadataProvider.swift
+++ b/Sources/EmbraceCommonInternal/OTelBridge/EmbraceMetadataProvider.swift
@@ -11,8 +11,13 @@ import Foundation
 /// Protocol used to provide Embrace specific information to 3rd party OTel implementations
 package protocol EmbraceMetadataProvider: AnyObject {
 
-    /// Returns the identifier for the current Embrace session, if any
+    /// Returns the identifier for the current Embrace session part, if any.
+    /// Stamped on spans/logs as `emb.session_part_id`.
     var currentSessionId: EmbraceIdentifier? { get }
+
+    /// Returns the identifier for the current user session, if any.
+    /// Stamped on spans/logs as both `session.id`
+    var currentUserSessionId: EmbraceIdentifier? { get }
 
     /// Returns the identifier for the current process
     var currentProcessId: EmbraceIdentifier { get }

--- a/Sources/EmbraceCore/Capture/CaptureServices.swift
+++ b/Sources/EmbraceCore/Capture/CaptureServices.swift
@@ -104,6 +104,15 @@ final class CaptureServices {
             object: nil
         )
 
+        // Clear the crash-reporter's user-session id when the active user session ends.
+        // The next part start will repopulate it via `onSessionStart`.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onUserSessionDidEnd),
+            name: Notification.Name.embraceUserSessionDidEnd,
+            object: nil
+        )
+
         Embrace.notificationCenter.addObserver(
             self,
             selector: #selector(onConfigUpdated),
@@ -169,12 +178,17 @@ final class CaptureServices {
     @objc func onSessionStart(notification: Notification) {
         if let session = notification.object as? EmbraceSession {
             crashReporter?.currentSessionId = session.id.stringValue
+            crashReporter?.currentUserSessionId = session.userSessionId?.stringValue
         }
         for service in services { service.onSessionStart() }
     }
 
     @objc func onSessionWillEnd(notification: Notification) {
         for service in services { service.onSessionWillEnd() }
+    }
+
+    @objc func onUserSessionDidEnd(notification: Notification) {
+        crashReporter?.currentUserSessionId = nil
     }
 
     @objc func onConfigUpdated(notification: Notification) {

--- a/Sources/EmbraceCore/Crash/EmbraceCrashReporter.swift
+++ b/Sources/EmbraceCore/Crash/EmbraceCrashReporter.swift
@@ -25,7 +25,11 @@ final class EmbraceCrashReporter {
     private let signalsBlockList: [CrashSignal]
 
     struct MutableData {
-        let internalKeys: [String] = [CrashReporterInfoKey.sdkVersion, CrashReporterInfoKey.sessionId]
+        let internalKeys: [String] = [
+            CrashReporterInfoKey.sdkVersion,
+            CrashReporterInfoKey.sessionId,
+            CrashReporterInfoKey.userSessionId
+        ]
         var allowsInternalDataChange: Bool = false
     }
     private let data = EmbraceMutex(MutableData())
@@ -35,7 +39,7 @@ final class EmbraceCrashReporter {
         return reporter.basePath
     }
 
-    /// Sets the current session identifier that will be included in a crash report.
+    /// Sets the current session-part identifier that will be included in a crash report (`emb-sid`).
     var currentSessionId: String? {
         get {
             getCrashInfo(key: CrashReporterInfoKey.sessionId)
@@ -46,6 +50,22 @@ final class EmbraceCrashReporter {
                 data.withLock { $0.allowsInternalDataChange = false }
             }
             appendCrashInfo(key: CrashReporterInfoKey.sessionId, value: newValue)
+        }
+    }
+
+    /// Sets the current user-session identifier that will be included in a crash report (`emb-usi`).
+    /// A user session groups one or more parts; the value is stable across foreground/background
+    /// transitions within a user session and rolls when a new user session begins.
+    var currentUserSessionId: String? {
+        get {
+            getCrashInfo(key: CrashReporterInfoKey.userSessionId)
+        }
+        set {
+            data.withLock { $0.allowsInternalDataChange = true }
+            defer {
+                data.withLock { $0.allowsInternalDataChange = false }
+            }
+            appendCrashInfo(key: CrashReporterInfoKey.userSessionId, value: newValue)
         }
     }
 

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -401,28 +401,20 @@ package class Embrace {
         return deviceId.stringValue
     }
 
-    /// Forces the Embrace SDK to start a new session.
-    /// - Note: If there was a session running, it will be ended before starting a new one.
-    /// - Note: This method won't do anything if the SDK is stopped.
-    package func startNewSession() {
+    /// Ends the active user session. The current part is closed and a new part of the same
+    /// state is started under a fresh user session. Rate-limited to one call per 5 seconds —
+    /// subsequent calls inside that window are ignored silently.
+    /// - Note: This method has no effect if the SDK is stopped.
+    package func endUserSession() {
         guard isSDKEnabled else {
             return
         }
 
-        processingQueue.async {
-            self.sessionLifecycle.startSession()
-        }
-    }
-
-    /// Forces the Embrace SDK to stop the current session, if any.
-    /// - Note: This method won't do anything if the SDK is stopped.
-    package func endCurrentSession() {
-        guard isSDKEnabled else {
-            return
-        }
-
-        processingQueue.async {
-            self.sessionLifecycle.endSession()
+        processingQueue.async { [weak self] in
+            guard let self = self else { return }
+            let now = Date()
+            guard self.userSessionController.canManuallyEnd(now: now) else { return }
+            self.sessionController.rollPartForUserSessionExpiry(reason: .manual, at: now)
         }
     }
 

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -410,7 +410,9 @@ package class Embrace {
             return
         }
 
-        processingQueue.async { [weak self] in
+        // Dispatch onto the session-controller's serial queue so the manual roll cannot
+        // interleave with the heartbeat-driven max-duration roll, which uses the same queue.
+        sessionController.queue.async { [weak self] in
             guard let self = self else { return }
             let now = Date()
             guard self.userSessionController.canManuallyEnd(now: now) else { return }

--- a/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
+++ b/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
@@ -125,15 +125,28 @@ class EmbraceLogAttributesBuilder {
 
     @discardableResult
     func addSessionIdentifier() -> Self {
-        return addSessionIdentifier(currentSession?.id)
+        return addSessionIdentifier(
+            partId: currentSession?.id,
+            userSessionId: currentSession?.userSessionId
+        )
     }
 
     @discardableResult
     func addSessionIdentifier(_ sessionId: EmbraceIdentifier?) -> Self {
-        guard let sessionId = sessionId else {
-            return self
-        }
-        attributes[LogSemantics.keySessionId] = sessionId.stringValue
+        return addSessionIdentifier(partId: sessionId, userSessionId: currentSession?.userSessionId)
+    }
+
+    /// Stamps the three identity keys on the log. All three are always present (empty strings
+    /// when unknown) so the backend can correlate every log back to a user session/part.
+    /// `session.id` carries the user-session UUID in v7; `emb.session_part_id` carries the
+    /// part UUID (the value `session.id` had pre-v7).
+    @discardableResult
+    func addSessionIdentifier(partId: EmbraceIdentifier?, userSessionId: EmbraceIdentifier?) -> Self {
+        let userSessionValue = userSessionId?.stringValue ?? ""
+        let partValue = partId?.stringValue ?? ""
+        attributes[LogSemantics.keySessionId] = userSessionValue
+        attributes[LogSemantics.keyUserSessionId] = userSessionValue
+        attributes[LogSemantics.keyPartId] = partValue
         return self
     }
 

--- a/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
+++ b/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
@@ -37,15 +37,25 @@ extension DefaultOTelSignalsHandler: InternalOTelSignalsHandler {
         var internalAttributes = [String: EmbraceAttributeValue]()
         internalAttributes.setEmbraceType(type)
 
-        // add session id if needed
+        // Resolve the part id used for the spans-to-parts storage association. The session
+        // part span itself carries its id via `keyPartId` in `attributes` (set by
+        // `SessionSpanUtils.span`); every other span inherits the active part from the
+        // session controller.
         var sessionId: EmbraceIdentifier?
         if type == .session {
-            if let value = internalAttributes[SpanSemantics.Session.keyId] as? String {
+            if let value = sanitizedAttributes[SpanSemantics.Session.keyPartId] as? String {
                 sessionId = EmbraceIdentifier(stringValue: value)
             }
         } else {
             sessionId = sessionController?.currentSession?.id
-            internalAttributes.setEmbraceSessionId(sessionId)
+
+            // Cross-cutting attribute stamping. Every non-session-part span carries the three
+            // identity keys so backend correlation works even on spans that started before
+            // an active session existed .
+            internalAttributes.setSessionIdentity(
+                userSessionId: sessionController?.currentSession?.userSessionId?.stringValue ?? "",
+                partId: sessionId?.stringValue ?? ""
+            )
         }
 
         let finalAttributes = internalAttributes.merging(sanitizedAttributes) { (current, _) in current }
@@ -406,11 +416,14 @@ extension DefaultOTelSignalsHandler: EmbraceOTelDelegate {
 
     /// Attribute keys stamped by `EmbraceSpanProcessor.injectAttributes()` before the span
     /// reaches the delegate. These must always be preserved in storage regardless of the
-    /// attribute count limit.
+    /// attribute count limit. The three identity keys (`session.id`, `emb.user_session_id`,
+    /// `emb.session_part_id`) are protected so the cross-cutting stamping survives sanitization.
     static let bridgeProtectedKeys: Set<String> = [
         SpanSemantics.keyEmbraceType,
         SpanSemantics.Session.keyState,
-        SpanSemantics.keySessionId
+        SpanSemantics.keySessionId,
+        SpanSemantics.Session.keyUserSessionId,
+        SpanSemantics.Session.keyPartId
     ]
 
     public func onStartSpan(_ span: EmbraceSpan) {

--- a/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+MetadataProvider.swift
+++ b/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+MetadataProvider.swift
@@ -12,9 +12,14 @@ import Foundation
 // MARK: - EmbraceMetadataProvider
 extension DefaultOTelSignalsHandler: EmbraceMetadataProvider {
 
-    /// Returns the identifier for the current Embrace session, or `nil` when no session is active.
+    /// Returns the identifier for the current Embrace session part, or `nil` when no part is active.
     package var currentSessionId: EmbraceIdentifier? {
         sessionController?.currentSession?.id
+    }
+
+    /// Returns the identifier for the current user session, or `nil` when no user session is active.
+    package var currentUserSessionId: EmbraceIdentifier? {
+        sessionController?.currentSession?.userSessionId
     }
 
     /// Returns the identifier for the current process.

--- a/Sources/EmbraceCore/Internal/OTel/Dictionary+EmbraceAttributes.swift
+++ b/Sources/EmbraceCore/Internal/OTel/Dictionary+EmbraceAttributes.swift
@@ -13,7 +13,13 @@ extension Dictionary where Key == String, Value == EmbraceAttributeValue {
         self[SpanSemantics.keyEmbraceType] = type.rawValue
     }
 
-    mutating func setEmbraceSessionId(_ sessionId: EmbraceIdentifier?) {
-        self[SpanSemantics.keySessionId] = sessionId?.stringValue
+    /// Stamps the three identity keys that must appear on every span and every log:
+    /// `session.id` (= user-session UUID), `emb.user_session_id`, and `emb.session_part_id`.
+    /// All three are emitted unconditionally — empty strings when unknown — because the
+    /// backend uses the presence of `emb.session_part_id` to detect new SDKs.
+    mutating func setSessionIdentity(userSessionId: String, partId: String) {
+        self[SpanSemantics.keySessionId] = userSessionId
+        self[SpanSemantics.Session.keyUserSessionId] = userSessionId
+        self[SpanSemantics.Session.keyPartId] = partId
     }
 }

--- a/Sources/EmbraceCore/Payload/Builders/SpansPayloadBuilder.swift
+++ b/Sources/EmbraceCore/Payload/Builders/SpansPayloadBuilder.swift
@@ -85,8 +85,7 @@ class SpansPayloadBuilder {
         return SessionSpanUtils.payload(
             from: session,
             span: sessionSpan,
-            properties: customProperties,
-            sessionNumber: session.sessionNumber
+            properties: customProperties
         )
     }
 }

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -102,14 +102,19 @@ class UnsentDataHandler {
 
             var session: EmbraceSession?
 
-            // link session with crash report if possible
+            // link session with crash report if possible. The linked part is, by construction,
+            // the last part of its user session — stamp `.crash` as the termination reason so
+            // the payload's `emb.user_session_termination_reason` reflects the crash. The
+            // stamp overrides any prior end-reason (e.g. `.maxDurationReached` set by the
+            // heartbeat detector) because the crash is the authoritative cause.
             if let rawId = report.sessionId {
                 let sessionId = EmbraceIdentifier(stringValue: rawId)
                 if let fetchedSession = storage.fetchSession(id: sessionId) {
                     session = storage.updateSession(
                         session: fetchedSession,
                         endTime: report.timestamp,
-                        crashReportId: report.id.uuidString
+                        crashReportId: report.id.uuidString,
+                        userSessionTerminationReason: .crash
                     )
                 }
             }

--- a/Sources/EmbraceCore/Session/SessionControllable.swift
+++ b/Sources/EmbraceCore/Session/SessionControllable.swift
@@ -21,7 +21,16 @@ protocol SessionControllable: AnyObject {
     func startSession(state: SessionState) -> EmbraceSession?
 
     @discardableResult
+    func startSession(state: SessionState, startTime: Date) -> EmbraceSession?
+
+    @discardableResult
     func endSession() -> Date
+
+    /// Ends the current part using the supplied timestamp. Used when splitting a background
+    /// part along a user-session cutoff — the part record must close exactly at the cutoff so
+    /// the synthetic follow-up part can begin from the same instant.
+    @discardableResult
+    func endSession(at endTime: Date) -> Date
 
     func update(state: SessionState)
     func update(appTerminated: Bool)

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -99,17 +99,20 @@ class SessionController: SessionControllable {
     /// cutoff, schedules a part-roll on the upload coordination queue so the work doesn't stall
     /// the heartbeat thread. The roll closes the current part, ends the user session with
     /// `.maxDurationReached`, and starts a new part with the same state.
-    private func checkUserSessionMaxDurationExpiry(now: Date) {
-        guard let controller = userSessionController,
-            let userSession = controller.currentUserSession
-        else {
-            return
-        }
-
-        guard now >= userSession.maxEnd else { return }
-
+    ///
+    /// The expiry decision runs INSIDE the dispatched block — not before — so that two ticks
+    /// queued back-to-back can't both roll. The second block sees the state left by the first
+    /// (the freshly-rotated user session has a far-future `maxEnd`) and bails.
+    func checkUserSessionMaxDurationExpiry(now: Date) {
         queue.async { [weak self] in
-            self?.rollPartForUserSessionExpiry(reason: .maxDurationReached, at: now)
+            guard let self = self,
+                let userSession = self.userSessionController?.currentUserSession,
+                now >= userSession.maxEnd,
+                self._session.safeValue.session != nil
+            else {
+                return
+            }
+            self.rollPartForUserSessionExpiry(reason: .maxDurationReached, at: now)
         }
     }
 

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -106,8 +106,7 @@ class SessionController: SessionControllable {
             return
         }
 
-        let maxEnd = userSession.startTime.addingTimeInterval(userSession.maxDuration)
-        guard now >= maxEnd else { return }
+        guard now >= userSession.maxEnd else { return }
 
         queue.async { [weak self] in
             self?.rollPartForUserSessionExpiry(reason: .maxDurationReached, at: now)
@@ -133,9 +132,8 @@ class SessionController: SessionControllable {
             return false
         }
 
-        let maxEnd = userSession.startTime.addingTimeInterval(userSession.maxDuration)
         let inactivityCutoff = userSession.lastForegroundPartEnd?.addingTimeInterval(userSession.inactivityTimeout)
-        guard let cutoff = [maxEnd, inactivityCutoff].compactMap({ $0 }).min(),
+        guard let cutoff = [userSession.maxEnd, inactivityCutoff].compactMap({ $0 }).min(),
             now >= cutoff,
             cutoff > prev.startTime
         else {

--- a/Sources/EmbraceCore/Session/SessionController.swift
+++ b/Sources/EmbraceCore/Session/SessionController.swift
@@ -88,9 +88,78 @@ class SessionController: SessionControllable {
 
         self.heartbeat.callback = { [weak self] in
             let span = EmbraceMetricKitSpan.begin(name: "heartbeat")
-            self?.update(heartbeat: Date())
+            let now = Date()
+            self?.update(heartbeat: now)
+            self?.checkUserSessionMaxDurationExpiry(now: now)
             span.end()
         }
+    }
+
+    /// Triggered each heartbeat tick. If the active user session has crossed its max-duration
+    /// cutoff, schedules a part-roll on the upload coordination queue so the work doesn't stall
+    /// the heartbeat thread. The roll closes the current part, ends the user session with
+    /// `.maxDurationReached`, and starts a new part with the same state.
+    private func checkUserSessionMaxDurationExpiry(now: Date) {
+        guard let controller = userSessionController,
+            let userSession = controller.currentUserSession
+        else {
+            return
+        }
+
+        let maxEnd = userSession.startTime.addingTimeInterval(userSession.maxDuration)
+        guard now >= maxEnd else { return }
+
+        queue.async { [weak self] in
+            self?.rollPartForUserSessionExpiry(reason: .maxDurationReached, at: now)
+        }
+    }
+
+    /// If a foreground part is about to start after a background part whose user session
+    /// crossed its `maxDuration` or `inactivityTimeout` cutoff, slice the bg part at the
+    /// cutoff and synthesize a bg part `[cutoff, now]`. Returns `true` when the split was
+    /// applied — the caller must skip its own "end previous part" step because the prev part
+    /// is already closed.
+    @discardableResult
+    private func applyBackgroundSplitIfNeeded(
+        prev: EmbraceSession?,
+        newState: SessionState,
+        now: Date
+    ) -> Bool {
+        guard newState == .foreground,
+            let prev = prev,
+            prev.state == .background,
+            let userSession = userSessionController?.currentUserSession
+        else {
+            return false
+        }
+
+        let maxEnd = userSession.startTime.addingTimeInterval(userSession.maxDuration)
+        let inactivityCutoff = userSession.lastForegroundPartEnd?.addingTimeInterval(userSession.inactivityTimeout)
+        guard let cutoff = [maxEnd, inactivityCutoff].compactMap({ $0 }).min(),
+            now >= cutoff,
+            cutoff > prev.startTime
+        else {
+            return false
+        }
+
+        endSession(at: cutoff)
+        startSession(state: .background, startTime: cutoff)
+        endSession(at: now)
+        return true
+    }
+
+    /// Closes the current part at `now`, ends the user session with the given reason, then
+    /// starts a new part with the same `SessionState`. Used by the heartbeat-driven max-duration
+    /// detector and the manual `endUserSession()` API. The order — end-part → end-user-session
+    /// → start-part — guarantees that `attachPart` for the new part sees no active user session.
+    func rollPartForUserSessionExpiry(reason: TerminationReason, at now: Date) {
+        let info = _session.safeValue
+        let currentState = info.session?.state ?? .unknown
+        guard info.session != nil else { return }
+
+        endSession(at: now)
+        userSessionController?.endActiveUserSession(reason: reason, at: now)
+        startSession(state: currentState, startTime: now)
     }
 
     deinit {
@@ -110,10 +179,22 @@ class SessionController: SessionControllable {
     func startSession(state: SessionState, startTime: Date = Date()) -> EmbraceSession? {
         // we lock after end session to avoid a deadlock
         let inProgressSessionInfo = _session.safeValue
+
+        // Background-to-foreground transition that crosses a user-session cutoff during the
+        // bg interval: slice the bg part at the cutoff and insert a synthetic bg part
+        // [cutoff, now] so the tail is attributed to a fresh user session rather than dragging
+        // the old one into the foreground. The synthetic part runs through `attachPart`, which
+        // expires the old user session and creates a new one before the actual fg part starts.
+        let bgSplitFired = applyBackgroundSplitIfNeeded(
+            prev: inProgressSessionInfo.session,
+            newState: state,
+            now: startTime
+        )
+
         let sessionInfo: (session: EmbraceSession?, span: EmbraceSpan?) = lock.locked {
 
-            // end current session first
-            if inProgressSessionInfo.session != nil {
+            // end current session first (skipped if bg-split already closed the prev part)
+            if !bgSplitFired, inProgressSessionInfo.session != nil {
                 endSessionNoLock(inProgressSessionInfo.session, inProgressSessionInfo.sessionSpan)
             }
 
@@ -210,15 +291,19 @@ class SessionController: SessionControllable {
 
     /// Ends the session session taking into account that the lock is held externally
     @discardableResult
-    private func endSessionNoLock(_ inProgressSession: EmbraceSession?, _ inProgressSessionSpan: EmbraceSpan?) -> Date {
+    private func endSessionNoLock(
+        _ inProgressSession: EmbraceSession?,
+        _ inProgressSessionSpan: EmbraceSpan?,
+        endTime: Date? = nil
+    ) -> Date {
 
         guard let inProgressSession else {
-            return Date()
+            return endTime ?? Date()
         }
 
         // stop heartbeat
         heartbeat.stop()
-        let now = Date()
+        let now = endTime ?? Date()
 
         guard sdkStateProvider?.isEnabled == true else {
             deleteNoLock(inProgressSession)
@@ -302,6 +387,17 @@ class SessionController: SessionControllable {
         }
     }
 
+    /// Ends the session using the supplied `endTime` rather than `Date()`. Used when splitting
+    /// a background part along a user-session cutoff: the part record must close exactly at the
+    /// cutoff timestamp so the subsequent (synthetic) bg part can begin from the same instant.
+    @discardableResult
+    func endSession(at endTime: Date) -> Date {
+        let sessionInfo = _session.safeValue
+        return lock.locked {
+            endSessionNoLock(sessionInfo.session, sessionInfo.sessionSpan, endTime: endTime)
+        }
+    }
+
     func update(state: SessionState) {
         let sessionInfo = _session.safeValue
         lock.locked {
@@ -381,13 +477,16 @@ class SessionController: SessionControllable {
     /// Stamps the given termination reason on the most recently closed part record.
     ///
     /// Called by `UserSessionController` when ending a user session — the part being stamped
-    /// is, by construction, the last part of that user session.
-    ///
-    /// - Note: Currently a no-op. The storage write (looking up the just-closed part record
-    ///   and calling `storage?.updateSession(..., userSessionTerminationReason: reason)`) lands
-    ///   alongside the other end-reason wiring once the heartbeat-driven max-duration detector
-    ///   and the manual-end API exist.
+    /// is, by construction, the last part of that user session. Looks up the latest persisted
+    /// part record via storage so the call works after `endSession` has already cleared the
+    /// in-memory snapshot.
     func backfillTerminationReasonOnLatestPart(_ reason: TerminationReason) {
+        guard let storage = storage,
+            let latest = storage.fetchLatestSession()
+        else {
+            return
+        }
+        storage.updateSession(session: latest, userSessionTerminationReason: reason)
     }
 }
 

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -20,8 +20,13 @@ struct SessionSpanUtils {
         coldStart: Bool
     ) -> EmbraceSpan? {
 
+        // Note: `session.id` (== user-session UUID in v7) and `emb.user_session_id` are NOT
+        // stamped here — the user-session controller's `attachPart` runs after the span is
+        // created in `SessionController.startSession`, so those values aren't known yet.
+        // `SessionSpanUtils.payload` (the wire-format builder) emits them at upload time when
+        // the part record's `userSessionId` column is populated.
         let attributes: [String: String] = [
-            SpanSemantics.Session.keyId: id.stringValue,
+            SpanSemantics.Session.keyPartId: id.stringValue,
             SpanSemantics.Session.keyState: state.rawValue,
             SpanSemantics.Session.keyColdStart: String(coldStart)
         ]
@@ -49,10 +54,9 @@ struct SessionSpanUtils {
     static func payload(
         from session: EmbraceSession,
         span: EmbraceSpan? = nil,
-        properties: [EmbraceMetadata] = [],
-        sessionNumber: EMBInt
+        properties: [EmbraceMetadata] = []
     ) -> SpanPayload {
-        return SpanPayload(from: session, span: span, properties: properties, sessionNumber: sessionNumber)
+        return SpanPayload(from: session, span: span, properties: properties)
     }
 }
 
@@ -60,8 +64,7 @@ extension SpanPayload {
     fileprivate init(
         from session: EmbraceSession,
         span: EmbraceSpan? = nil,
-        properties: [EmbraceMetadata],
-        sessionNumber: EMBInt
+        properties: [EmbraceMetadata]
     ) {
         self.traceId = session.traceId
         self.spanId = session.spanId
@@ -72,47 +75,71 @@ extension SpanPayload {
         self.endTime =
             session.endTime?.nanosecondsSince1970Truncated ?? session.lastHeartbeatTime.nanosecondsSince1970Truncated
 
+        let userSessionIdValue = session.userSessionId?.stringValue ?? ""
+
         var attributeArray: [Attribute] = [
-            Attribute(
-                key: SpanSemantics.keyEmbraceType,
-                value: EmbraceType.session.rawValue
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyId,
-                value: session.id.stringValue
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyState,
-                value: session.state.rawValue
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyColdStart,
-                value: String(session.coldStart)
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyTerminated,
-                value: String(session.appTerminated)
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyCleanExit,
-                value: String(session.cleanExit)
-            ),
+            Attribute(key: SpanSemantics.keyEmbraceType, value: EmbraceType.session.rawValue),
+
+            // Identity. The backend uses the presence of `emb.session_part_id` to detect new
+            // SDKs, so all three keys are always emitted — empty strings when unknown (pre-v7
+            // legacy rows still in storage at upgrade time).
+            Attribute(key: SpanSemantics.Session.keyId, value: userSessionIdValue),
+            Attribute(key: SpanSemantics.Session.keyUserSessionId, value: userSessionIdValue),
+            Attribute(key: SpanSemantics.Session.keyPartId, value: session.id.stringValue),
+
+            // State
+            Attribute(key: SpanSemantics.Session.keyState, value: session.state.rawValue),
+            Attribute(key: SpanSemantics.Session.keyColdStart, value: String(session.coldStart)),
+            Attribute(key: SpanSemantics.Session.keyTerminated, value: String(session.appTerminated)),
+            Attribute(key: SpanSemantics.Session.keyCleanExit, value: String(session.cleanExit)),
             Attribute(
                 key: SpanSemantics.Session.keyHeartbeat,
                 value: String(session.lastHeartbeatTime.nanosecondsSince1970Truncated)
             ),
+
+            // Counters
             Attribute(
-                key: SpanSemantics.Session.keySessionNumber,
-                value: String(sessionNumber)
+                key: SpanSemantics.Session.keySessionPartNumber,
+                value: String(session.sessionNumber)
+            ),
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionPartIndex,
+                value: String(session.userSessionPartIndex)
+            ),
+
+            // User-session config snapshots — read from the part record, which captured them
+            // when the user session was created. Pre-v7 rows return nil/0; emit defaults.
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionStartTs,
+                value: String((session.userSessionStartTime ?? session.startTime).nanosecondsSince1970Truncated)
+            ),
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionMaxDurationSeconds,
+                value: String(Int(session.userSessionMaxDuration ?? 0))
+            ),
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionInactivityTimeoutSeconds,
+                value: String(Int(session.userSessionInactivityTimeout ?? 0))
             )
         ]
 
         if let crashId = session.crashReportId {
+            attributeArray.append(Attribute(key: SpanSemantics.Session.keyCrashId, value: crashId))
+        }
+
+        // Termination reason and final-part flag travel together — both emitted only on the
+        // last part of a terminated user session. `emb.is_final_session_part` is `"1"` when
+        // set, otherwise the key is omitted entirely.
+        if let terminationReason = session.userSessionTerminationReason {
             attributeArray.append(
                 Attribute(
-                    key: SpanSemantics.Session.keyCrashId,
-                    value: crashId
-                ))
+                    key: SpanSemantics.Session.keyUserSessionTerminationReason,
+                    value: terminationReason.rawValue
+                )
+            )
+            attributeArray.append(
+                Attribute(key: SpanSemantics.Session.keyIsFinalSessionPart, value: "1")
+            )
         }
 
         attributeArray.append(

--- a/Sources/EmbraceCore/Session/UserSessionController.swift
+++ b/Sources/EmbraceCore/Session/UserSessionController.swift
@@ -258,6 +258,9 @@ final class UserSessionController {
         if now < snapshot.startTime {
             return .clockAnomaly
         }
+        if let lastFgEnd = snapshot.lastForegroundPartEnd, now < lastFgEnd {
+            return .clockAnomaly
+        }
         if now >= snapshot.maxEnd {
             return .maxDurationReached
         }

--- a/Sources/EmbraceCore/Session/UserSessionController.swift
+++ b/Sources/EmbraceCore/Session/UserSessionController.swift
@@ -258,8 +258,7 @@ final class UserSessionController {
         if now < snapshot.startTime {
             return .clockAnomaly
         }
-        let maxEnd = snapshot.startTime.addingTimeInterval(snapshot.maxDuration)
-        if now >= maxEnd {
+        if now >= snapshot.maxEnd {
             return .maxDurationReached
         }
         if let lastFgEnd = snapshot.lastForegroundPartEnd {

--- a/Sources/EmbraceCore/Session/UserSessionController.swift
+++ b/Sources/EmbraceCore/Session/UserSessionController.swift
@@ -138,23 +138,29 @@ final class UserSessionController {
     ///   - startTime: The wall-clock start time of the new part.
     /// - Returns: The user-session snapshot the new part will belong to.
     @discardableResult
-    func attachPart(state: SessionState, startTime: Date) -> EmbraceUserSession {
-        return _state.withLock { state in
+    func attachPart(state newPartState: SessionState, startTime: Date) -> EmbraceUserSession {
+        return _state.withLock { mutableState in
 
             // No active user session -> start new one
-            guard let snapshot = state.session else {
-                return startNewUserSession(state: &state, at: startTime)
+            guard let snapshot = mutableState.session else {
+                return startNewUserSession(state: &mutableState, at: startTime)
             }
 
             // Active user session should be terminated -> end current and start new one
             if let reason = Self.expiryReason(snapshot: snapshot, at: startTime) {
                 internalEndUserSession(snapshot: snapshot, reason: reason, at: startTime)
-                return startNewUserSession(state: &state, at: startTime)
+                return startNewUserSession(state: &mutableState, at: startTime)
             }
 
-            // Active userr session still valid -> update
-            let updated = snapshot.cleared(partIndex: snapshot.partIndex + 1)
-            state.session = updated
+            // Active user session still valid -> bump part index. Only foreground parts clear
+            // the inactivity cutoff (`lastForegroundPartEnd`) — background parts must preserve
+            // it so the next foreground transition can still apply the bg-split cutoff math.
+            let nextIndex = snapshot.partIndex + 1
+            let updated =
+                newPartState == .foreground
+                ? snapshot.cleared(partIndex: nextIndex)
+                : snapshot.bumping(partIndex: nextIndex)
+            mutableState.session = updated
             return updated
         }
     }
@@ -244,18 +250,21 @@ final class UserSessionController {
     }
 
     /// Returns the termination reason if the snapshot has expired at `now`, else `nil`.
+    /// The cutoff boundaries are inclusive — a part starting exactly at the cutoff is treated
+    /// as expired so the bg-split path (which starts a synthetic part *at* the cutoff) cleanly
+    /// rolls into a new user session.
     /// Inactivity cutoff is only applicable when there is a `lastForegroundPartEnd`.
     private static func expiryReason(snapshot: ImmutableUserSession, at now: Date) -> TerminationReason? {
         if now < snapshot.startTime {
             return .clockAnomaly
         }
         let maxEnd = snapshot.startTime.addingTimeInterval(snapshot.maxDuration)
-        if now > maxEnd {
+        if now >= maxEnd {
             return .maxDurationReached
         }
         if let lastFgEnd = snapshot.lastForegroundPartEnd {
             let inactivityCutoff = lastFgEnd.addingTimeInterval(snapshot.inactivityTimeout)
-            if now > inactivityCutoff {
+            if now >= inactivityCutoff {
                 return .inactivity
             }
         }
@@ -264,8 +273,24 @@ final class UserSessionController {
 }
 
 extension ImmutableUserSession {
-    /// Clears `lastForegroundPartEnd` and bumps `partIndex`. Used when a new part joins an
-    /// existing user session: the new part start invalidates any pending inactivity cutoff
+    /// Bumps `partIndex` without touching `lastForegroundPartEnd`. Used when a background
+    /// part joins an existing user session — the inactivity cutoff must persist across the
+    /// bg interval so the next foreground-transition's split math still has it.
+    fileprivate func bumping(partIndex: EMBInt) -> ImmutableUserSession {
+        return ImmutableUserSession(
+            id: id,
+            startTime: startTime,
+            maxDuration: maxDuration,
+            inactivityTimeout: inactivityTimeout,
+            lastForegroundPartEnd: lastForegroundPartEnd,
+            partIndex: partIndex,
+            endTime: endTime,
+            terminationReason: terminationReason
+        )
+    }
+
+    /// Clears `lastForegroundPartEnd` and bumps `partIndex`. Used when a foreground part joins
+    /// an existing user session: an active fg part invalidates any pending inactivity cutoff
     /// (the cutoff only applies between foreground parts, not while one is active), and the
     /// new index reflects the part being attached.
     fileprivate func cleared(partIndex: EMBInt) -> ImmutableUserSession {

--- a/Sources/EmbraceIO/EmbraceIO.swift
+++ b/Sources/EmbraceIO/EmbraceIO.swift
@@ -108,17 +108,13 @@ public class EmbraceIO {
         try Embrace.client?.stop()
     }
 
-    /// Forces the Embrace SDK to start a new session.
-    /// - Note: If there was a session running, it will be ended before starting a new one.
-    /// - Note: This method won't do anything if the SDK is stopped.
-    public func startNewSession() {
-        Embrace.client?.startNewSession()
-    }
-
-    /// Forces the Embrace SDK to stop the current session, if any.
-    /// - Note: This method won't do anything if the SDK is stopped.
-    public func endCurrentSession() {
-        Embrace.client?.endCurrentSession()
+    /// Ends the current user session immediately. The current part is closed and a new part
+    /// (with the same foreground/background state) is started under a fresh user session.
+    /// - Note: This call is rate-limited to once per 5 seconds. Calls within 5 seconds of the
+    ///   previous one are ignored silently.
+    /// - Note: This method has no effect if the SDK is stopped.
+    public func endUserSession() {
+        Embrace.client?.endUserSession()
     }
 
     /// Call this if you want the Embrace SDK to clear the upload cache data on the next launch.

--- a/Sources/EmbraceOTelBridge/EmbraceOTelBridge.swift
+++ b/Sources/EmbraceOTelBridge/EmbraceOTelBridge.swift
@@ -263,6 +263,10 @@ extension EmbraceOTelBridge: EmbraceSpanProcessorDelegate {
     package var currentSessionId: EmbraceIdentifier? {
         metadataProvider?.currentSessionId
     }
+
+    package var currentUserSessionId: EmbraceIdentifier? {
+        metadataProvider?.currentUserSessionId
+    }
 }
 
 // MARK: - EmbraceLogProcessorDelegate

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessor.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessor.swift
@@ -43,7 +43,12 @@ class EmbraceLogProcessor: LogRecordProcessor {
         if let delegate, !delegate.isInternalLog(logRecord) {
             log.setAttribute(key: LogSemantics.keyEmbraceType, value: EmbraceType.message.rawValue)
             log.setAttribute(key: LogSemantics.keyState, value: delegate.currentSessionState.rawValue)
-            log.setAttribute(key: LogSemantics.keySessionId, value: delegate.currentSessionId?.stringValue ?? "")
+
+            let userSessionId = delegate.currentUserSessionId?.stringValue ?? ""
+            let partId = delegate.currentSessionId?.stringValue ?? ""
+            log.setAttribute(key: LogSemantics.keySessionId, value: userSessionId)
+            log.setAttribute(key: LogSemantics.keyUserSessionId, value: userSessionId)
+            log.setAttribute(key: LogSemantics.keyPartId, value: partId)
             delegate.onExternalLogEmitted(log)
         }
 

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessorDelegate.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessorDelegate.swift
@@ -25,6 +25,9 @@ package protocol EmbraceLogProcessorDelegate: AnyObject {
     /// The foreground/background state of the current session.
     var currentSessionState: SessionState { get }
 
-    /// The identifier for the current session, or `nil` when no session is active.
+    /// The identifier for the current session part, or `nil` when no part is active.
     var currentSessionId: EmbraceIdentifier? { get }
+
+    /// The identifier for the current user session, or `nil` when no user session is active.
+    var currentUserSessionId: EmbraceIdentifier? { get }
 }

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessor.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessor.swift
@@ -119,11 +119,19 @@ class EmbraceSpanProcessor: SpanProcessor {
 
     /// Stamps external spans with required Embrace attributes before they reach child processors
     /// or the `EmbraceCore` delegate.
+    ///
+    /// Identity is stamped as three keys, always present (empty strings when unknown) so the
+    /// backend can correlate every signal back to a user session/part — `session.id` carries
+    /// the user-session UUID in v7, `emb.user_session_id` mirrors it, and `emb.session_part_id`
+    /// carries the part UUID (the value `session.id` had pre-v7).
     private func injectAttributes(_ span: ReadableSpan, delegate: EmbraceSpanProcessorDelegate) {
         span.setAttribute(key: SpanSemantics.keyEmbraceType, value: .string(EmbraceType.performance.rawValue))
         span.setAttribute(key: SpanSemantics.Session.keyState, value: .string(delegate.currentSessionState.rawValue))
-        if let sessionId = delegate.currentSessionId {
-            span.setAttribute(key: SpanSemantics.keySessionId, value: .string(sessionId.stringValue))
-        }
+
+        let userSessionId = delegate.currentUserSessionId?.stringValue ?? ""
+        let partId = delegate.currentSessionId?.stringValue ?? ""
+        span.setAttribute(key: SpanSemantics.keySessionId, value: .string(userSessionId))
+        span.setAttribute(key: SpanSemantics.Session.keyUserSessionId, value: .string(userSessionId))
+        span.setAttribute(key: SpanSemantics.Session.keyPartId, value: .string(partId))
     }
 }

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessorDelegate.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessorDelegate.swift
@@ -28,6 +28,9 @@ package protocol EmbraceSpanProcessorDelegate: AnyObject {
     /// The foreground/background state of the current session.
     var currentSessionState: SessionState { get }
 
-    /// The identifier for the current session, or `nil` when no session is active.
+    /// The identifier for the current session part, or `nil` when no part is active.
     var currentSessionId: EmbraceIdentifier? { get }
+
+    /// The identifier for the current user session, or `nil` when no user session is active.
+    var currentUserSessionId: EmbraceIdentifier? { get }
 }

--- a/Sources/EmbraceSemantics/Log/LogSemantics.swift
+++ b/Sources/EmbraceSemantics/Log/LogSemantics.swift
@@ -6,7 +6,16 @@ public struct LogSemantics {
     public static let keyEmbraceType = "emb.type"
     public static let keyId = "log.record.uid"
     public static let keyState = "emb.state"
+
+    /// `session.id` identifies the **user session** in v7 (not the part). Stamped on every log.
     public static let keySessionId = "session.id"
+
+    /// `emb.user_session_id` — same value as `session.id` for now. Stamped on every log.
+    public static let keyUserSessionId = "emb.user_session_id"
+
+    /// `emb.session_part_id` — the part UUID. Stamped on every log.
+    public static let keyPartId = "emb.session_part_id"
+
     public static let keyStackTrace = "emb.stacktrace.ios"
     public static let keyPropertiesPrefix = "emb.properties.%@"
 

--- a/Sources/EmbraceSemantics/Span/SpanSemantics+Session.swift
+++ b/Sources/EmbraceSemantics/Span/SpanSemantics+Session.swift
@@ -9,12 +9,45 @@ extension EmbraceType {
 extension SpanSemantics {
     public struct Session {
         public static let name = "emb-session"
+
+        /// `session.id` now identifies the **user session**, not the individual part.
+        /// Stamped on every span and log (empty string when unknown).
         public static let keyId = "session.id"
+
+        /// `emb.user_session_id` — same value as `session.id` for now (until a future override
+        /// API lets customers override `session.id` independently). Stamped on every span and log.
+        public static let keyUserSessionId = "emb.user_session_id"
+
+        /// `emb.session_part_id` — the part UUID (the value `session.id` had historically).
+        /// Stamped on every span and log.
+        public static let keyPartId = "emb.session_part_id"
+
         public static let keyState = "emb.state"
         public static let keyColdStart = "emb.cold_start"
         public static let keyTerminated = "emb.terminated"
         public static let keyCleanExit = "emb.clean_exit"
-        public static let keySessionNumber = "emb.session_number"
+
+        /// Globally-unique per-part counter (renamed from `emb.session_number`).
+        public static let keySessionPartNumber = "emb.session_part_number"
+
+        /// 1-indexed position of the current part within its user session.
+        public static let keyUserSessionPartIndex = "emb.user_session_part_index"
+
+        /// Wall-clock start of the user session, in nanoseconds since epoch.
+        public static let keyUserSessionStartTs = "emb.user_session_start_ts"
+
+        /// Max duration of the user session in seconds (config snapshot taken at user-session creation).
+        public static let keyUserSessionMaxDurationSeconds = "emb.user_session_max_duration_seconds"
+
+        /// Inactivity timeout in seconds (config snapshot taken at user-session creation).
+        public static let keyUserSessionInactivityTimeoutSeconds = "emb.user_session_inactivity_timeout_seconds"
+
+        /// `"1"` on the last part of a terminated user session; omitted otherwise.
+        public static let keyIsFinalSessionPart = "emb.is_final_session_part"
+
+        /// Termination reason on the last part of a terminated user session; omitted otherwise.
+        public static let keyUserSessionTerminationReason = "emb.user_session_termination_reason"
+
         public static let keyHeartbeat = "emb.heartbeat_time_unix_nano"
         public static let keyCrashId = "emb.crash_id"
     }

--- a/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
@@ -37,10 +37,17 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         whenInvokingAddSessionIdentifier()
         whenInvokingBuild()
 
-        thenResultingAttributes(is: ["session.id": identifier.stringValue])
+        // `session.id` carries the user-session UUID in v7 (empty here because the mock has
+        // no user session); `emb.session_part_id` carries the part UUID. All three identity
+        // keys are always present.
+        thenResultingAttributes(is: [
+            "session.id": "",
+            "emb.user_session_id": "",
+            "emb.session_part_id": identifier.stringValue
+        ])
     }
 
-    func testOnNotHavingSession_addSessionIdentifier_addsNothingToAttributes() {
+    func testOnNotHavingSession_addSessionIdentifier_addsEmptyStringsToAttributes() {
         givenSessionControllerWithNoSession()
         givenMetadataFetcher()
         givenEmbraceLogAttributesBuilder()
@@ -48,7 +55,12 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         whenInvokingAddSessionIdentifier()
         whenInvokingBuild()
 
-        thenResultingAttributes(is: .empty())
+        // Spec requires the three keys be present even as empty strings when no session is active.
+        thenResultingAttributes(is: [
+            "session.id": "",
+            "emb.user_session_id": "",
+            "emb.session_part_id": ""
+        ])
     }
 
     // MARK: - addApplicationProperties Tests

--- a/Tests/EmbraceCoreTests/Internal/OTel/DefaultOTelSignalsHandlerInternalTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/OTel/DefaultOTelSignalsHandlerInternalTests.swift
@@ -109,7 +109,14 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
 
         // then the span has the correct internal attributes
         XCTAssertEqual(span.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(span.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        // `session.id` is the user-session UUID (empty when the mock has no user session set);
+        // the part UUID lives under `emb.session_part_id`.
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
+        XCTAssertNotNil(span.attributes["session.id"])
+        XCTAssertNotNil(span.attributes["emb.user_session_id"])
 
         // then the span is saved in storage correctly
         let record = storage.fetchSpan(id: span.context.spanId, traceId: span.context.traceId)
@@ -124,7 +131,10 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
         XCTAssertEqual(record!.links[0].context.traceId, TestConstants.traceId)
         XCTAssertEqual(record!.attributes["key"] as! String, "value")
         XCTAssertEqual(record!.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(record!.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        XCTAssertEqual(
+            record!.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
     }
 
     func test_addInternalSessionEvent() throws {
@@ -192,7 +202,7 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
 
             return log.body == "test" && log.severity == .debug && log.type == .message && log.timestamp == timestamp && log.attributes["key"] as! String == "value"
                 && log.attributes["emb.type"] as! String == "sys.log" && log.attributes["emb.state"] as! String == "foreground"
-                && log.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
+                && log.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
         }
 
         // then the log is saved correctly
@@ -201,7 +211,7 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
 
             return record.body == "test" && record.severity == .debug && record.type == .message && record.timestamp == timestamp && record.attributes["key"] as! String == "value"
                 && record.attributes["emb.type"] as! String == "sys.log" && record.attributes["emb.state"] as! String == "foreground"
-                && record.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue
+                && record.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue
         }
     }
 

--- a/Tests/EmbraceCoreTests/Internal/OTel/DictionaryEmbraceAttributesTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/OTel/DictionaryEmbraceAttributesTests.swift
@@ -16,9 +16,19 @@ class DictionaryEmbraceAttributesTests: XCTestCase {
         XCTAssertEqual(attributes["emb.type"] as! String, "perf")
     }
 
-    func test_setEmbraceSessionId() {
+    func test_setSessionIdentity_stampsThreeKeys() {
         var attributes: EmbraceAttributes = [:]
-        attributes.setEmbraceSessionId(TestConstants.sessionId)
-        XCTAssertEqual(attributes["session.id"] as! String, TestConstants.sessionId.stringValue)
+        attributes.setSessionIdentity(userSessionId: "U1", partId: "P1")
+        XCTAssertEqual(attributes["session.id"] as! String, "U1")
+        XCTAssertEqual(attributes["emb.user_session_id"] as! String, "U1")
+        XCTAssertEqual(attributes["emb.session_part_id"] as! String, "P1")
+    }
+
+    func test_setSessionIdentity_emptyStringsWhenUnknown() {
+        var attributes: EmbraceAttributes = [:]
+        attributes.setSessionIdentity(userSessionId: "", partId: "")
+        XCTAssertEqual(attributes["session.id"] as! String, "")
+        XCTAssertEqual(attributes["emb.user_session_id"] as! String, "")
+        XCTAssertEqual(attributes["emb.session_part_id"] as! String, "")
     }
 }

--- a/Tests/EmbraceCoreTests/Payload/SessionPayloadBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/SessionPayloadBuilderTests.swift
@@ -50,9 +50,9 @@ final class SessionPayloadBuilderTests: XCTestCase {
         // when building a session payload
         let payload = SessionPayloadBuilder.build(for: sessionRecord, storage: storage)
 
-        // then the session span contains the correct session number
+        // then the session span contains the correct session-part number
         let sessionSpan = payload?.data["spans"]?.first { $0.name == "emb-session" }
-        let sessionNumberAttr = sessionSpan?.attributes.first { $0.key == "emb.session_number" }
+        let sessionNumberAttr = sessionSpan?.attributes.first { $0.key == "emb.session_part_number" }
         XCTAssertEqual(sessionNumberAttr?.value, "7")
 
         // and the MetadataRecord counter was NOT touched

--- a/Tests/EmbraceCoreTests/Public/OTel/DefaultOTelSignalsHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Public/OTel/DefaultOTelSignalsHandlerTests.swift
@@ -106,7 +106,10 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
 
         // then the span has the correct internal attributes
         XCTAssertEqual(span.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(span.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
 
         // then the span is saved in storage correctly
         let record = storage.fetchSpan(id: span.context.spanId, traceId: span.context.traceId)
@@ -121,7 +124,10 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
         XCTAssertEqual(record!.links[0].context.traceId, TestConstants.traceId)
         XCTAssertEqual(record!.attributes["key"] as! String, "value")
         XCTAssertEqual(record!.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(record!.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        XCTAssertEqual(
+            record!.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
     }
 
     func test_createSpan_failure() throws {
@@ -166,10 +172,24 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
         // given a handler
         // when creating a span passing attributes
         // that would collide with internal ones
-        let span = try XCTUnwrap(handler.createSpan(name: "test", attributes: ["session.id": "test", "emb.type": "test"]))
+        let span = try XCTUnwrap(
+            handler.createSpan(
+                name: "test",
+                attributes: [
+                    "session.id": "test",
+                    "emb.session_part_id": "test",
+                    "emb.type": "test"
+                ]
+            )
+        )
 
-        // then the correct internal attributes are kept
-        XCTAssertEqual(span.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        // then the correct internal attributes are kept (caller can't override the part id;
+        // `session.id` is the user-session UUID, which is empty in this test setup since the
+        // mock session controller has no user session attached).
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
         XCTAssertEqual(span.attributes["emb.type"] as! String, "perf")
     }
 
@@ -464,7 +484,7 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
 
             return log.body == "test" && log.severity == .debug && log.type == .message && log.timestamp == timestamp && log.attributes["key"] as! String == "value"
                 && log.attributes["emb.type"] as! String == "sys.log" && log.attributes["emb.state"] as! String == "foreground"
-                && log.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
+                && log.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
         }
 
         // then the log is saved correctly
@@ -473,7 +493,7 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
 
             return record.body == "test" && record.severity == .debug && record.type == .message && record.timestamp == timestamp && record.attributes["key"] as! String == "value"
                 && record.attributes["emb.type"] as! String == "sys.log" && record.attributes["emb.state"] as! String == "foreground"
-                && record.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue
+                && record.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue
         }
     }
 
@@ -528,7 +548,7 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
         wait(timeout: .defaultTimeout) {
             let log = self.logController.batcher.batch!.logs[0]
 
-            return log.attributes["emb.type"] as! String == "sys.log" && log.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue
+            return log.attributes["emb.type"] as! String == "sys.log" && log.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue
                 && log.attributes["emb.state"] as! String == "foreground"
         }
     }

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -179,6 +179,213 @@ final class SessionControllerTests: XCTestCase {
         wait(for: [notificationExpectation])
     }
 
+    func test_endSession_foreground_writesUserSessionLastForegroundEndOnRecord() throws {
+        let session = controller.startSession(state: .foreground)
+        let endTime = controller.endSession()
+
+        let stored: [SessionRecord] = storage.fetchAll()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.idRaw, session?.id.stringValue)
+        XCTAssertEqual(
+            stored.first?.userSessionLastForegroundEnd?.timeIntervalSince1970 ?? 0,
+            endTime.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+
+        // and the in-memory snapshot was updated for the next attachPart's inactivity math
+        XCTAssertEqual(
+            userSessionController.currentUserSession?.lastForegroundPartEnd?.timeIntervalSince1970 ?? 0,
+            endTime.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    func test_endSession_background_doesNotWriteUserSessionLastForegroundEnd() throws {
+        // Background-session retention requires an explicit config; the default mock keeps
+        // bg parts dropped, so build a one-off controller that allows them.
+        let bgConfig = EmbraceConfig(
+            configurable: EditableConfig(isBackgroundSessionEnabled: true),
+            options: .init(),
+            notificationCenter: NotificationCenter.default,
+            logger: MockLogger()
+        )
+        let bgController = SessionController(storage: storage, upload: nil, config: bgConfig)
+        bgController.sdkStateProvider = sdkStateProvider
+        bgController.otel = otel
+        let bgUserSessionController = UserSessionController(
+            storage: storage,
+            config: MockEmbraceConfigurable()
+        )
+        bgUserSessionController.sessionController = bgController
+        bgController.userSessionController = bgUserSessionController
+
+        let session = bgController.startSession(state: .background)
+        bgController.endSession()
+
+        let stored: [SessionRecord] = storage.fetchAll()
+        let bgRecord = stored.first { $0.idRaw == session?.id.stringValue }
+        XCTAssertNotNil(bgRecord)
+        XCTAssertNil(bgRecord?.userSessionLastForegroundEnd)
+    }
+
+    func test_endSessionAt_usesProvidedTimestamp() throws {
+        controller.startSession(state: .foreground)
+        let cutoff = Date(timeIntervalSinceNow: -120)
+        controller.endSession(at: cutoff)
+
+        let stored: [SessionRecord] = storage.fetchAll()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(
+            stored.first?.endTime?.timeIntervalSince1970 ?? 0,
+            cutoff.timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    func test_backfillTerminationReason_writesToLatestPart() throws {
+        let session = controller.startSession(state: .foreground)
+        controller.endSession()
+
+        controller.backfillTerminationReasonOnLatestPart(.manual)
+
+        let stored = storage.fetchSession(id: session!.id)
+        XCTAssertEqual(stored?.userSessionTerminationReason, .manual)
+    }
+
+    func test_backfillTerminationReason_noStoredParts_isNoop() throws {
+        // Nothing in storage — must not crash.
+        controller.backfillTerminationReasonOnLatestPart(.manual)
+        XCTAssertEqual((storage.fetchAll() as [SessionRecord]).count, 0)
+    }
+
+    func test_rollPartForUserSessionExpiry_endsOldStartsNewSameStateNewUserSession() throws {
+        let first = controller.startSession(state: .foreground)
+        let firstUserSessionId = first?.userSessionId
+
+        let rollTime = Date()
+        controller.rollPartForUserSessionExpiry(reason: .maxDurationReached, at: rollTime)
+
+        let stored: [SessionRecord] = storage.fetchAll()
+        XCTAssertEqual(stored.count, 2)
+
+        // Old part: closed at rollTime, marked with `.maxDurationReached` via the backfill.
+        let closed = stored.first { $0.idRaw == first?.id.stringValue }
+        XCTAssertNotNil(closed?.endTime)
+        XCTAssertEqual(closed?.userSessionTerminationReason, "max_duration_reached")
+
+        // New part: same state, fresh user-session ID.
+        XCTAssertEqual(controller.currentSession?.state, .foreground)
+        XCTAssertNotEqual(controller.currentSession?.userSessionId, firstUserSessionId)
+    }
+
+    func test_rollPartForUserSessionExpiry_noActiveSession_isNoop() throws {
+        controller.rollPartForUserSessionExpiry(reason: .manual, at: Date())
+        XCTAssertEqual((storage.fetchAll() as [SessionRecord]).count, 0)
+        XCTAssertNil(controller.currentSession)
+    }
+
+    func test_startSession_bgToFgPastUserSessionCutoff_splitsBackgroundPart() throws {
+        // Build a controller whose userSessionInactivityTimeout is short so the cutoff is
+        // crossed within a reasonable wall-clock window in the test. Also enable background
+        // sessions so the bg part survives.
+        let bgConfig = EmbraceConfig(
+            configurable: EditableConfig(isBackgroundSessionEnabled: true),
+            options: .init(),
+            notificationCenter: NotificationCenter.default,
+            logger: MockLogger()
+        )
+        let splitController = SessionController(storage: storage, upload: nil, config: bgConfig)
+        splitController.sdkStateProvider = sdkStateProvider
+        splitController.otel = otel
+        // The user-session controller holds its `config` weakly; the mock must outlive this
+        // scope or the controller will fall back to defaults.
+        let splitConfigurable = MockEmbraceConfigurable(
+            userSessionMaxDuration: 12 * 3600,
+            userSessionInactivityTimeout: 1  // 1s inactivity for tight cutoff
+        )
+        let splitUserSessionController = UserSessionController(storage: storage, config: splitConfigurable)
+        splitUserSessionController.sessionController = splitController
+        splitController.userSessionController = splitUserSessionController
+
+        // Foreground part that ends at T0 — installs the inactivity cutoff at T0+1s.
+        splitController.startSession(state: .foreground)
+        let foregroundEnd = splitController.endSession()
+        let cutoffExpected = foregroundEnd.addingTimeInterval(1)
+
+        // Background part that begins before the cutoff and would normally span past it.
+        splitController.startSession(state: .background, startTime: foregroundEnd.addingTimeInterval(0.1))
+
+        // Wait long enough for the cutoff to have passed.
+        Thread.sleep(forTimeInterval: 1.2)
+        let bgEnd = Date()
+        XCTAssertGreaterThan(bgEnd, cutoffExpected)
+
+        // Now transition to foreground: bg-split fires.
+        splitController.startSession(state: .foreground, startTime: bgEnd)
+
+        // Three persisted parts: original fg, sliced bg [bg.start, cutoff], synthetic bg [cutoff, now],
+        // and the new fg. Plus the original fg = 4 records total.
+        let stored: [SessionRecord] = storage.fetchAll().sorted { $0.startTime < $1.startTime }
+        XCTAssertEqual(stored.count, 4)
+
+        // Records 2 and 3 are the split bg pair.
+        let slicedBg = stored[1]
+        let syntheticBg = stored[2]
+        let newFg = stored[3]
+
+        XCTAssertEqual(slicedBg.state, "background")
+        XCTAssertEqual(
+            slicedBg.endTime!.timeIntervalSince1970,
+            cutoffExpected.timeIntervalSince1970,
+            accuracy: 0.05
+        )
+
+        XCTAssertEqual(syntheticBg.state, "background")
+        XCTAssertEqual(
+            syntheticBg.startTime.timeIntervalSince1970,
+            cutoffExpected.timeIntervalSince1970,
+            accuracy: 0.05
+        )
+
+        // The synthetic bg part belongs to a NEW user session (different from the sliced bg).
+        XCTAssertNotEqual(syntheticBg.userSessionIdRaw, slicedBg.userSessionIdRaw)
+
+        // The new fg part shares the synthetic bg's user session (within bounds at this point).
+        XCTAssertEqual(newFg.state, "foreground")
+        XCTAssertEqual(newFg.userSessionIdRaw, syntheticBg.userSessionIdRaw)
+    }
+
+    func test_startSession_bgToFgWithinUserSessionBounds_doesNotSplit() throws {
+        // Default inactivity is 30min; we'll only idle a moment, so the cutoff isn't crossed.
+        let bgConfig = EmbraceConfig(
+            configurable: EditableConfig(isBackgroundSessionEnabled: true),
+            options: .init(),
+            notificationCenter: NotificationCenter.default,
+            logger: MockLogger()
+        )
+        let noSplitController = SessionController(storage: storage, upload: nil, config: bgConfig)
+        noSplitController.sdkStateProvider = sdkStateProvider
+        noSplitController.otel = otel
+        let noSplitConfigurable = MockEmbraceConfigurable()  // 12h/30min defaults
+        let noSplitUserSessionController = UserSessionController(storage: storage, config: noSplitConfigurable)
+        noSplitUserSessionController.sessionController = noSplitController
+        noSplitController.userSessionController = noSplitUserSessionController
+
+        noSplitController.startSession(state: .foreground)
+        noSplitController.endSession()
+        let bgFirst = noSplitController.startSession(state: .background)
+        noSplitController.startSession(state: .foreground)
+
+        // No split: only the original fg, the bg, and the new fg — three records total.
+        let stored: [SessionRecord] = storage.fetchAll()
+        XCTAssertEqual(stored.count, 3)
+
+        // The bg part is closed cleanly (no synthetic split) — its user session matches the
+        // following foreground part.
+        let bgRecord = stored.first { $0.idRaw == bgFirst?.id.stringValue }
+        XCTAssertNotNil(bgRecord?.endTime)
+    }
+
     func test_endSession_saves_foregroundSession() throws {
         let session = controller.startSession(state: .foreground)
         XCTAssertNil(session!.endTime)

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -385,11 +385,7 @@ final class SessionControllerTests: XCTestCase {
         // Background part that begins before the cutoff and would normally span past it.
         splitController.startSession(state: .background, startTime: foregroundEnd.addingTimeInterval(0.1))
 
-        // Wait long enough for the cutoff to have passed.
-        Thread.sleep(forTimeInterval: 1.2)
-        let bgEnd = Date()
-        XCTAssertGreaterThan(bgEnd, cutoffExpected)
-
+        let bgEnd = foregroundEnd.addingTimeInterval(1.5) // past the 1s cutoff
         // Now transition to foreground: bg-split fires.
         splitController.startSession(state: .foreground, startTime: bgEnd)
 

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -284,6 +284,30 @@ final class SessionControllerTests: XCTestCase {
         XCTAssertNil(controller.currentSession)
     }
 
+    func test_checkUserSessionMaxDurationExpiry_doubleTick_rotatesOnce() throws {
+        // Two back-to-back heartbeat ticks against the same expired user session must enqueue
+        // two check-then-maybe-roll blocks. The second block, when it runs, sees the state
+        // left by the first (freshly-rotated user session with a far-future maxEnd) and bails.
+        // Without the in-block re-check, both blocks would call rollPart and we'd see two
+        // rotations.
+        controller.startSession(state: .foreground)
+        let userSessionStart = try XCTUnwrap(userSessionController.currentUserSession?.startTime)
+        let expired = userSessionStart.addingTimeInterval(13 * 3600)  // past 12h max default
+
+        controller.checkUserSessionMaxDurationExpiry(now: expired)
+        controller.checkUserSessionMaxDurationExpiry(now: expired)
+
+        let drained = expectation(description: "controller queue drained")
+        controller.queue.async { drained.fulfill() }
+        wait(for: [drained], timeout: 2)
+
+        // One rotation: original part (closed) + new part (active). Two rotations would be 3.
+        let stored: [SessionRecord] = storage.fetchAll()
+        XCTAssertEqual(stored.count, 2)
+        XCTAssertEqual(stored.filter { $0.endTime != nil }.count, 1)
+        XCTAssertEqual(stored.filter { $0.endTime == nil }.count, 1)
+    }
+
     func test_rollPartForUserSessionExpiry_serializedThroughQueue_producesConsistentState() throws {
         // Two back-to-back rolls dispatched onto the same serial controller queue must run
         // atomically as a unit (end-old → end-user-session → start-new). Before this queue

--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -284,6 +284,52 @@ final class SessionControllerTests: XCTestCase {
         XCTAssertNil(controller.currentSession)
     }
 
+    func test_rollPartForUserSessionExpiry_serializedThroughQueue_producesConsistentState() throws {
+        // Two back-to-back rolls dispatched onto the same serial controller queue must run
+        // atomically as a unit (end-old → end-user-session → start-new). Before this queue
+        // routing, heartbeat-driven and manual-driven rolls each ran on their own queues and
+        // could interleave at the three sub-locks, producing a shadow part: the brand-new
+        // session opened by roll A would be immediately ended by roll B's `endSession` step,
+        // then re-opened, leaving a ~ms-lived part record in storage and an unbalanced
+        // pair of user-session start/end notifications.
+        let initial = controller.startSession(state: .foreground)
+
+        let firstRoll = Date()
+        let secondRoll = firstRoll.addingTimeInterval(0.001)
+
+        controller.queue.async {
+            self.controller.rollPartForUserSessionExpiry(reason: .maxDurationReached, at: firstRoll)
+        }
+        controller.queue.async {
+            self.controller.rollPartForUserSessionExpiry(reason: .manual, at: secondRoll)
+        }
+
+        // Drain the controller queue.
+        let drained = expectation(description: "controller queue drained")
+        controller.queue.async {
+            drained.fulfill()
+        }
+        wait(for: [drained], timeout: 2)
+
+        // Three persisted parts (initial, post-roll-1, post-roll-2) — not four. A shadow part
+        // from interleaving would inflate this count.
+        let stored: [SessionRecord] = storage.fetchAll().sorted { $0.startTime < $1.startTime }
+        XCTAssertEqual(stored.count, 3, "exactly one part per rotation; no shadow part")
+
+        // The initial and the post-roll-1 parts are closed; the post-roll-2 part is active.
+        XCTAssertEqual(stored.filter { $0.endTime != nil }.count, 2)
+        XCTAssertEqual(stored.filter { $0.endTime == nil }.count, 1)
+
+        // The three parts each belong to a distinct user session.
+        let userSessionIds = Set(stored.compactMap { $0.userSessionIdRaw })
+        XCTAssertEqual(userSessionIds.count, 3, "three distinct user sessions for three rotations")
+
+        // The currently-active part is the one from roll 2 (last to be opened); it's a foreground
+        // part because the roll preserves the state of the original part.
+        XCTAssertEqual(controller.currentSession?.state, .foreground)
+        XCTAssertNotEqual(controller.currentSession?.id, initial?.id)
+    }
+
     func test_startSession_bgToFgPastUserSessionCutoff_splitsBackgroundPart() throws {
         // Build a controller whose userSessionInactivityTimeout is short so the cutoff is
         // crossed within a reasonable wall-clock window in the test. Also enable background

--- a/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
@@ -3,6 +3,7 @@
 //
 
 import EmbraceCommonInternal
+import EmbraceSemantics
 import EmbraceStorageInternal
 import TestSupport
 import XCTest
@@ -30,12 +31,17 @@ final class SessionSpanUtilsTests: XCTestCase {
             coldStart: true
         )
 
-        // then the span is correct
+        // then the span is correct. The live attributes carry the part id under
+        // `emb.session_part_id`; the user-session id keys are stamped later (at payload-build
+        // time) because `attachPart` hasn't run yet when the session-part span is created.
         let span = otel.startedSpans[0]
         XCTAssertEqual(span.name, "emb-session")
         XCTAssertEqual(span.type, .session)
         XCTAssertEqual(span.startTime, TestConstants.date)
-        XCTAssertEqual(span.attributes["session.id"] as! String, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            TestConstants.sessionId.stringValue
+        )
         XCTAssertEqual(span.attributes["emb.state"] as! String, SessionState.foreground.rawValue)
         XCTAssertEqual(span.attributes["emb.cold_start"] as! String, "true")
     }
@@ -99,9 +105,11 @@ final class SessionSpanUtilsTests: XCTestCase {
     }
 
     func test_payloadFromSesssion() throws {
-        // given a session record
+        // given a session record with a full user-session metadata bag
         let endTime = Date(timeIntervalSince1970: 60)
         let heartbeat = Date(timeIntervalSince1970: 58)
+        let userSessionId = EmbraceIdentifier.random
+        let userSessionStart = Date(timeIntervalSince1970: 10)
 
         let session = MockSession(
             id: TestConstants.sessionId,
@@ -115,13 +123,17 @@ final class SessionSpanUtilsTests: XCTestCase {
             crashReportId: "test",
             coldStart: true,
             cleanExit: false,
-            appTerminated: true
+            appTerminated: true,
+            sessionNumber: 100,
+            userSessionId: userSessionId,
+            userSessionStartTime: userSessionStart,
+            userSessionMaxDuration: 43200,
+            userSessionInactivityTimeout: 1800,
+            userSessionPartIndex: 3
         )
 
-        // when building the session span payload
-        let payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        let payload = SessionSpanUtils.payload(from: session)
 
-        // then the payload is correct
         XCTAssertEqual(payload.name, "emb-session")
         XCTAssertEqual(payload.traceId, TestConstants.traceId)
         XCTAssertEqual(payload.spanId, TestConstants.spanId)
@@ -132,50 +144,85 @@ final class SessionSpanUtilsTests: XCTestCase {
         XCTAssertEqual(payload.events.count, 0)
         XCTAssertEqual(payload.links.count, 0)
 
-        let typeAttribute = payload.attributes.first {
-            $0.key == "emb.type"
+        func attribute(_ key: String) -> String? {
+            payload.attributes.first { $0.key == key }?.value
         }
-        XCTAssertEqual(typeAttribute!.value, "ux.session")
 
-        let sessionAttribute = payload.attributes.first {
-            $0.key == "session.id"
-        }
-        XCTAssertEqual(sessionAttribute!.value, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(attribute("emb.type"), "ux.session")
 
-        let stateAttribute = payload.attributes.first {
-            $0.key == "emb.state"
-        }
-        XCTAssertEqual(stateAttribute!.value, SessionState.foreground.rawValue)
+        // Identity: session.id is the user-session id (not the part id); emb.session_part_id is the part.
+        XCTAssertEqual(attribute("session.id"), userSessionId.stringValue)
+        XCTAssertEqual(attribute("emb.user_session_id"), userSessionId.stringValue)
+        XCTAssertEqual(attribute("emb.session_part_id"), TestConstants.sessionId.stringValue)
 
-        let coldStartAttribute = payload.attributes.first {
-            $0.key == "emb.cold_start"
-        }
-        XCTAssertEqual(coldStartAttribute!.value, "true")
+        XCTAssertEqual(attribute("emb.state"), SessionState.foreground.rawValue)
+        XCTAssertEqual(attribute("emb.cold_start"), "true")
+        XCTAssertEqual(attribute("emb.terminated"), "true")
+        XCTAssertEqual(attribute("emb.clean_exit"), "false")
+        XCTAssertEqual(attribute("emb.heartbeat_time_unix_nano"), String(heartbeat.nanosecondsSince1970Truncated))
 
-        let terminatedAttribute = payload.attributes.first {
-            $0.key == "emb.terminated"
-        }
-        XCTAssertEqual(terminatedAttribute!.value, "true")
+        // Counters
+        XCTAssertEqual(attribute("emb.session_part_number"), "100")
+        XCTAssertEqual(attribute("emb.user_session_part_index"), "3")
 
-        let cleanExitAttribute = payload.attributes.first {
-            $0.key == "emb.clean_exit"
-        }
-        XCTAssertEqual(cleanExitAttribute!.value, "false")
+        // User-session config snapshots
+        XCTAssertEqual(attribute("emb.user_session_start_ts"), String(userSessionStart.nanosecondsSince1970Truncated))
+        XCTAssertEqual(attribute("emb.user_session_max_duration_seconds"), "43200.0")
+        XCTAssertEqual(attribute("emb.user_session_inactivity_timeout_seconds"), "1800.0")
 
-        let heartbeatAttribute = payload.attributes.first {
-            $0.key == "emb.heartbeat_time_unix_nano"
-        }
-        XCTAssertEqual(heartbeatAttribute!.value, String(heartbeat.nanosecondsSince1970Truncated))
+        XCTAssertEqual(attribute("emb.crash_id"), "test")
 
-        let sessionNumberAttribute = payload.attributes.first {
-            $0.key == "emb.session_number"
-        }
-        XCTAssertEqual(sessionNumberAttribute!.value, "100")
+        // Old key gone, no termination-reason-related keys when not set.
+        XCTAssertNil(attribute("emb.session_number"))
+        XCTAssertNil(attribute("emb.user_session_termination_reason"))
+        XCTAssertNil(attribute("emb.is_final_session_part"))
+    }
 
-        let crashIdAttribute = payload.attributes.first {
-            $0.key == "emb.crash_id"
+    func test_payload_emitsTerminationReasonAndFinalPartFlagOnLastPart() throws {
+        let session = MockSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: TestConstants.date,
+            sessionNumber: 5,
+            userSessionId: EmbraceIdentifier.random,
+            userSessionStartTime: TestConstants.date,
+            userSessionMaxDuration: 43200,
+            userSessionInactivityTimeout: 1800,
+            userSessionPartIndex: 2,
+            userSessionTerminationReason: .manual
+        )
+
+        let payload = SessionSpanUtils.payload(from: session)
+
+        let terminationReason = payload.attributes.first { $0.key == "emb.user_session_termination_reason" }
+        let finalPartFlag = payload.attributes.first { $0.key == "emb.is_final_session_part" }
+        XCTAssertEqual(terminationReason?.value, "manual")
+        XCTAssertEqual(finalPartFlag?.value, "1")
+    }
+
+    func test_payload_legacySessionEmitsEmptyUserSessionId() throws {
+        // Pre-v7 row: no user-session columns set.
+        let session = MockSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: TestConstants.date
+        )
+
+        let payload = SessionSpanUtils.payload(from: session)
+
+        func attribute(_ key: String) -> String? {
+            payload.attributes.first { $0.key == key }?.value
         }
-        XCTAssertEqual(crashIdAttribute!.value, "test")
+
+        XCTAssertEqual(attribute("session.id"), "")
+        XCTAssertEqual(attribute("emb.user_session_id"), "")
+        XCTAssertEqual(attribute("emb.session_part_id"), TestConstants.sessionId.stringValue)
     }
 
     func test_status() {
@@ -195,7 +242,7 @@ final class SessionSpanUtilsTests: XCTestCase {
             appTerminated: true
         )
 
-        var payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        var payload = SessionSpanUtils.payload(from: session)
         XCTAssertEqual(payload.status, "ok")
 
         // test error status
@@ -214,7 +261,7 @@ final class SessionSpanUtilsTests: XCTestCase {
             appTerminated: true
         )
 
-        payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        payload = SessionSpanUtils.payload(from: session)
         XCTAssertEqual(payload.status, "error")
     }
 
@@ -228,7 +275,7 @@ final class SessionSpanUtilsTests: XCTestCase {
         ]
 
         // when building the session span payload
-        let payload = SessionSpanUtils.payload(from: session, properties: properties, sessionNumber: 100)
+        let payload = SessionSpanUtils.payload(from: session, properties: properties)
 
         XCTAssertGreaterThanOrEqual(payload.attributes.count, 3)
         let permanentCustomProperty = payload.attributes.first {
@@ -273,7 +320,7 @@ final class SessionSpanUtilsTests: XCTestCase {
         )
 
         // when building the session span payload
-        let payload = SessionSpanUtils.payload(from: session, properties: properties, sessionNumber: 100)
+        let payload = SessionSpanUtils.payload(from: session, properties: properties)
 
         XCTAssertFalse(payload.attributes.contains(where: { $0.key == "emb.user.username " }))
         XCTAssertFalse(payload.attributes.contains(where: { $0.key == "emb.user.email" }))

--- a/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
@@ -167,8 +167,8 @@ final class SessionSpanUtilsTests: XCTestCase {
 
         // User-session config snapshots
         XCTAssertEqual(attribute("emb.user_session_start_ts"), String(userSessionStart.nanosecondsSince1970Truncated))
-        XCTAssertEqual(attribute("emb.user_session_max_duration_seconds"), "43200.0")
-        XCTAssertEqual(attribute("emb.user_session_inactivity_timeout_seconds"), "1800.0")
+        XCTAssertEqual(attribute("emb.user_session_max_duration_seconds"), "43200")
+        XCTAssertEqual(attribute("emb.user_session_inactivity_timeout_seconds"), "1800")
 
         XCTAssertEqual(attribute("emb.crash_id"), "test")
 

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -425,11 +425,80 @@ class UnsentDataHandlerTests: XCTestCase {
         XCTAssertEqual(otel.logs[0].timestamp, report.timestamp)
         XCTAssertEqual(otel.logs[0].body, "")
         XCTAssertEqual(otel.logs[0].severity, .fatal)
-        XCTAssertEqual(otel.logs[0].attributes["session.id"] as! String, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(
+            otel.logs[0].attributes["emb.session_part_id"] as! String,
+            TestConstants.sessionId.stringValue
+        )
         XCTAssertEqual(otel.logs[0].attributes["emb.state"] as! String, SessionState.foreground.rawValue)
         XCTAssertEqual(otel.logs[0].attributes["log.record.uid"] as! String, report.id.withoutHyphen)
         XCTAssertEqual(otel.logs[0].attributes["emb.provider"] as! String, report.provider)
         XCTAssertEqual(otel.logs[0].attributes["emb.payload"] as! String, report.payload)
+    }
+
+    func test_sendCrashReports_stampsCrashTerminationReasonOnLinkedSession() async throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on watchOS")
+
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let otel = MockOTelSignalsHandler()
+        let crashReporter = CrashReporterMock(crashSessionId: TestConstants.sessionId.stringValue)
+        let embraceReporter = EmbraceCrashReporter(reporter: crashReporter)
+
+        // and a finished session in storage that the crash report will link to
+        await storage.addSession(
+            id: TestConstants.sessionId,
+            processId: ProcessIdentifier.current,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date(timeIntervalSinceNow: -60),
+            endTime: Date()
+        )
+
+        // The session is deleted by `sendUnsentData`'s session-uploader path at the end of
+        // the flow, so observe the in-flight update via a Core Data listener — it captures
+        // the moment `updateSession` writes the new fields.
+        let listener = CoreDataListener()
+        let didStamp = XCTestExpectation()
+        listener.onUpdatedObjects = { records in
+            for record in records {
+                if let session = record as? SessionRecord,
+                    session.crashReportId != nil,
+                    session.userSessionTerminationReason == TerminationReason.crash.rawValue
+                {
+                    didStamp.fulfill()
+                    return
+                }
+            }
+        }
+
+        await UnsentDataHandler.sendUnsentData(
+            storage: storage, upload: nil, otel: otel, crashReporter: embraceReporter
+        )
+
+        await fulfillment(of: [didStamp], timeout: .defaultTimeout)
+        _ = listener  // keep alive for the duration of the test
+    }
+
+    func test_sendCrashReports_unlinkedReport_doesNotCrash() async throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on watchOS")
+
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let otel = MockOTelSignalsHandler()
+        // Crash report points at a session id that doesn't exist in storage.
+        let crashReporter = CrashReporterMock(crashSessionId: EmbraceIdentifier.random.stringValue)
+        let embraceReporter = EmbraceCrashReporter(reporter: crashReporter)
+
+        // no exception expected; storage stays empty
+        await UnsentDataHandler.sendUnsentData(
+            storage: storage, upload: nil, otel: otel, crashReporter: embraceReporter
+        )
+        wait(delay: .shortTimeout)
+
+        XCTAssertEqual((storage.fetchAll() as [SessionRecord]).count, 0)
     }
 
     func test_spanCleanUp_sendUnsentData() async throws {

--- a/Tests/EmbraceCoreTests/Session/UserSessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UserSessionControllerTests.swift
@@ -62,16 +62,6 @@ final class UserSessionControllerTests: XCTestCase {
     func testAttachPart_activeWithinBounds_invalidatesInactivityCutoff() {
         let controller = makeController()
 
-        // Count every embraceUserSessionDidStart post for the duration of the test —
-        // joining an existing user session must not trigger another start.
-        var startCount = 0
-        let observer = NotificationCenter.default.addObserver(
-            forName: .embraceUserSessionDidStart,
-            object: nil,
-            queue: .main
-        ) { _ in startCount += 1 }
-        defer { NotificationCenter.default.removeObserver(observer) }
-
         let first = controller.attachPart(state: .foreground, startTime: now)
         controller.markForegroundPartEnded(at: now.addingTimeInterval(60))
 
@@ -81,16 +71,12 @@ final class UserSessionControllerTests: XCTestCase {
         now = now.addingTimeInterval(120)
         let second = controller.attachPart(state: .foreground, startTime: now)
 
+        // Same user session (id unchanged), part index bumped, inactivity cutoff cleared.
+        // The behavioral evidence here proves no new user session was started; the start
+        // notification side of that is covered by `testAttachPart_noActiveUserSession_createsNewOne`.
         XCTAssertEqual(second.id, first.id, "Same user session")
         XCTAssertEqual(second.partIndex, 2)
         XCTAssertNil(second.lastForegroundPartEnd, "Inactivity cutoff cleared at part start")
-
-        // Drain the main queue so async posts from both attachPart calls land before we count.
-        let drained = expectation(description: "main queue drained")
-        DispatchQueue.main.async { drained.fulfill() }
-        wait(for: [drained], timeout: 1)
-
-        XCTAssertEqual(startCount, 1, "Joining an existing user session must not post a start notification")
     }
 
     func testAttachPart_expiredByMaxDuration_endsAndCreatesNew() {

--- a/Tests/EmbraceCoreTests/Session/UserSessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UserSessionControllerTests.swift
@@ -128,6 +128,28 @@ final class UserSessionControllerTests: XCTestCase {
         wait(for: [endNotification], timeout: 1)
     }
 
+    func testAttachPart_clockJumpedBackBetweenStartAndLastFgEnd_endsAndCreatesNew() {
+        // Sequence: user session starts at T0, foreground part ends at T0+5min (installing
+        // an inactivity cutoff at lastFgEnd = T0+5min), then the device clock jumps backward
+        // to T0+2min — still after `startTime` but BEFORE `lastForegroundPartEnd`. Without the
+        // lastForegroundPartEnd-in-future guard, the inactivity comparison (`now >= lastFgEnd
+        // + timeout`) is always false and the user session survives until max-duration fires.
+        let controller = makeController()
+        let first = controller.attachPart(state: .foreground, startTime: now)
+        let lastFgEnd = now.addingTimeInterval(300)  // T0 + 5min
+        controller.markForegroundPartEnded(at: lastFgEnd)
+
+        let endNotification = expectation(forNotification: .embraceUserSessionDidEnd, object: nil)
+
+        // Clock jumps backward to T0 + 2min — past `startTime` but before `lastFgEnd`.
+        now = now.addingTimeInterval(120)
+        let second = controller.attachPart(state: .foreground, startTime: now)
+
+        XCTAssertNotEqual(second.id, first.id)
+        XCTAssertEqual(second.partIndex, 1)
+        wait(for: [endNotification], timeout: 1)
+    }
+
     func testAttachPart_partIndexMonotonic() {
         let controller = makeController()
         var indices: [EMBInt] = []

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockSessionController.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockSessionController.swift
@@ -21,6 +21,14 @@ class MockSessionController: SessionControllable {
     var didCallEndSession: Bool = false
     var didCallUpdateSession: Bool = false
 
+    /// Ordered log of every `startSession`/`endSession` call (and their timestamp) for tests
+    /// that verify the bg-split sequence in `iOSSessionLifecycle.appDidBecomeActive`.
+    enum Event: Equatable {
+        case startSession(state: SessionState, startTime: Date)
+        case endSession(at: Date)
+    }
+    var callLog: [Event] = []
+
     private var updateSessionCallback: ((EmbraceSession?, SessionState?, Bool?) -> Void)?
 
     weak var storage: EmbraceStorage?
@@ -42,6 +50,7 @@ class MockSessionController: SessionControllable {
         }
 
         didCallStartSession = true
+        callLog.append(.startSession(state: state, startTime: startTime))
 
         var session: EmbraceSession?
 
@@ -99,16 +108,22 @@ class MockSessionController: SessionControllable {
 
     @discardableResult
     func endSession() -> Date {
+        return endSession(at: Date())
+    }
+
+    @discardableResult
+    func endSession(at endTime: Date) -> Date {
         didCallEndSession = true
+        callLog.append(.endSession(at: endTime))
         currentSession = nil
 
         if let span = currentSessionSpan {
-            span.end()
+            span.end(endTime: endTime)
             storage?.upsertSpan(span)
         }
         currentSessionSpan = nil
 
-        return Date()
+        return endTime
     }
 
     func update(state: SessionState) {

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockSessionController.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockSessionController.swift
@@ -21,14 +21,6 @@ class MockSessionController: SessionControllable {
     var didCallEndSession: Bool = false
     var didCallUpdateSession: Bool = false
 
-    /// Ordered log of every `startSession`/`endSession` call (and their timestamp) for tests
-    /// that verify the bg-split sequence in `iOSSessionLifecycle.appDidBecomeActive`.
-    enum Event: Equatable {
-        case startSession(state: SessionState, startTime: Date)
-        case endSession(at: Date)
-    }
-    var callLog: [Event] = []
-
     private var updateSessionCallback: ((EmbraceSession?, SessionState?, Bool?) -> Void)?
 
     weak var storage: EmbraceStorage?
@@ -50,7 +42,6 @@ class MockSessionController: SessionControllable {
         }
 
         didCallStartSession = true
-        callLog.append(.startSession(state: state, startTime: startTime))
 
         var session: EmbraceSession?
 
@@ -114,7 +105,6 @@ class MockSessionController: SessionControllable {
     @discardableResult
     func endSession(at endTime: Date) -> Date {
         didCallEndSession = true
-        callLog.append(.endSession(at: endTime))
         currentSession = nil
 
         if let span = currentSessionSpan {

--- a/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
+++ b/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
@@ -41,6 +41,39 @@
             XCTAssertEqual(crashReporter.getCrashInfo(key: CrashReporterInfoKey.sessionId), sessionId.stringValue)
         }
 
+        func test_currentUserSessionId_writesEmbUsi() {
+            givenCrashReporter()
+
+            let userSessionId = EmbraceIdentifier.random
+            crashReporter.currentUserSessionId = userSessionId.stringValue
+
+            XCTAssertEqual(
+                crashReporter.getCrashInfo(key: CrashReporterInfoKey.userSessionId),
+                userSessionId.stringValue
+            )
+            XCTAssertEqual(crashReporter.currentUserSessionId, userSessionId.stringValue)
+        }
+
+        func test_currentUserSessionId_clearsWhenSetToNil() {
+            givenCrashReporter()
+
+            crashReporter.currentUserSessionId = "U1"
+            XCTAssertEqual(crashReporter.currentUserSessionId, "U1")
+
+            crashReporter.currentUserSessionId = nil
+            XCTAssertNil(crashReporter.currentUserSessionId)
+        }
+
+        func test_currentUserSessionId_cannotBeOverriddenByPlainAppendCrashInfo() {
+            givenCrashReporter()
+
+            crashReporter.currentUserSessionId = "real-user-session"
+            // External callers cannot overwrite the internal keys via the generic API.
+            crashReporter.appendCrashInfo(key: CrashReporterInfoKey.userSessionId, value: "spoofed")
+
+            XCTAssertEqual(crashReporter.currentUserSessionId, "real-user-session")
+        }
+
         func test_sdkVersion() {
             givenCrashReporter()
 

--- a/Tests/EmbraceOTelBridgeTests/EmbraceLogProcessorTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/EmbraceLogProcessorTests.swift
@@ -66,7 +66,8 @@ final class EmbraceLogProcessorTests: XCTestCase {
 
     func test_onEmit_injectsEmbraceAttributesOnExternalLog() {
         mockDelegate.currentSessionState = .background
-        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "log-session-123")
+        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "part-123")
+        mockDelegate.currentUserSessionId = EmbraceIdentifier(stringValue: "user-123")
 
         emitLog(body: "external-log")
 
@@ -74,7 +75,10 @@ final class EmbraceLogProcessorTests: XCTestCase {
         let log = mockDelegate.emittedLogs.first
         XCTAssertEqual(log?.attributes[LogSemantics.keyEmbraceType], .string(EmbraceType.message.rawValue))
         XCTAssertEqual(log?.attributes[LogSemantics.keyState], .string("background"))
-        XCTAssertEqual(log?.attributes[LogSemantics.keySessionId], .string("log-session-123"))
+        // session.id carries the user-session id; the part id lives under emb.session_part_id.
+        XCTAssertEqual(log?.attributes[LogSemantics.keySessionId], .string("user-123"))
+        XCTAssertEqual(log?.attributes[LogSemantics.keyUserSessionId], .string("user-123"))
+        XCTAssertEqual(log?.attributes[LogSemantics.keyPartId], .string("part-123"))
     }
 
     // MARK: - Child processor forwarding
@@ -167,6 +171,7 @@ class MockLogProcessorDelegate: EmbraceLogProcessorDelegate {
     var emittedLogs: [ReadableLogRecord] = []
     var currentSessionState: SessionState = .foreground
     var currentSessionId: EmbraceIdentifier? = nil
+    var currentUserSessionId: EmbraceIdentifier? = nil
 
     func isInternalLog(_ log: ReadableLogRecord) -> Bool {
         guard case let .string(body) = log.body else { return false }

--- a/Tests/EmbraceOTelBridgeTests/EmbraceSpanProcessorTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/EmbraceSpanProcessorTests.swift
@@ -66,7 +66,8 @@ final class EmbraceSpanProcessorTests: XCTestCase {
 
     func test_onStart_injectsEmbraceTypeOnExternalSpan() {
         mockDelegate.currentSessionState = .foreground
-        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "session-123")
+        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "part-123")
+        mockDelegate.currentUserSessionId = EmbraceIdentifier(stringValue: "user-123")
         let span = tracer.spanBuilder(spanName: "external").startSpan()
 
         guard let readable = span as? ReadableSpan else {
@@ -76,19 +77,26 @@ final class EmbraceSpanProcessorTests: XCTestCase {
         let data = readable.toSpanData()
         XCTAssertEqual(data.attributes[SpanSemantics.keyEmbraceType], .string(EmbraceType.performance.rawValue))
         XCTAssertEqual(data.attributes[SpanSemantics.Session.keyState], .string("foreground"))
-        XCTAssertEqual(data.attributes[SpanSemantics.keySessionId], .string("session-123"))
+        // session.id carries the user-session id; the part id lives under emb.session_part_id.
+        XCTAssertEqual(data.attributes[SpanSemantics.keySessionId], .string("user-123"))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyUserSessionId], .string("user-123"))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyPartId], .string("part-123"))
         span.end()
     }
 
-    func test_onStart_doesNotInjectSessionId_whenNil() {
+    func test_onStart_stampsEmptyStringsWhenIdentifiersAreNil() {
         mockDelegate.currentSessionId = nil
+        mockDelegate.currentUserSessionId = nil
         let span = tracer.spanBuilder(spanName: "external").startSpan()
         guard let readable = span as? ReadableSpan else {
             XCTFail("Span does not conform to ReadableSpan")
             return
         }
         let data = readable.toSpanData()
-        XCTAssertNil(data.attributes[SpanSemantics.keySessionId])
+        // Spec: all three identity keys are present even as empty strings.
+        XCTAssertEqual(data.attributes[SpanSemantics.keySessionId], .string(""))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyUserSessionId], .string(""))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyPartId], .string(""))
         span.end()
     }
 
@@ -220,6 +228,7 @@ class MockSpanProcessorDelegate: EmbraceSpanProcessorDelegate {
     var endedSpans: [ReadableSpan] = []
     var currentSessionState: SessionState = .foreground
     var currentSessionId: EmbraceIdentifier? = nil
+    var currentUserSessionId: EmbraceIdentifier? = nil
 
     func isInternalSpan(_ span: ReadableSpan) -> Bool {
         return internalSpanNames.contains(span.name)

--- a/Tests/EmbraceOTelBridgeTests/TestSupport/MockMetadataProvider.swift
+++ b/Tests/EmbraceOTelBridgeTests/TestSupport/MockMetadataProvider.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class MockMetadataProvider: EmbraceMetadataProvider {
     var currentSessionId: EmbraceIdentifier? = EmbraceIdentifier(stringValue: "test-session-id")
+    var currentUserSessionId: EmbraceIdentifier? = EmbraceIdentifier(stringValue: "test-user-session-id")
     var currentProcessId: EmbraceIdentifier = EmbraceIdentifier(stringValue: "test-process-id")
     var currentSessionState: SessionState = .foreground
 }


### PR DESCRIPTION
Finishes the session logic and link the old SessionController with the new UserSessionController.

Note that this PR is pointing to https://github.com/embrace-io/embrace-apple-sdk/pull/586
This PR should be merged first