### PR TITLE
[EMBR-12164] Fix: Restrict hang capture to iOS/tvOS

### DIFF
--- a/Sources/EmbraceCore/Capture/CaptureServices.swift
+++ b/Sources/EmbraceCore/Capture/CaptureServices.swift
@@ -74,11 +74,13 @@ final class CaptureServices {
         }
 
         // Ensure the hang service has the right config
-        if let limits = config?.hangLimits {
-            services
-                .compactMap { $0 as? HangCaptureService }
-                .forEach { $0.limits = limits }
-        }
+        #if !os(watchOS) && !os(macOS)
+            if let limits = config?.hangLimits {
+                services
+                    .compactMap { $0 as? HangCaptureService }
+                    .forEach { $0.limits = limits }
+            }
+        #endif
 
         if let config {
             services.forEach { $0.onConfigUpdated(config) }

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -14,12 +14,13 @@ import OpenTelemetryApi
     import EmbraceConfiguration
 #endif
 
-// CADisplayLink is not available on watchOS, so hang capture based on frame rate
-// is not supported on that platform. watchOS support will be revisited in the future.
-#if !os(watchOS)
+// CADisplayLink is unavailable on watchOS, and on macOS it can only be
+// obtained via NSView/NSWindow/NSScreen.displayLink(target:selector:)
+// rather than constructed standalone — so frame-rate based hang capture
+// is not supported on those platforms.
+#if !os(watchOS) && !os(macOS)
 
     /// Service that generates OpenTelemetry span events for hangs.
-    @available(macOS 14.0, *)
     @objc(EMBHangCaptureService)
     public final class HangCaptureService: CaptureService {
 

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/FrameRateMonitor.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/FrameRateMonitor.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 
     import Foundation
     import QuartzCore
@@ -24,7 +24,6 @@
     /// `preferredFrameRateRange` transitions never produce false positives.
     /// `CADisplayLink` also pauses automatically in the background, so suspend
     /// gaps are excluded without any extra bookkeeping.
-    @available(macOS 14.0, *)
     final class FrameRateMonitor {
 
         /// Apple's own definition of a hang (≈ 250 ms).
@@ -132,4 +131,4 @@
         }
     }
 
-#endif  // !os(watchOS)
+#endif  // !os(watchOS) && !os(macOS)

--- a/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
+++ b/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
@@ -62,8 +62,11 @@ import Foundation
         return PushNotificationCaptureService(options: options)
     }
 
-    #if !os(watchOS)
-        @available(macOS 14.0, *)
+    #if !os(watchOS) && !os(macOS)
+        /// Returns a `HangCaptureService`.
+        /// - Note: Available on iOS and tvOS only. Hang detection relies on
+        ///   `CADisplayLink`, which has no standalone initializer on macOS and
+        ///   is not available on watchOS.
         static func hangWatchdog() -> HangCaptureService {
             return HangCaptureService()
         }

--- a/Sources/EmbraceIO/Capture/CaptureServicesOptionsBuilder.swift
+++ b/Sources/EmbraceIO/Capture/CaptureServicesOptionsBuilder.swift
@@ -184,14 +184,18 @@ public class CaptureServicesOptionsBuilder: NSObject {
         return self
     }
 
-    /// Adds a new `HangCaptureService`.
-    /// - Note: If there was another `HangCaptureService` previously added, it will be replaced with the new one.
-    @available(macOS 14.0, *)
-    @discardableResult
-    public func addHangCaptureService() -> Self {
-        map[.hang] = true
-        return self
-    }
+    #if !os(watchOS) && !os(macOS)
+        /// Adds a new `HangCaptureService`.
+        /// - Note: Available on iOS and tvOS only. Hang detection relies on
+        ///   `CADisplayLink`, which has no standalone initializer on macOS and
+        ///   is not available on watchOS.
+        /// - Note: If there was another `HangCaptureService` previously added, it will be replaced with the new one.
+        @discardableResult
+        public func addHangCaptureService() -> Self {
+            map[.hang] = true
+            return self
+        }
+    #endif
 
     /// Adds the given custom `CaptureService`.
     /// - Note: If there was another `CaptureService` already added of the same type, it will be replaced with the new one.
@@ -240,9 +244,11 @@ public class CaptureServicesOptionsBuilder: NSObject {
             map[.lowPowerMode] = nil
         }
 
-        if type == HangCaptureService.self {
-            map[.hang] = nil
-        }
+        #if !os(watchOS) && !os(macOS)
+            if type == HangCaptureService.self {
+                map[.hang] = nil
+            }
+        #endif
 
         customServices.removeAll(where: { $0.isKind(of: type) })
 

--- a/Sources/EmbraceIO/Options/EmbraceIO+CaptureServicesOptions.swift
+++ b/Sources/EmbraceIO/Options/EmbraceIO+CaptureServicesOptions.swift
@@ -153,8 +153,8 @@ extension EmbraceIO {
                 services.append(LowPowerModeCaptureService())
             }
 
-            #if !os(watchOS)
-                if hang, #available(macOS 14.0, *) {
+            #if !os(watchOS) && !os(macOS)
+                if hang {
                     services.append(HangCaptureService())
                 }
             #endif

--- a/Tests/EmbraceCoreTests/Capture/Hang/FrameRateMonitorTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/FrameRateMonitorTests.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 
     import TestSupport
     import XCTest
@@ -145,4 +145,4 @@
         }
     }
 
-#endif  // !os(watchOS)
+#endif  // !os(watchOS) && !os(macOS)

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -2,7 +2,7 @@
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 
     import EmbraceCommonInternal
     import EmbraceConfiguration
@@ -166,136 +166,136 @@
         }
     }
 
-#endif  // !os(watchOS)
+    // MARK: - Test Helpers
 
-// MARK: - Test Helpers
-
-class MockHangObserver: HangObserver {
-    private let lock = NSLock()
-
-    // Callback handlers
-    private var _onHangStarted: ((Date, TimeInterval) -> Void)?
-    var onHangStarted: ((Date, TimeInterval) -> Void)? {
-        get {
+    class MockHangObserver: HangObserver {
+        private let lock = NSLock()
+    
+        // Callback handlers
+        private var _onHangStarted: ((Date, TimeInterval) -> Void)?
+        var onHangStarted: ((Date, TimeInterval) -> Void)? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return _onHangStarted
+            }
+            set {
+                lock.lock()
+                defer { lock.unlock() }
+                _onHangStarted = newValue
+            }
+        }
+    
+        private var _onHangUpdated: ((Date, TimeInterval) -> Void)?
+        var onHangUpdated: ((Date, TimeInterval) -> Void)? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return _onHangUpdated
+            }
+            set {
+                lock.lock()
+                defer { lock.unlock() }
+                _onHangUpdated = newValue
+            }
+        }
+    
+        private var _onHangEnded: ((Date, TimeInterval) -> Void)?
+        var onHangEnded: ((Date, TimeInterval) -> Void)? {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return _onHangEnded
+            }
+            set {
+                lock.lock()
+                defer { lock.unlock() }
+                _onHangEnded = newValue
+            }
+        }
+    
+        // Tracking properties
+        private var _hangStartedCalled = false
+        var hangStartedCalled: Bool {
             lock.lock()
             defer { lock.unlock() }
-            return _onHangStarted
+            return _hangStartedCalled
         }
-        set {
+    
+        private var _hangUpdatedCalled = false
+        var hangUpdatedCalled: Bool {
             lock.lock()
             defer { lock.unlock() }
-            _onHangStarted = newValue
+            return _hangUpdatedCalled
         }
-    }
-
-    private var _onHangUpdated: ((Date, TimeInterval) -> Void)?
-    var onHangUpdated: ((Date, TimeInterval) -> Void)? {
-        get {
+    
+        private var _hangEndedCalled = false
+        var hangEndedCalled: Bool {
             lock.lock()
             defer { lock.unlock() }
-            return _onHangUpdated
+            return _hangEndedCalled
         }
-        set {
+    
+        private var _hangStartedCallCount = 0
+        var hangStartedCallCount: Int {
             lock.lock()
             defer { lock.unlock() }
-            _onHangUpdated = newValue
+            return _hangStartedCallCount
         }
-    }
-
-    private var _onHangEnded: ((Date, TimeInterval) -> Void)?
-    var onHangEnded: ((Date, TimeInterval) -> Void)? {
-        get {
+    
+        private var _hangUpdatedCallCount = 0
+        var hangUpdatedCallCount: Int {
             lock.lock()
             defer { lock.unlock() }
-            return _onHangEnded
+            return _hangUpdatedCallCount
         }
-        set {
+    
+        private var _hangEndedCallCount = 0
+        var hangEndedCallCount: Int {
             lock.lock()
             defer { lock.unlock() }
-            _onHangEnded = newValue
+            return _hangEndedCallCount
+        }
+    
+        private var _lastHangDuration: TimeInterval = 0
+        var lastHangDuration: TimeInterval {
+            lock.lock()
+            defer { lock.unlock() }
+            return _lastHangDuration
+        }
+    
+        func hangStarted(at: Date, duration: TimeInterval) {
+            lock.lock()
+            _hangStartedCalled = true
+            _hangStartedCallCount += 1
+            _lastHangDuration = duration
+            let callback = _onHangStarted
+            lock.unlock()
+    
+            callback?(at, duration)
+        }
+    
+        func hangUpdated(at: Date, duration: TimeInterval) {
+            lock.lock()
+            _hangUpdatedCalled = true
+            _hangUpdatedCallCount += 1
+            _lastHangDuration = duration
+            let callback = _onHangUpdated
+            lock.unlock()
+    
+            callback?(at, duration)
+        }
+    
+        func hangEnded(at: Date, duration: TimeInterval) {
+            lock.lock()
+            _hangEndedCalled = true
+            _hangEndedCallCount += 1
+            _lastHangDuration = duration
+            let callback = _onHangEnded
+            lock.unlock()
+    
+            callback?(at, duration)
         }
     }
 
-    // Tracking properties
-    private var _hangStartedCalled = false
-    var hangStartedCalled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return _hangStartedCalled
-    }
-
-    private var _hangUpdatedCalled = false
-    var hangUpdatedCalled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return _hangUpdatedCalled
-    }
-
-    private var _hangEndedCalled = false
-    var hangEndedCalled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return _hangEndedCalled
-    }
-
-    private var _hangStartedCallCount = 0
-    var hangStartedCallCount: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _hangStartedCallCount
-    }
-
-    private var _hangUpdatedCallCount = 0
-    var hangUpdatedCallCount: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _hangUpdatedCallCount
-    }
-
-    private var _hangEndedCallCount = 0
-    var hangEndedCallCount: Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return _hangEndedCallCount
-    }
-
-    private var _lastHangDuration: TimeInterval = 0
-    var lastHangDuration: TimeInterval {
-        lock.lock()
-        defer { lock.unlock() }
-        return _lastHangDuration
-    }
-
-    func hangStarted(at: Date, duration: TimeInterval) {
-        lock.lock()
-        _hangStartedCalled = true
-        _hangStartedCallCount += 1
-        _lastHangDuration = duration
-        let callback = _onHangStarted
-        lock.unlock()
-
-        callback?(at, duration)
-    }
-
-    func hangUpdated(at: Date, duration: TimeInterval) {
-        lock.lock()
-        _hangUpdatedCalled = true
-        _hangUpdatedCallCount += 1
-        _lastHangDuration = duration
-        let callback = _onHangUpdated
-        lock.unlock()
-
-        callback?(at, duration)
-    }
-
-    func hangEnded(at: Date, duration: TimeInterval) {
-        lock.lock()
-        _hangEndedCalled = true
-        _hangEndedCallCount += 1
-        _lastHangDuration = duration
-        let callback = _onHangEnded
-        lock.unlock()
-
-        callback?(at, duration)
-    }
-}
+#endif  // !os(watchOS) && !os(macOS)

--- a/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
@@ -37,7 +37,9 @@ class CaptureServiceBuilderTests: XCTestCase {
 
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
-        XCTAssertNil(list.first(where: { $0 is HangCaptureService }))
+        #if !os(watchOS) && !os(macOS)
+            XCTAssertNil(list.first(where: { $0 is HangCaptureService }))
+        #endif
 
         XCTAssertEqual(list.count, count)
 
@@ -60,7 +62,9 @@ class CaptureServiceBuilderTests: XCTestCase {
 
         var count = 3
 
-        XCTAssertNil(list.first(where: { $0 is HangCaptureService }))
+        #if !os(watchOS) && !os(macOS)
+            XCTAssertNil(list.first(where: { $0 is HangCaptureService }))
+        #endif
 
         #if canImport(UIKit) && !os(watchOS)
             count += 2
@@ -111,7 +115,9 @@ class CaptureServiceBuilderTests: XCTestCase {
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
         XCTAssertNotNil(list.first(where: { $0 is LowPowerModeCaptureService }))
 
-        XCTAssertNil(list.first(where: { $0 is HangCaptureService }))
+        #if !os(watchOS) && !os(macOS)
+            XCTAssertNil(list.first(where: { $0 is HangCaptureService }))
+        #endif
 
         XCTAssertEqual(list.count, count)
     }
@@ -217,19 +223,21 @@ class CaptureServiceBuilderTests: XCTestCase {
         XCTAssertNotNil(list.first(where: { $0 is LowMemoryWarningCaptureService }))
     }
 
-    func test_addHangCaptureService() throws {
-        // given a builder
-        let builder = CaptureServiceBuilder()
+    #if !os(watchOS) && !os(macOS)
+        func test_addHangCaptureService() throws {
+            // given a builder
+            let builder = CaptureServiceBuilder()
 
-        // when adding a HangCaptureService
-        builder.add(.hangWatchdog())
+            // when adding a HangCaptureService
+            builder.add(.hangWatchdog())
 
-        // then the list contains the capture service
-        let list = builder.build()
+            // then the list contains the capture service
+            let list = builder.build()
 
-        XCTAssertEqual(list.count, 1)
-        XCTAssertNotNil(list.first(where: { $0 is HangCaptureService }))
-    }
+            XCTAssertEqual(list.count, 1)
+            XCTAssertNotNil(list.first(where: { $0 is HangCaptureService }))
+        }
+    #endif
 
     func test_addLowPowerModeCaptureService() throws {
         // given a builder

--- a/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
@@ -269,32 +269,36 @@ class CaptureServicesOptionsBuilderTests: XCTestCase {
         XCTAssertFalse(options.lowPowerMode)
     }
 
-    func test_hang() throws {
-        // given a builder
-        let builder = CaptureServicesOptionsBuilder()
+    #if !os(watchOS) && !os(macOS)
+        func test_hang() throws {
+            // given a builder
+            let builder = CaptureServicesOptionsBuilder()
 
-        // when adding hang
-        builder.addHangCaptureService()
+            // when adding hang
+            builder.addHangCaptureService()
 
-        // then the result contains the correct options
-        let options = builder.build()
+            // then the result contains the correct options
+            let options = builder.build()
 
-        XCTAssertTrue(options.hang)
-    }
+            XCTAssertTrue(options.hang)
+        }
+    #endif
 
-    func test_hang_remove() throws {
-        // given a builder with default services
-        let builder = CaptureServicesOptionsBuilder()
-        builder.addDefaults()
+    #if !os(watchOS) && !os(macOS)
+        func test_hang_remove() throws {
+            // given a builder with default services
+            let builder = CaptureServicesOptionsBuilder()
+            builder.addDefaults()
 
-        // when removing hang
-        builder.remove(embraceType: .hang)
+            // when removing hang
+            builder.remove(embraceType: .hang)
 
-        // then the result contains the correct options
-        let options = builder.build()
+            // then the result contains the correct options
+            let options = builder.build()
 
-        XCTAssertFalse(options.hang)
-    }
+            XCTAssertFalse(options.hang)
+        }
+    #endif
 
     func test_customService() throws {
         // given a builder


### PR DESCRIPTION
## Summary 

 - Gates the hang feature behind `#if !os(watchOS) && !os(macOS)` everywhere it's referenced; drops the now-unreachable `@available(macOS 14.0, *)` annotations and adds  matching guards in the tests.

## Why

`Build Platforms` has been failing.

  - **watchOS**: `CaptureServices.swift:79` referenced `HangCaptureService` outside the existing `#if !os(watchOS)` block — symbol didn't exist there.
  - **macOS**: the feature could not compile. On iOS/tvOS you create a `CADisplayLink` directly with `CADisplayLink(target:selector:)`. On macOS that initializer doesn't exist — you can only get one by calling `someNSView.displayLink(target:selector:)`, which means you need a view to hang it off of. `FrameRateMonitor` has no view,    so the file can't compile against the macOS SDK regardless of `@available` annotations.

Proper macOS support would require holding a view reference and switching to `NSView.displayLink` — out of scope for this PR.

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
