### PR TITLE
[EMBR-12166] Chore: CI: Surface xcodebuild errors on failure

### DIFF
--- a/.github/actions/run-xcodebuild/action.yml
+++ b/.github/actions/run-xcodebuild/action.yml
@@ -55,6 +55,7 @@ runs:
         SANITIZER: ${{ inputs.sanitizer }}
         CODE_COVERAGE: ${{ inputs.code-coverage }}
         RESULT_BUNDLE_PATH: ${{ inputs.result-bundle-path }}
+        XCODEBUILD_LOG: ${{ runner.temp }}/xcodebuild.log
       run: |
         set -euo pipefail
 
@@ -72,10 +73,15 @@ runs:
           *)            echo "::error::run-xcodebuild: unknown platform '$PLATFORM'"; exit 1 ;;
         esac
 
+        # `-skip*Validation` flags suppress the interactive trust prompt for
+        # SwiftPM plugins and Swift macros, which would hang non-interactive CI.
+        # These are the local equivalent of mxcl/xcodebuild's `trust-plugins: false`.
         ARGS=(
           -workspace "$WORKSPACE"
           -scheme "$SCHEME"
           -destination "$DESTINATION"
+          -skipPackagePluginValidation
+          -skipMacroValidation
         )
 
         if [[ "$XCODE_ACTION" == "test" ]]; then
@@ -98,9 +104,68 @@ runs:
         echo "::endgroup::"
 
         # `set -o pipefail` is the load-bearing line: without it, xcbeautify's
-        # (always 0) exit code would mask xcodebuild failures.
+        # (always 0) exit code would mask xcodebuild failures. `tee` captures
+        # raw xcodebuild output so the next step can grep error: lines —
+        # xcbeautify swallows them into ::error:: annotations that don't show
+        # up in the log itself.
         set -o pipefail
-        xcodebuild "$XCODE_ACTION" "${ARGS[@]}" | xcbeautify --renderer github-actions
+        xcodebuild "$XCODE_ACTION" "${ARGS[@]}" 2>&1 \
+          | tee "$XCODEBUILD_LOG" \
+          | xcbeautify --renderer github-actions
+
+    - name: Summarize xcodebuild log
+      if: failure()
+      shell: bash
+      env:
+        XCODEBUILD_LOG: ${{ runner.temp }}/xcodebuild.log
+      run: |
+        set -euo pipefail
+
+        if [[ ! -r "$XCODEBUILD_LOG" ]]; then
+          echo "::warning::xcodebuild log not readable at $XCODEBUILD_LOG — failure summary unavailable"
+          ls -la "$(dirname "$XCODEBUILD_LOG")" 2>&1 || true
+          exit 0
+        fi
+
+        # `: error: ` is xcodebuild's diagnostic prefix and covers compile
+        # errors, linker (`ld: error: …`), driver (`clang: error: …`), and
+        # XCTest assertion failures (`Tests.swift:13: error: -[Suite t]…`).
+        # Dedup in build order (the first error is usually the root cause)
+        # and cap because a single bad type cascades into dozens of lines.
+        errors=$(grep -E ': error: ' "$XCODEBUILD_LOG" | awk '!seen[$0]++' | head -50)
+
+        if [[ -z "$errors" ]]; then
+          # Failures without `error:` lines (codesigning, install-time,
+          # simulator boot, etc.) — surface the tail so the contributor
+          # isn't stranded with only xcbeautify's filtered output.
+          echo "::group::No 'error:' lines matched — last 200 lines of xcodebuild log"
+          tail -n 200 "$XCODEBUILD_LOG"
+          echo "::endgroup::"
+          echo "### ⚠️ xcodebuild failed without matching \`error:\` lines — see job log" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        error_count=$(printf '%s\n' "$errors" | wc -l | tr -d ' ')
+        echo "::group::xcodebuild errors (${error_count}, first 50, deduplicated in build order)"
+        echo "$errors"
+        echo "::endgroup::"
+
+        {
+          echo "### ❌ xcodebuild errors (${error_count})"
+          echo ""
+          echo '```'
+          echo "$errors"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload xcodebuild log on failure
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: xcodebuild-log-${{ inputs.platform }}-${{ inputs.action }}-${{ inputs.sanitizer }}
+        path: ${{ runner.temp }}/xcodebuild.log
+        if-no-files-found: ignore
+        retention-days: 7
 
     - name: Summarize xcresult
       if: ${{ always() && inputs.action == 'test' }}

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -75,27 +75,11 @@ jobs:
         restore-keys: swiftpm-${{ runner.os }}-
 
     - name: Build
-      uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5 # v3.6.0
+      uses: ./.github/actions/run-xcodebuild
       with:
-        action: build
         workspace: ".swiftpm/xcode/package.xcworkspace"
         scheme: EmbraceIO-Package
         platform: ${{ matrix.platform }}
         platform-version: ${{ matrix.platform-version }}
-        upload-logs: always
-        code-coverage: false
-        trust-plugins: false
         arch: arm64
-
-    # Dumps the xcresult build log into the job log so a compile error
-    # can be diagnosed without downloading the xcresult artifact.
-    - name: Surface failure summary from xcresult
-      if: failure()
-      run: |
-        if [ ! -d build.xcresult ]; then
-          echo "build.xcresult not found in $(pwd); skipping summary."
-          exit 0
-        fi
-        echo "::group::Build log"
-        xcrun xcresulttool get log --path build.xcresult --type build || true
-        echo "::endgroup::"
+        action: build


### PR DESCRIPTION
  - Adopts the local `run-xcodebuild` composite action in `build-platforms.yml`, parallel to what #596 did for `run-tests.yml`.
    - Drops the now-redundant inline `Surface failure summary from xcresult` step.
  - Extends the composite action with failure diagnostics:
    - Captures raw xcodebuild output via `tee` to `$RUNNER_TEMP/xcodebuild.log`.
    - Adds a `Summarize xcodebuild log` step that runs on `failure()`.
    - Uploads the captured log as an artifact on failure.
    - Passes `-skipPackagePluginValidation -skipMacroValidation` to xcodebuild (replaces mxcl's `trust-plugins: false`).

## Why

When the macOS/watchOS builds were failing on PRs, the actual compile errors were buried inside a 56k-line JSON dump from `xcresulttool get log --type build`. The diagnostic info existed but was effectively unreachable without downloading the xcresult artifact.

`xcbeautify --renderer github-actions` (from #596) already turns errors into `::error::` annotations in the GitHub UI — but those don't appear in the raw log, and contributors who scroll the log get a wall of text either way.

## What the new step does

- Greps `: error: ` lines from the captured log — covers compile errors, linker (`ld: error:`), driver (`clang: error:`), and XCTest assertion failures.
- Dedups in build order via `awk '!seen[$0]++'` so the first error (usually the root cause) stays first.
- Caps at 50 lines and includes the error count in both the collapsible log group header and the `### ❌ xcodebuild errors (N)` block in `$GITHUB_STEP_SUMMARY`.
- Falls back to `tail -n 200` of the raw log when no `error:` lines match, so codesign / install-time / simulator-boot failures aren't silent. The fallback emits a `### ⚠️ xcodebuild failed without matching error: lines — see job log` entry to the job summary.
  - Uploads the full log as `xcodebuild-log-<platform>-<action>-<sanitizer>` with 7-day retention.
 
## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
