### PR TITLE
[EMBR-12187] Chore: CI: Retry xcodebuild -downloadPlatform on transient CDN failures

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -57,7 +57,15 @@ jobs:
       run: |
         xcodebuild -runFirstLaunch
         xcrun simctl list
-        xcodebuild -downloadPlatform ${MATRIX_PLATFORM}
+        for i in 1 2 3; do
+          xcodebuild -downloadPlatform "${MATRIX_PLATFORM}" && break
+          if [ "$i" -eq 3 ]; then
+            echo "::error title=downloadPlatform failed::all 3 attempts failed for ${MATRIX_PLATFORM}"
+            exit 1
+          fi
+          echo "::warning title=downloadPlatform retry::attempt $i failed for ${MATRIX_PLATFORM}; retrying in 15s"
+          sleep 15
+        done
         xcodebuild -runFirstLaunch
       env:
         MATRIX_PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/cocoapod-lint.yml
+++ b/.github/workflows/cocoapod-lint.yml
@@ -37,7 +37,15 @@ jobs:
         run: |
           xcodebuild -runFirstLaunch
           xcrun simctl list
-          xcodebuild -downloadPlatform iOS
+          for i in 1 2 3; do
+            xcodebuild -downloadPlatform iOS && break
+            if [ "$i" -eq 3 ]; then
+              echo "::error title=downloadPlatform failed::all 3 attempts failed for iOS"
+              exit 1
+            fi
+            echo "::warning title=downloadPlatform retry::attempt $i failed for iOS; retrying in 15s"
+            sleep 15
+          done
           xcodebuild -runFirstLaunch
 
       - name: Checkout PR

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,15 @@ jobs:
         run: |
           xcodebuild -runFirstLaunch
           xcrun simctl list
-          xcodebuild -downloadPlatform ${MATRIX_PLATFORM}
+          for i in 1 2 3; do
+            xcodebuild -downloadPlatform "${MATRIX_PLATFORM}" && break
+            if [ "$i" -eq 3 ]; then
+              echo "::error title=downloadPlatform failed::all 3 attempts failed for ${MATRIX_PLATFORM}"
+              exit 1
+            fi
+            echo "::warning title=downloadPlatform retry::attempt $i failed for ${MATRIX_PLATFORM}; retrying in 15s"
+            sleep 15
+          done
           xcodebuild -runFirstLaunch
         env:
           MATRIX_PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
  ## Context

  `xcodebuild -downloadPlatform` occasionally fails within seconds with `DVTDownloadable: Download Failed` from Apple's `mobileAsset` CDN. This kills the job before tests ever compile — it's an infra flake, not a code issue. Observed once in the last 100 `run-tests.yml` runs.

## Changes

Wrap the `-downloadPlatform` call in a 3-attempt retry loop (15s pause between attempts) in all three workflows that download simulator runtimes:

  - `.github/workflows/run-tests.yml`
  - `.github/workflows/build-platforms.yml`
  - `.github/workflows/cocoapod-lint.yml`

Each retry emits a `::warning::` annotation so flakes surface on the run summary without digging into logs. If all 3 attempts fail, a `::error::` annotation is emitted before exiting non-zero.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
