### PR TITLE
[EMBR-12008] Feature: Propagating new fields to signals and payloads

### DIFF
--- a/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
+++ b/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
@@ -23,8 +23,14 @@ public enum LastRunState: Int {
 /// These keys are intended for use with `CrashReporter.appendCrashInfo(key:value:)`
 /// and retrieval via `CrashReporter.getCrashInfo(key:)`.
 public struct CrashReporterInfoKey {
-    /// Session identifier (e.g., Embrace session id). Value should be a stable string for the lifetime of the session.
+    /// Session-part identifier. Value is the UUID of the current Embrace session part.
     static public let sessionId = "emb-sid"
+
+    /// User-session identifier. Value is the UUID of the current Embrace user session — the
+    /// logical grouping of one or more parts. Stable across foreground/background transitions
+    /// within a user session; rolls when a new user session begins.
+    static public let userSessionId = "emb-usi"
+
     /// SDK version string (e.g., "5.2.1"). Use to correlate reports with the runtime SDK build.
     static public let sdkVersion = "emb-sdk"
 }

--- a/Sources/EmbraceCommonInternal/OTelBridge/EmbraceMetadataProvider.swift
+++ b/Sources/EmbraceCommonInternal/OTelBridge/EmbraceMetadataProvider.swift
@@ -16,8 +16,7 @@ package protocol EmbraceMetadataProvider: AnyObject {
     var currentSessionId: EmbraceIdentifier? { get }
 
     /// Returns the identifier for the current user session, if any.
-    /// Stamped on spans/logs as both `session.id` (in v7, `session.id` represents the user
-    /// session, not the part) and `emb.user_session_id`.
+    /// Stamped on spans/logs as both `session.id`
     var currentUserSessionId: EmbraceIdentifier? { get }
 
     /// Returns the identifier for the current process

--- a/Sources/EmbraceCommonInternal/OTelBridge/EmbraceMetadataProvider.swift
+++ b/Sources/EmbraceCommonInternal/OTelBridge/EmbraceMetadataProvider.swift
@@ -11,8 +11,14 @@ import Foundation
 /// Protocol used to provide Embrace specific information to 3rd party OTel implementations
 package protocol EmbraceMetadataProvider: AnyObject {
 
-    /// Returns the identifier for the current Embrace session, if any
+    /// Returns the identifier for the current Embrace session part, if any.
+    /// Stamped on spans/logs as `emb.session_part_id`.
     var currentSessionId: EmbraceIdentifier? { get }
+
+    /// Returns the identifier for the current user session, if any.
+    /// Stamped on spans/logs as both `session.id` (in v7, `session.id` represents the user
+    /// session, not the part) and `emb.user_session_id`.
+    var currentUserSessionId: EmbraceIdentifier? { get }
 
     /// Returns the identifier for the current process
     var currentProcessId: EmbraceIdentifier { get }

--- a/Sources/EmbraceCore/Capture/CaptureServices.swift
+++ b/Sources/EmbraceCore/Capture/CaptureServices.swift
@@ -104,6 +104,15 @@ final class CaptureServices {
             object: nil
         )
 
+        // Clear the crash-reporter's user-session id when the active user session ends.
+        // The next part start will repopulate it via `onSessionStart`.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onUserSessionDidEnd),
+            name: Notification.Name.embraceUserSessionDidEnd,
+            object: nil
+        )
+
         Embrace.notificationCenter.addObserver(
             self,
             selector: #selector(onConfigUpdated),
@@ -169,12 +178,17 @@ final class CaptureServices {
     @objc func onSessionStart(notification: Notification) {
         if let session = notification.object as? EmbraceSession {
             crashReporter?.currentSessionId = session.id.stringValue
+            crashReporter?.currentUserSessionId = session.userSessionId?.stringValue
         }
         for service in services { service.onSessionStart() }
     }
 
     @objc func onSessionWillEnd(notification: Notification) {
         for service in services { service.onSessionWillEnd() }
+    }
+
+    @objc func onUserSessionDidEnd(notification: Notification) {
+        crashReporter?.currentUserSessionId = nil
     }
 
     @objc func onConfigUpdated(notification: Notification) {

--- a/Sources/EmbraceCore/Crash/EmbraceCrashReporter.swift
+++ b/Sources/EmbraceCore/Crash/EmbraceCrashReporter.swift
@@ -25,7 +25,11 @@ final class EmbraceCrashReporter {
     private let signalsBlockList: [CrashSignal]
 
     struct MutableData {
-        let internalKeys: [String] = [CrashReporterInfoKey.sdkVersion, CrashReporterInfoKey.sessionId]
+        let internalKeys: [String] = [
+            CrashReporterInfoKey.sdkVersion,
+            CrashReporterInfoKey.sessionId,
+            CrashReporterInfoKey.userSessionId
+        ]
         var allowsInternalDataChange: Bool = false
     }
     private let data = EmbraceMutex(MutableData())
@@ -35,7 +39,7 @@ final class EmbraceCrashReporter {
         return reporter.basePath
     }
 
-    /// Sets the current session identifier that will be included in a crash report.
+    /// Sets the current session-part identifier that will be included in a crash report (`emb-sid`).
     var currentSessionId: String? {
         get {
             getCrashInfo(key: CrashReporterInfoKey.sessionId)
@@ -46,6 +50,22 @@ final class EmbraceCrashReporter {
                 data.withLock { $0.allowsInternalDataChange = false }
             }
             appendCrashInfo(key: CrashReporterInfoKey.sessionId, value: newValue)
+        }
+    }
+
+    /// Sets the current user-session identifier that will be included in a crash report (`emb-usi`).
+    /// A user session groups one or more parts; the value is stable across foreground/background
+    /// transitions within a user session and rolls when a new user session begins.
+    var currentUserSessionId: String? {
+        get {
+            getCrashInfo(key: CrashReporterInfoKey.userSessionId)
+        }
+        set {
+            data.withLock { $0.allowsInternalDataChange = true }
+            defer {
+                data.withLock { $0.allowsInternalDataChange = false }
+            }
+            appendCrashInfo(key: CrashReporterInfoKey.userSessionId, value: newValue)
         }
     }
 

--- a/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
+++ b/Sources/EmbraceCore/Internal/Logs/EmbraceLogAttributesBuilder.swift
@@ -125,15 +125,28 @@ class EmbraceLogAttributesBuilder {
 
     @discardableResult
     func addSessionIdentifier() -> Self {
-        return addSessionIdentifier(currentSession?.id)
+        return addSessionIdentifier(
+            partId: currentSession?.id,
+            userSessionId: currentSession?.userSessionId
+        )
     }
 
     @discardableResult
     func addSessionIdentifier(_ sessionId: EmbraceIdentifier?) -> Self {
-        guard let sessionId = sessionId else {
-            return self
-        }
-        attributes[LogSemantics.keySessionId] = sessionId.stringValue
+        return addSessionIdentifier(partId: sessionId, userSessionId: currentSession?.userSessionId)
+    }
+
+    /// Stamps the three identity keys on the log. All three are always present (empty strings
+    /// when unknown) so the backend can correlate every log back to a user session/part.
+    /// `session.id` carries the user-session UUID in v7; `emb.session_part_id` carries the
+    /// part UUID (the value `session.id` had pre-v7).
+    @discardableResult
+    func addSessionIdentifier(partId: EmbraceIdentifier?, userSessionId: EmbraceIdentifier?) -> Self {
+        let userSessionValue = userSessionId?.stringValue ?? ""
+        let partValue = partId?.stringValue ?? ""
+        attributes[LogSemantics.keySessionId] = userSessionValue
+        attributes[LogSemantics.keyUserSessionId] = userSessionValue
+        attributes[LogSemantics.keyPartId] = partValue
         return self
     }
 

--- a/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
+++ b/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
@@ -51,8 +51,7 @@ extension DefaultOTelSignalsHandler: InternalOTelSignalsHandler {
 
             // Cross-cutting attribute stamping. Every non-session-part span carries the three
             // identity keys so backend correlation works even on spans that started before
-            // an active session existed (in which case the values are empty strings, per the
-            // backend's "presence of `emb.session_part_id` means new SDK" detection).
+            // an active session existed .
             internalAttributes.setSessionIdentity(
                 userSessionId: sessionController?.currentSession?.userSessionId?.stringValue ?? "",
                 partId: sessionId?.stringValue ?? ""

--- a/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
+++ b/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
@@ -37,15 +37,26 @@ extension DefaultOTelSignalsHandler: InternalOTelSignalsHandler {
         var internalAttributes = [String: EmbraceAttributeValue]()
         internalAttributes.setEmbraceType(type)
 
-        // add session id if needed
+        // Resolve the part id used for the spans-to-parts storage association. The session
+        // part span itself carries its id via `keyPartId` in `attributes` (set by
+        // `SessionSpanUtils.span`); every other span inherits the active part from the
+        // session controller.
         var sessionId: EmbraceIdentifier?
         if type == .session {
-            if let value = internalAttributes[SpanSemantics.Session.keyId] as? String {
+            if let value = sanitizedAttributes[SpanSemantics.Session.keyPartId] as? String {
                 sessionId = EmbraceIdentifier(stringValue: value)
             }
         } else {
             sessionId = sessionController?.currentSession?.id
-            internalAttributes.setEmbraceSessionId(sessionId)
+
+            // Cross-cutting attribute stamping. Every non-session-part span carries the three
+            // identity keys so backend correlation works even on spans that started before
+            // an active session existed (in which case the values are empty strings, per the
+            // backend's "presence of `emb.session_part_id` means new SDK" detection).
+            internalAttributes.setSessionIdentity(
+                userSessionId: sessionController?.currentSession?.userSessionId?.stringValue ?? "",
+                partId: sessionId?.stringValue ?? ""
+            )
         }
 
         let finalAttributes = internalAttributes.merging(sanitizedAttributes) { (current, _) in current }
@@ -406,11 +417,14 @@ extension DefaultOTelSignalsHandler: EmbraceOTelDelegate {
 
     /// Attribute keys stamped by `EmbraceSpanProcessor.injectAttributes()` before the span
     /// reaches the delegate. These must always be preserved in storage regardless of the
-    /// attribute count limit.
+    /// attribute count limit. The three identity keys (`session.id`, `emb.user_session_id`,
+    /// `emb.session_part_id`) are protected so the cross-cutting stamping survives sanitization.
     static let bridgeProtectedKeys: Set<String> = [
         SpanSemantics.keyEmbraceType,
         SpanSemantics.Session.keyState,
-        SpanSemantics.keySessionId
+        SpanSemantics.keySessionId,
+        SpanSemantics.Session.keyUserSessionId,
+        SpanSemantics.Session.keyPartId
     ]
 
     public func onStartSpan(_ span: EmbraceSpan) {

--- a/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+MetadataProvider.swift
+++ b/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+MetadataProvider.swift
@@ -12,9 +12,14 @@ import Foundation
 // MARK: - EmbraceMetadataProvider
 extension DefaultOTelSignalsHandler: EmbraceMetadataProvider {
 
-    /// Returns the identifier for the current Embrace session, or `nil` when no session is active.
+    /// Returns the identifier for the current Embrace session part, or `nil` when no part is active.
     package var currentSessionId: EmbraceIdentifier? {
         sessionController?.currentSession?.id
+    }
+
+    /// Returns the identifier for the current user session, or `nil` when no user session is active.
+    package var currentUserSessionId: EmbraceIdentifier? {
+        sessionController?.currentSession?.userSessionId
     }
 
     /// Returns the identifier for the current process.

--- a/Sources/EmbraceCore/Internal/OTel/Dictionary+EmbraceAttributes.swift
+++ b/Sources/EmbraceCore/Internal/OTel/Dictionary+EmbraceAttributes.swift
@@ -13,7 +13,13 @@ extension Dictionary where Key == String, Value == EmbraceAttributeValue {
         self[SpanSemantics.keyEmbraceType] = type.rawValue
     }
 
-    mutating func setEmbraceSessionId(_ sessionId: EmbraceIdentifier?) {
-        self[SpanSemantics.keySessionId] = sessionId?.stringValue
+    /// Stamps the three identity keys that must appear on every span and every log:
+    /// `session.id` (= user-session UUID), `emb.user_session_id`, and `emb.session_part_id`.
+    /// All three are emitted unconditionally — empty strings when unknown — because the
+    /// backend uses the presence of `emb.session_part_id` to detect new SDKs.
+    mutating func setSessionIdentity(userSessionId: String, partId: String) {
+        self[SpanSemantics.keySessionId] = userSessionId
+        self[SpanSemantics.Session.keyUserSessionId] = userSessionId
+        self[SpanSemantics.Session.keyPartId] = partId
     }
 }

--- a/Sources/EmbraceCore/Payload/Builders/SpansPayloadBuilder.swift
+++ b/Sources/EmbraceCore/Payload/Builders/SpansPayloadBuilder.swift
@@ -85,8 +85,7 @@ class SpansPayloadBuilder {
         return SessionSpanUtils.payload(
             from: session,
             span: sessionSpan,
-            properties: customProperties,
-            sessionNumber: session.sessionNumber
+            properties: customProperties
         )
     }
 }

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -102,14 +102,19 @@ class UnsentDataHandler {
 
             var session: EmbraceSession?
 
-            // link session with crash report if possible
+            // link session with crash report if possible. The linked part is, by construction,
+            // the last part of its user session — stamp `.crash` as the termination reason so
+            // the payload's `emb.user_session_termination_reason` reflects the crash. The
+            // stamp overrides any prior end-reason (e.g. `.maxDurationReached` set by the
+            // heartbeat detector) because the crash is the authoritative cause.
             if let rawId = report.sessionId {
                 let sessionId = EmbraceIdentifier(stringValue: rawId)
                 if let fetchedSession = storage.fetchSession(id: sessionId) {
                     session = storage.updateSession(
                         session: fetchedSession,
                         endTime: report.timestamp,
-                        crashReportId: report.id.uuidString
+                        crashReportId: report.id.uuidString,
+                        userSessionTerminationReason: .crash
                     )
                 }
             }

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -115,7 +115,7 @@ extension SpanPayload {
             ),
             Attribute(
                 key: SpanSemantics.Session.keyUserSessionMaxDurationSeconds,
-                value: String(session.userSessionMaxDuration ?? 0)
+                value: String(Int(session.userSessionMaxDuration ?? 0))
             ),
             Attribute(
                 key: SpanSemantics.Session.keyUserSessionInactivityTimeoutSeconds,

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -20,8 +20,13 @@ struct SessionSpanUtils {
         coldStart: Bool
     ) -> EmbraceSpan? {
 
+        // Note: `session.id` (== user-session UUID in v7) and `emb.user_session_id` are NOT
+        // stamped here — the user-session controller's `attachPart` runs after the span is
+        // created in `SessionController.startSession`, so those values aren't known yet.
+        // `SessionSpanUtils.payload` (the wire-format builder) emits them at upload time when
+        // the part record's `userSessionId` column is populated.
         let attributes: [String: String] = [
-            SpanSemantics.Session.keyId: id.stringValue,
+            SpanSemantics.Session.keyPartId: id.stringValue,
             SpanSemantics.Session.keyState: state.rawValue,
             SpanSemantics.Session.keyColdStart: String(coldStart)
         ]
@@ -49,10 +54,9 @@ struct SessionSpanUtils {
     static func payload(
         from session: EmbraceSession,
         span: EmbraceSpan? = nil,
-        properties: [EmbraceMetadata] = [],
-        sessionNumber: EMBInt
+        properties: [EmbraceMetadata] = []
     ) -> SpanPayload {
-        return SpanPayload(from: session, span: span, properties: properties, sessionNumber: sessionNumber)
+        return SpanPayload(from: session, span: span, properties: properties)
     }
 }
 
@@ -60,8 +64,7 @@ extension SpanPayload {
     fileprivate init(
         from session: EmbraceSession,
         span: EmbraceSpan? = nil,
-        properties: [EmbraceMetadata],
-        sessionNumber: EMBInt
+        properties: [EmbraceMetadata]
     ) {
         self.traceId = session.traceId
         self.spanId = session.spanId
@@ -72,47 +75,71 @@ extension SpanPayload {
         self.endTime =
             session.endTime?.nanosecondsSince1970Truncated ?? session.lastHeartbeatTime.nanosecondsSince1970Truncated
 
+        let userSessionIdValue = session.userSessionId?.stringValue ?? ""
+
         var attributeArray: [Attribute] = [
-            Attribute(
-                key: SpanSemantics.keyEmbraceType,
-                value: EmbraceType.session.rawValue
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyId,
-                value: session.id.stringValue
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyState,
-                value: session.state.rawValue
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyColdStart,
-                value: String(session.coldStart)
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyTerminated,
-                value: String(session.appTerminated)
-            ),
-            Attribute(
-                key: SpanSemantics.Session.keyCleanExit,
-                value: String(session.cleanExit)
-            ),
+            Attribute(key: SpanSemantics.keyEmbraceType, value: EmbraceType.session.rawValue),
+
+            // Identity. The backend uses the presence of `emb.session_part_id` to detect new
+            // SDKs, so all three keys are always emitted — empty strings when unknown (pre-v7
+            // legacy rows still in storage at upgrade time).
+            Attribute(key: SpanSemantics.Session.keyId, value: userSessionIdValue),
+            Attribute(key: SpanSemantics.Session.keyUserSessionId, value: userSessionIdValue),
+            Attribute(key: SpanSemantics.Session.keyPartId, value: session.id.stringValue),
+
+            // State
+            Attribute(key: SpanSemantics.Session.keyState, value: session.state.rawValue),
+            Attribute(key: SpanSemantics.Session.keyColdStart, value: String(session.coldStart)),
+            Attribute(key: SpanSemantics.Session.keyTerminated, value: String(session.appTerminated)),
+            Attribute(key: SpanSemantics.Session.keyCleanExit, value: String(session.cleanExit)),
             Attribute(
                 key: SpanSemantics.Session.keyHeartbeat,
                 value: String(session.lastHeartbeatTime.nanosecondsSince1970Truncated)
             ),
+
+            // Counters
             Attribute(
-                key: SpanSemantics.Session.keySessionNumber,
-                value: String(sessionNumber)
+                key: SpanSemantics.Session.keySessionPartNumber,
+                value: String(session.sessionNumber)
+            ),
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionPartIndex,
+                value: String(session.userSessionPartIndex)
+            ),
+
+            // User-session config snapshots — read from the part record, which captured them
+            // when the user session was created. Pre-v7 rows return nil/0; emit defaults.
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionStartTs,
+                value: String((session.userSessionStartTime ?? session.startTime).nanosecondsSince1970Truncated)
+            ),
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionMaxDurationSeconds,
+                value: String(session.userSessionMaxDuration ?? 0)
+            ),
+            Attribute(
+                key: SpanSemantics.Session.keyUserSessionInactivityTimeoutSeconds,
+                value: String(session.userSessionInactivityTimeout ?? 0)
             )
         ]
 
         if let crashId = session.crashReportId {
+            attributeArray.append(Attribute(key: SpanSemantics.Session.keyCrashId, value: crashId))
+        }
+
+        // Termination reason and final-part flag travel together — both emitted only on the
+        // last part of a terminated user session. `emb.is_final_session_part` is `"1"` when
+        // set, otherwise the key is omitted entirely.
+        if let terminationReason = session.userSessionTerminationReason {
             attributeArray.append(
                 Attribute(
-                    key: SpanSemantics.Session.keyCrashId,
-                    value: crashId
-                ))
+                    key: SpanSemantics.Session.keyUserSessionTerminationReason,
+                    value: terminationReason.rawValue
+                )
+            )
+            attributeArray.append(
+                Attribute(key: SpanSemantics.Session.keyIsFinalSessionPart, value: "1")
+            )
         }
 
         attributeArray.append(

--- a/Sources/EmbraceCore/Session/SessionSpanUtils.swift
+++ b/Sources/EmbraceCore/Session/SessionSpanUtils.swift
@@ -119,7 +119,7 @@ extension SpanPayload {
             ),
             Attribute(
                 key: SpanSemantics.Session.keyUserSessionInactivityTimeoutSeconds,
-                value: String(session.userSessionInactivityTimeout ?? 0)
+                value: String(Int(session.userSessionInactivityTimeout ?? 0))
             )
         ]
 

--- a/Sources/EmbraceOTelBridge/EmbraceOTelBridge.swift
+++ b/Sources/EmbraceOTelBridge/EmbraceOTelBridge.swift
@@ -263,6 +263,10 @@ extension EmbraceOTelBridge: EmbraceSpanProcessorDelegate {
     package var currentSessionId: EmbraceIdentifier? {
         metadataProvider?.currentSessionId
     }
+
+    package var currentUserSessionId: EmbraceIdentifier? {
+        metadataProvider?.currentUserSessionId
+    }
 }
 
 // MARK: - EmbraceLogProcessorDelegate

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessor.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessor.swift
@@ -43,7 +43,12 @@ class EmbraceLogProcessor: LogRecordProcessor {
         if let delegate, !delegate.isInternalLog(logRecord) {
             log.setAttribute(key: LogSemantics.keyEmbraceType, value: EmbraceType.message.rawValue)
             log.setAttribute(key: LogSemantics.keyState, value: delegate.currentSessionState.rawValue)
-            log.setAttribute(key: LogSemantics.keySessionId, value: delegate.currentSessionId?.stringValue ?? "")
+
+            let userSessionId = delegate.currentUserSessionId?.stringValue ?? ""
+            let partId = delegate.currentSessionId?.stringValue ?? ""
+            log.setAttribute(key: LogSemantics.keySessionId, value: userSessionId)
+            log.setAttribute(key: LogSemantics.keyUserSessionId, value: userSessionId)
+            log.setAttribute(key: LogSemantics.keyPartId, value: partId)
             delegate.onExternalLogEmitted(log)
         }
 

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessorDelegate.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceLogProcessorDelegate.swift
@@ -25,6 +25,9 @@ package protocol EmbraceLogProcessorDelegate: AnyObject {
     /// The foreground/background state of the current session.
     var currentSessionState: SessionState { get }
 
-    /// The identifier for the current session, or `nil` when no session is active.
+    /// The identifier for the current session part, or `nil` when no part is active.
     var currentSessionId: EmbraceIdentifier? { get }
+
+    /// The identifier for the current user session, or `nil` when no user session is active.
+    var currentUserSessionId: EmbraceIdentifier? { get }
 }

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessor.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessor.swift
@@ -119,11 +119,19 @@ class EmbraceSpanProcessor: SpanProcessor {
 
     /// Stamps external spans with required Embrace attributes before they reach child processors
     /// or the `EmbraceCore` delegate.
+    ///
+    /// Identity is stamped as three keys, always present (empty strings when unknown) so the
+    /// backend can correlate every signal back to a user session/part — `session.id` carries
+    /// the user-session UUID in v7, `emb.user_session_id` mirrors it, and `emb.session_part_id`
+    /// carries the part UUID (the value `session.id` had pre-v7).
     private func injectAttributes(_ span: ReadableSpan, delegate: EmbraceSpanProcessorDelegate) {
         span.setAttribute(key: SpanSemantics.keyEmbraceType, value: .string(EmbraceType.performance.rawValue))
         span.setAttribute(key: SpanSemantics.Session.keyState, value: .string(delegate.currentSessionState.rawValue))
-        if let sessionId = delegate.currentSessionId {
-            span.setAttribute(key: SpanSemantics.keySessionId, value: .string(sessionId.stringValue))
-        }
+
+        let userSessionId = delegate.currentUserSessionId?.stringValue ?? ""
+        let partId = delegate.currentSessionId?.stringValue ?? ""
+        span.setAttribute(key: SpanSemantics.keySessionId, value: .string(userSessionId))
+        span.setAttribute(key: SpanSemantics.Session.keyUserSessionId, value: .string(userSessionId))
+        span.setAttribute(key: SpanSemantics.Session.keyPartId, value: .string(partId))
     }
 }

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessorDelegate.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessorDelegate.swift
@@ -28,6 +28,9 @@ package protocol EmbraceSpanProcessorDelegate: AnyObject {
     /// The foreground/background state of the current session.
     var currentSessionState: SessionState { get }
 
-    /// The identifier for the current session, or `nil` when no session is active.
+    /// The identifier for the current session part, or `nil` when no part is active.
     var currentSessionId: EmbraceIdentifier? { get }
+
+    /// The identifier for the current user session, or `nil` when no user session is active.
+    var currentUserSessionId: EmbraceIdentifier? { get }
 }

--- a/Sources/EmbraceSemantics/Log/LogSemantics.swift
+++ b/Sources/EmbraceSemantics/Log/LogSemantics.swift
@@ -6,7 +6,16 @@ public struct LogSemantics {
     public static let keyEmbraceType = "emb.type"
     public static let keyId = "log.record.uid"
     public static let keyState = "emb.state"
+
+    /// `session.id` identifies the **user session** in v7 (not the part). Stamped on every log.
     public static let keySessionId = "session.id"
+
+    /// `emb.user_session_id` — same value as `session.id` for now. Stamped on every log.
+    public static let keyUserSessionId = "emb.user_session_id"
+
+    /// `emb.session_part_id` — the part UUID. Stamped on every log.
+    public static let keyPartId = "emb.session_part_id"
+
     public static let keyStackTrace = "emb.stacktrace.ios"
     public static let keyPropertiesPrefix = "emb.properties.%@"
 

--- a/Sources/EmbraceSemantics/Span/SpanSemantics+Session.swift
+++ b/Sources/EmbraceSemantics/Span/SpanSemantics+Session.swift
@@ -9,12 +9,45 @@ extension EmbraceType {
 extension SpanSemantics {
     public struct Session {
         public static let name = "emb-session"
+
+        /// `session.id` now identifies the **user session**, not the individual part.
+        /// Stamped on every span and log (empty string when unknown).
         public static let keyId = "session.id"
+
+        /// `emb.user_session_id` — same value as `session.id` for now (until a future override
+        /// API lets customers override `session.id` independently). Stamped on every span and log.
+        public static let keyUserSessionId = "emb.user_session_id"
+
+        /// `emb.session_part_id` — the part UUID (the value `session.id` had historically).
+        /// Stamped on every span and log.
+        public static let keyPartId = "emb.session_part_id"
+
         public static let keyState = "emb.state"
         public static let keyColdStart = "emb.cold_start"
         public static let keyTerminated = "emb.terminated"
         public static let keyCleanExit = "emb.clean_exit"
-        public static let keySessionNumber = "emb.session_number"
+
+        /// Globally-unique per-part counter (renamed from `emb.session_number`).
+        public static let keySessionPartNumber = "emb.session_part_number"
+
+        /// 1-indexed position of the current part within its user session.
+        public static let keyUserSessionPartIndex = "emb.user_session_part_index"
+
+        /// Wall-clock start of the user session, in nanoseconds since epoch.
+        public static let keyUserSessionStartTs = "emb.user_session_start_ts"
+
+        /// Max duration of the user session in seconds (config snapshot taken at user-session creation).
+        public static let keyUserSessionMaxDurationSeconds = "emb.user_session_max_duration_seconds"
+
+        /// Inactivity timeout in seconds (config snapshot taken at user-session creation).
+        public static let keyUserSessionInactivityTimeoutSeconds = "emb.user_session_inactivity_timeout_seconds"
+
+        /// `"1"` on the last part of a terminated user session; omitted otherwise.
+        public static let keyIsFinalSessionPart = "emb.is_final_session_part"
+
+        /// Termination reason on the last part of a terminated user session; omitted otherwise.
+        public static let keyUserSessionTerminationReason = "emb.user_session_termination_reason"
+
         public static let keyHeartbeat = "emb.heartbeat_time_unix_nano"
         public static let keyCrashId = "emb.crash_id"
     }

--- a/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
@@ -37,10 +37,17 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         whenInvokingAddSessionIdentifier()
         whenInvokingBuild()
 
-        thenResultingAttributes(is: ["session.id": identifier.stringValue])
+        // `session.id` carries the user-session UUID in v7 (empty here because the mock has
+        // no user session); `emb.session_part_id` carries the part UUID. All three identity
+        // keys are always present.
+        thenResultingAttributes(is: [
+            "session.id": "",
+            "emb.user_session_id": "",
+            "emb.session_part_id": identifier.stringValue
+        ])
     }
 
-    func testOnNotHavingSession_addSessionIdentifier_addsNothingToAttributes() {
+    func testOnNotHavingSession_addSessionIdentifier_addsEmptyStringsToAttributes() {
         givenSessionControllerWithNoSession()
         givenMetadataFetcher()
         givenEmbraceLogAttributesBuilder()
@@ -48,7 +55,12 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         whenInvokingAddSessionIdentifier()
         whenInvokingBuild()
 
-        thenResultingAttributes(is: .empty())
+        // Spec requires the three keys be present even as empty strings when no session is active.
+        thenResultingAttributes(is: [
+            "session.id": "",
+            "emb.user_session_id": "",
+            "emb.session_part_id": ""
+        ])
     }
 
     // MARK: - addApplicationProperties Tests

--- a/Tests/EmbraceCoreTests/Internal/OTel/DefaultOTelSignalsHandlerInternalTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/OTel/DefaultOTelSignalsHandlerInternalTests.swift
@@ -109,7 +109,14 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
 
         // then the span has the correct internal attributes
         XCTAssertEqual(span.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(span.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        // `session.id` is the user-session UUID (empty when the mock has no user session set);
+        // the part UUID lives under `emb.session_part_id`.
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
+        XCTAssertNotNil(span.attributes["session.id"])
+        XCTAssertNotNil(span.attributes["emb.user_session_id"])
 
         // then the span is saved in storage correctly
         let record = storage.fetchSpan(id: span.context.spanId, traceId: span.context.traceId)
@@ -124,7 +131,10 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
         XCTAssertEqual(record!.links[0].context.traceId, TestConstants.traceId)
         XCTAssertEqual(record!.attributes["key"] as! String, "value")
         XCTAssertEqual(record!.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(record!.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        XCTAssertEqual(
+            record!.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
     }
 
     func test_addInternalSessionEvent() throws {
@@ -192,7 +202,7 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
 
             return log.body == "test" && log.severity == .debug && log.type == .message && log.timestamp == timestamp && log.attributes["key"] as! String == "value"
                 && log.attributes["emb.type"] as! String == "sys.log" && log.attributes["emb.state"] as! String == "foreground"
-                && log.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
+                && log.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
         }
 
         // then the log is saved correctly
@@ -201,7 +211,7 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
 
             return record.body == "test" && record.severity == .debug && record.type == .message && record.timestamp == timestamp && record.attributes["key"] as! String == "value"
                 && record.attributes["emb.type"] as! String == "sys.log" && record.attributes["emb.state"] as! String == "foreground"
-                && record.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue
+                && record.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue
         }
     }
 

--- a/Tests/EmbraceCoreTests/Internal/OTel/DictionaryEmbraceAttributesTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/OTel/DictionaryEmbraceAttributesTests.swift
@@ -16,9 +16,19 @@ class DictionaryEmbraceAttributesTests: XCTestCase {
         XCTAssertEqual(attributes["emb.type"] as! String, "perf")
     }
 
-    func test_setEmbraceSessionId() {
+    func test_setSessionIdentity_stampsThreeKeys() {
         var attributes: EmbraceAttributes = [:]
-        attributes.setEmbraceSessionId(TestConstants.sessionId)
-        XCTAssertEqual(attributes["session.id"] as! String, TestConstants.sessionId.stringValue)
+        attributes.setSessionIdentity(userSessionId: "U1", partId: "P1")
+        XCTAssertEqual(attributes["session.id"] as! String, "U1")
+        XCTAssertEqual(attributes["emb.user_session_id"] as! String, "U1")
+        XCTAssertEqual(attributes["emb.session_part_id"] as! String, "P1")
+    }
+
+    func test_setSessionIdentity_emptyStringsWhenUnknown() {
+        var attributes: EmbraceAttributes = [:]
+        attributes.setSessionIdentity(userSessionId: "", partId: "")
+        XCTAssertEqual(attributes["session.id"] as! String, "")
+        XCTAssertEqual(attributes["emb.user_session_id"] as! String, "")
+        XCTAssertEqual(attributes["emb.session_part_id"] as! String, "")
     }
 }

--- a/Tests/EmbraceCoreTests/Payload/SessionPayloadBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Payload/SessionPayloadBuilderTests.swift
@@ -50,9 +50,9 @@ final class SessionPayloadBuilderTests: XCTestCase {
         // when building a session payload
         let payload = SessionPayloadBuilder.build(for: sessionRecord, storage: storage)
 
-        // then the session span contains the correct session number
+        // then the session span contains the correct session-part number
         let sessionSpan = payload?.data["spans"]?.first { $0.name == "emb-session" }
-        let sessionNumberAttr = sessionSpan?.attributes.first { $0.key == "emb.session_number" }
+        let sessionNumberAttr = sessionSpan?.attributes.first { $0.key == "emb.session_part_number" }
         XCTAssertEqual(sessionNumberAttr?.value, "7")
 
         // and the MetadataRecord counter was NOT touched

--- a/Tests/EmbraceCoreTests/Public/OTel/DefaultOTelSignalsHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Public/OTel/DefaultOTelSignalsHandlerTests.swift
@@ -106,7 +106,10 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
 
         // then the span has the correct internal attributes
         XCTAssertEqual(span.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(span.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
 
         // then the span is saved in storage correctly
         let record = storage.fetchSpan(id: span.context.spanId, traceId: span.context.traceId)
@@ -121,7 +124,10 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
         XCTAssertEqual(record!.links[0].context.traceId, TestConstants.traceId)
         XCTAssertEqual(record!.attributes["key"] as! String, "value")
         XCTAssertEqual(record!.attributes["emb.type"] as! String, "perf")
-        XCTAssertEqual(record!.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        XCTAssertEqual(
+            record!.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
     }
 
     func test_createSpan_failure() throws {
@@ -166,10 +172,24 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
         // given a handler
         // when creating a span passing attributes
         // that would collide with internal ones
-        let span = try XCTUnwrap(handler.createSpan(name: "test", attributes: ["session.id": "test", "emb.type": "test"]))
+        let span = try XCTUnwrap(
+            handler.createSpan(
+                name: "test",
+                attributes: [
+                    "session.id": "test",
+                    "emb.session_part_id": "test",
+                    "emb.type": "test"
+                ]
+            )
+        )
 
-        // then the correct internal attributes are kept
-        XCTAssertEqual(span.attributes["session.id"] as! String, sessionController.currentSession!.id.stringValue)
+        // then the correct internal attributes are kept (caller can't override the part id;
+        // `session.id` is the user-session UUID, which is empty in this test setup since the
+        // mock session controller has no user session attached).
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            sessionController.currentSession!.id.stringValue
+        )
         XCTAssertEqual(span.attributes["emb.type"] as! String, "perf")
     }
 
@@ -464,7 +484,7 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
 
             return log.body == "test" && log.severity == .debug && log.type == .message && log.timestamp == timestamp && log.attributes["key"] as! String == "value"
                 && log.attributes["emb.type"] as! String == "sys.log" && log.attributes["emb.state"] as! String == "foreground"
-                && log.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
+                && log.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue && self.bridge.createLogCallCount == 1
         }
 
         // then the log is saved correctly
@@ -473,7 +493,7 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
 
             return record.body == "test" && record.severity == .debug && record.type == .message && record.timestamp == timestamp && record.attributes["key"] as! String == "value"
                 && record.attributes["emb.type"] as! String == "sys.log" && record.attributes["emb.state"] as! String == "foreground"
-                && record.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue
+                && record.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue
         }
     }
 
@@ -528,7 +548,7 @@ class DefaultOTelSignalsHandlerTests: XCTestCase {
         wait(timeout: .defaultTimeout) {
             let log = self.logController.batcher.batch!.logs[0]
 
-            return log.attributes["emb.type"] as! String == "sys.log" && log.attributes["session.id"] as! String == self.sessionController.currentSession!.id.stringValue
+            return log.attributes["emb.type"] as! String == "sys.log" && log.attributes["emb.session_part_id"] as! String == self.sessionController.currentSession!.id.stringValue
                 && log.attributes["emb.state"] as! String == "foreground"
         }
     }

--- a/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionSpanUtilsTests.swift
@@ -3,6 +3,7 @@
 //
 
 import EmbraceCommonInternal
+import EmbraceSemantics
 import EmbraceStorageInternal
 import TestSupport
 import XCTest
@@ -30,12 +31,17 @@ final class SessionSpanUtilsTests: XCTestCase {
             coldStart: true
         )
 
-        // then the span is correct
+        // then the span is correct. The live attributes carry the part id under
+        // `emb.session_part_id`; the user-session id keys are stamped later (at payload-build
+        // time) because `attachPart` hasn't run yet when the session-part span is created.
         let span = otel.startedSpans[0]
         XCTAssertEqual(span.name, "emb-session")
         XCTAssertEqual(span.type, .session)
         XCTAssertEqual(span.startTime, TestConstants.date)
-        XCTAssertEqual(span.attributes["session.id"] as! String, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(
+            span.attributes["emb.session_part_id"] as! String,
+            TestConstants.sessionId.stringValue
+        )
         XCTAssertEqual(span.attributes["emb.state"] as! String, SessionState.foreground.rawValue)
         XCTAssertEqual(span.attributes["emb.cold_start"] as! String, "true")
     }
@@ -99,9 +105,11 @@ final class SessionSpanUtilsTests: XCTestCase {
     }
 
     func test_payloadFromSesssion() throws {
-        // given a session record
+        // given a session record with a full user-session metadata bag
         let endTime = Date(timeIntervalSince1970: 60)
         let heartbeat = Date(timeIntervalSince1970: 58)
+        let userSessionId = EmbraceIdentifier.random
+        let userSessionStart = Date(timeIntervalSince1970: 10)
 
         let session = MockSession(
             id: TestConstants.sessionId,
@@ -115,13 +123,17 @@ final class SessionSpanUtilsTests: XCTestCase {
             crashReportId: "test",
             coldStart: true,
             cleanExit: false,
-            appTerminated: true
+            appTerminated: true,
+            sessionNumber: 100,
+            userSessionId: userSessionId,
+            userSessionStartTime: userSessionStart,
+            userSessionMaxDuration: 43200,
+            userSessionInactivityTimeout: 1800,
+            userSessionPartIndex: 3
         )
 
-        // when building the session span payload
-        let payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        let payload = SessionSpanUtils.payload(from: session)
 
-        // then the payload is correct
         XCTAssertEqual(payload.name, "emb-session")
         XCTAssertEqual(payload.traceId, TestConstants.traceId)
         XCTAssertEqual(payload.spanId, TestConstants.spanId)
@@ -132,50 +144,85 @@ final class SessionSpanUtilsTests: XCTestCase {
         XCTAssertEqual(payload.events.count, 0)
         XCTAssertEqual(payload.links.count, 0)
 
-        let typeAttribute = payload.attributes.first {
-            $0.key == "emb.type"
+        func attribute(_ key: String) -> String? {
+            payload.attributes.first { $0.key == key }?.value
         }
-        XCTAssertEqual(typeAttribute!.value, "ux.session")
 
-        let sessionAttribute = payload.attributes.first {
-            $0.key == "session.id"
-        }
-        XCTAssertEqual(sessionAttribute!.value, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(attribute("emb.type"), "ux.session")
 
-        let stateAttribute = payload.attributes.first {
-            $0.key == "emb.state"
-        }
-        XCTAssertEqual(stateAttribute!.value, SessionState.foreground.rawValue)
+        // Identity: session.id is the user-session id (not the part id); emb.session_part_id is the part.
+        XCTAssertEqual(attribute("session.id"), userSessionId.stringValue)
+        XCTAssertEqual(attribute("emb.user_session_id"), userSessionId.stringValue)
+        XCTAssertEqual(attribute("emb.session_part_id"), TestConstants.sessionId.stringValue)
 
-        let coldStartAttribute = payload.attributes.first {
-            $0.key == "emb.cold_start"
-        }
-        XCTAssertEqual(coldStartAttribute!.value, "true")
+        XCTAssertEqual(attribute("emb.state"), SessionState.foreground.rawValue)
+        XCTAssertEqual(attribute("emb.cold_start"), "true")
+        XCTAssertEqual(attribute("emb.terminated"), "true")
+        XCTAssertEqual(attribute("emb.clean_exit"), "false")
+        XCTAssertEqual(attribute("emb.heartbeat_time_unix_nano"), String(heartbeat.nanosecondsSince1970Truncated))
 
-        let terminatedAttribute = payload.attributes.first {
-            $0.key == "emb.terminated"
-        }
-        XCTAssertEqual(terminatedAttribute!.value, "true")
+        // Counters
+        XCTAssertEqual(attribute("emb.session_part_number"), "100")
+        XCTAssertEqual(attribute("emb.user_session_part_index"), "3")
 
-        let cleanExitAttribute = payload.attributes.first {
-            $0.key == "emb.clean_exit"
-        }
-        XCTAssertEqual(cleanExitAttribute!.value, "false")
+        // User-session config snapshots
+        XCTAssertEqual(attribute("emb.user_session_start_ts"), String(userSessionStart.nanosecondsSince1970Truncated))
+        XCTAssertEqual(attribute("emb.user_session_max_duration_seconds"), "43200.0")
+        XCTAssertEqual(attribute("emb.user_session_inactivity_timeout_seconds"), "1800.0")
 
-        let heartbeatAttribute = payload.attributes.first {
-            $0.key == "emb.heartbeat_time_unix_nano"
-        }
-        XCTAssertEqual(heartbeatAttribute!.value, String(heartbeat.nanosecondsSince1970Truncated))
+        XCTAssertEqual(attribute("emb.crash_id"), "test")
 
-        let sessionNumberAttribute = payload.attributes.first {
-            $0.key == "emb.session_number"
-        }
-        XCTAssertEqual(sessionNumberAttribute!.value, "100")
+        // Old key gone, no termination-reason-related keys when not set.
+        XCTAssertNil(attribute("emb.session_number"))
+        XCTAssertNil(attribute("emb.user_session_termination_reason"))
+        XCTAssertNil(attribute("emb.is_final_session_part"))
+    }
 
-        let crashIdAttribute = payload.attributes.first {
-            $0.key == "emb.crash_id"
+    func test_payload_emitsTerminationReasonAndFinalPartFlagOnLastPart() throws {
+        let session = MockSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: TestConstants.date,
+            sessionNumber: 5,
+            userSessionId: EmbraceIdentifier.random,
+            userSessionStartTime: TestConstants.date,
+            userSessionMaxDuration: 43200,
+            userSessionInactivityTimeout: 1800,
+            userSessionPartIndex: 2,
+            userSessionTerminationReason: .manual
+        )
+
+        let payload = SessionSpanUtils.payload(from: session)
+
+        let terminationReason = payload.attributes.first { $0.key == "emb.user_session_termination_reason" }
+        let finalPartFlag = payload.attributes.first { $0.key == "emb.is_final_session_part" }
+        XCTAssertEqual(terminationReason?.value, "manual")
+        XCTAssertEqual(finalPartFlag?.value, "1")
+    }
+
+    func test_payload_legacySessionEmitsEmptyUserSessionId() throws {
+        // Pre-v7 row: no user-session columns set.
+        let session = MockSession(
+            id: TestConstants.sessionId,
+            processId: TestConstants.processId,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: TestConstants.date
+        )
+
+        let payload = SessionSpanUtils.payload(from: session)
+
+        func attribute(_ key: String) -> String? {
+            payload.attributes.first { $0.key == key }?.value
         }
-        XCTAssertEqual(crashIdAttribute!.value, "test")
+
+        XCTAssertEqual(attribute("session.id"), "")
+        XCTAssertEqual(attribute("emb.user_session_id"), "")
+        XCTAssertEqual(attribute("emb.session_part_id"), TestConstants.sessionId.stringValue)
     }
 
     func test_status() {
@@ -195,7 +242,7 @@ final class SessionSpanUtilsTests: XCTestCase {
             appTerminated: true
         )
 
-        var payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        var payload = SessionSpanUtils.payload(from: session)
         XCTAssertEqual(payload.status, "ok")
 
         // test error status
@@ -214,7 +261,7 @@ final class SessionSpanUtilsTests: XCTestCase {
             appTerminated: true
         )
 
-        payload = SessionSpanUtils.payload(from: session, sessionNumber: 100)
+        payload = SessionSpanUtils.payload(from: session)
         XCTAssertEqual(payload.status, "error")
     }
 
@@ -228,7 +275,7 @@ final class SessionSpanUtilsTests: XCTestCase {
         ]
 
         // when building the session span payload
-        let payload = SessionSpanUtils.payload(from: session, properties: properties, sessionNumber: 100)
+        let payload = SessionSpanUtils.payload(from: session, properties: properties)
 
         XCTAssertGreaterThanOrEqual(payload.attributes.count, 3)
         let permanentCustomProperty = payload.attributes.first {
@@ -273,7 +320,7 @@ final class SessionSpanUtilsTests: XCTestCase {
         )
 
         // when building the session span payload
-        let payload = SessionSpanUtils.payload(from: session, properties: properties, sessionNumber: 100)
+        let payload = SessionSpanUtils.payload(from: session, properties: properties)
 
         XCTAssertFalse(payload.attributes.contains(where: { $0.key == "emb.user.username " }))
         XCTAssertFalse(payload.attributes.contains(where: { $0.key == "emb.user.email" }))

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -425,7 +425,10 @@ class UnsentDataHandlerTests: XCTestCase {
         XCTAssertEqual(otel.logs[0].timestamp, report.timestamp)
         XCTAssertEqual(otel.logs[0].body, "")
         XCTAssertEqual(otel.logs[0].severity, .fatal)
-        XCTAssertEqual(otel.logs[0].attributes["session.id"] as! String, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(
+            otel.logs[0].attributes["emb.session_part_id"] as! String,
+            TestConstants.sessionId.stringValue
+        )
         XCTAssertEqual(otel.logs[0].attributes["emb.state"] as! String, SessionState.foreground.rawValue)
         XCTAssertEqual(otel.logs[0].attributes["log.record.uid"] as! String, report.id.withoutHyphen)
         XCTAssertEqual(otel.logs[0].attributes["emb.provider"] as! String, report.provider)

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -435,6 +435,72 @@ class UnsentDataHandlerTests: XCTestCase {
         XCTAssertEqual(otel.logs[0].attributes["emb.payload"] as! String, report.payload)
     }
 
+    func test_sendCrashReports_stampsCrashTerminationReasonOnLinkedSession() async throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on watchOS")
+
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let otel = MockOTelSignalsHandler()
+        let crashReporter = CrashReporterMock(crashSessionId: TestConstants.sessionId.stringValue)
+        let embraceReporter = EmbraceCrashReporter(reporter: crashReporter)
+
+        // and a finished session in storage that the crash report will link to
+        await storage.addSession(
+            id: TestConstants.sessionId,
+            processId: ProcessIdentifier.current,
+            state: .foreground,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date(timeIntervalSinceNow: -60),
+            endTime: Date()
+        )
+
+        // The session is deleted by `sendUnsentData`'s session-uploader path at the end of
+        // the flow, so observe the in-flight update via a Core Data listener — it captures
+        // the moment `updateSession` writes the new fields.
+        let listener = CoreDataListener()
+        let didStamp = XCTestExpectation()
+        listener.onUpdatedObjects = { records in
+            for record in records {
+                if let session = record as? SessionRecord,
+                    session.crashReportId != nil,
+                    session.userSessionTerminationReason == TerminationReason.crash.rawValue
+                {
+                    didStamp.fulfill()
+                    return
+                }
+            }
+        }
+
+        await UnsentDataHandler.sendUnsentData(
+            storage: storage, upload: nil, otel: otel, crashReporter: embraceReporter
+        )
+
+        await fulfillment(of: [didStamp], timeout: .defaultTimeout)
+        _ = listener  // keep alive for the duration of the test
+    }
+
+    func test_sendCrashReports_unlinkedReport_doesNotCrash() async throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on watchOS")
+
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let otel = MockOTelSignalsHandler()
+        // Crash report points at a session id that doesn't exist in storage.
+        let crashReporter = CrashReporterMock(crashSessionId: EmbraceIdentifier.random.stringValue)
+        let embraceReporter = EmbraceCrashReporter(reporter: crashReporter)
+
+        // no exception expected; storage stays empty
+        await UnsentDataHandler.sendUnsentData(
+            storage: storage, upload: nil, otel: otel, crashReporter: embraceReporter
+        )
+        wait(delay: .shortTimeout)
+
+        XCTAssertEqual((storage.fetchAll() as [SessionRecord]).count, 0)
+    }
+
     func test_spanCleanUp_sendUnsentData() async throws {
         // mock successful requests
         EmbraceHTTPMock.mock(url: testSpansUrl())

--- a/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
+++ b/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
@@ -41,6 +41,39 @@
             XCTAssertEqual(crashReporter.getCrashInfo(key: CrashReporterInfoKey.sessionId), sessionId.stringValue)
         }
 
+        func test_currentUserSessionId_writesEmbUsi() {
+            givenCrashReporter()
+
+            let userSessionId = EmbraceIdentifier.random
+            crashReporter.currentUserSessionId = userSessionId.stringValue
+
+            XCTAssertEqual(
+                crashReporter.getCrashInfo(key: CrashReporterInfoKey.userSessionId),
+                userSessionId.stringValue
+            )
+            XCTAssertEqual(crashReporter.currentUserSessionId, userSessionId.stringValue)
+        }
+
+        func test_currentUserSessionId_clearsWhenSetToNil() {
+            givenCrashReporter()
+
+            crashReporter.currentUserSessionId = "U1"
+            XCTAssertEqual(crashReporter.currentUserSessionId, "U1")
+
+            crashReporter.currentUserSessionId = nil
+            XCTAssertNil(crashReporter.currentUserSessionId)
+        }
+
+        func test_currentUserSessionId_cannotBeOverriddenByPlainAppendCrashInfo() {
+            givenCrashReporter()
+
+            crashReporter.currentUserSessionId = "real-user-session"
+            // External callers cannot overwrite the internal keys via the generic API.
+            crashReporter.appendCrashInfo(key: CrashReporterInfoKey.userSessionId, value: "spoofed")
+
+            XCTAssertEqual(crashReporter.currentUserSessionId, "real-user-session")
+        }
+
         func test_sdkVersion() {
             givenCrashReporter()
 

--- a/Tests/EmbraceOTelBridgeTests/EmbraceLogProcessorTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/EmbraceLogProcessorTests.swift
@@ -66,7 +66,8 @@ final class EmbraceLogProcessorTests: XCTestCase {
 
     func test_onEmit_injectsEmbraceAttributesOnExternalLog() {
         mockDelegate.currentSessionState = .background
-        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "log-session-123")
+        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "part-123")
+        mockDelegate.currentUserSessionId = EmbraceIdentifier(stringValue: "user-123")
 
         emitLog(body: "external-log")
 
@@ -74,7 +75,10 @@ final class EmbraceLogProcessorTests: XCTestCase {
         let log = mockDelegate.emittedLogs.first
         XCTAssertEqual(log?.attributes[LogSemantics.keyEmbraceType], .string(EmbraceType.message.rawValue))
         XCTAssertEqual(log?.attributes[LogSemantics.keyState], .string("background"))
-        XCTAssertEqual(log?.attributes[LogSemantics.keySessionId], .string("log-session-123"))
+        // session.id carries the user-session id; the part id lives under emb.session_part_id.
+        XCTAssertEqual(log?.attributes[LogSemantics.keySessionId], .string("user-123"))
+        XCTAssertEqual(log?.attributes[LogSemantics.keyUserSessionId], .string("user-123"))
+        XCTAssertEqual(log?.attributes[LogSemantics.keyPartId], .string("part-123"))
     }
 
     // MARK: - Child processor forwarding
@@ -167,6 +171,7 @@ class MockLogProcessorDelegate: EmbraceLogProcessorDelegate {
     var emittedLogs: [ReadableLogRecord] = []
     var currentSessionState: SessionState = .foreground
     var currentSessionId: EmbraceIdentifier? = nil
+    var currentUserSessionId: EmbraceIdentifier? = nil
 
     func isInternalLog(_ log: ReadableLogRecord) -> Bool {
         guard case let .string(body) = log.body else { return false }

--- a/Tests/EmbraceOTelBridgeTests/EmbraceSpanProcessorTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/EmbraceSpanProcessorTests.swift
@@ -66,7 +66,8 @@ final class EmbraceSpanProcessorTests: XCTestCase {
 
     func test_onStart_injectsEmbraceTypeOnExternalSpan() {
         mockDelegate.currentSessionState = .foreground
-        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "session-123")
+        mockDelegate.currentSessionId = EmbraceIdentifier(stringValue: "part-123")
+        mockDelegate.currentUserSessionId = EmbraceIdentifier(stringValue: "user-123")
         let span = tracer.spanBuilder(spanName: "external").startSpan()
 
         guard let readable = span as? ReadableSpan else {
@@ -76,19 +77,26 @@ final class EmbraceSpanProcessorTests: XCTestCase {
         let data = readable.toSpanData()
         XCTAssertEqual(data.attributes[SpanSemantics.keyEmbraceType], .string(EmbraceType.performance.rawValue))
         XCTAssertEqual(data.attributes[SpanSemantics.Session.keyState], .string("foreground"))
-        XCTAssertEqual(data.attributes[SpanSemantics.keySessionId], .string("session-123"))
+        // session.id carries the user-session id; the part id lives under emb.session_part_id.
+        XCTAssertEqual(data.attributes[SpanSemantics.keySessionId], .string("user-123"))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyUserSessionId], .string("user-123"))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyPartId], .string("part-123"))
         span.end()
     }
 
-    func test_onStart_doesNotInjectSessionId_whenNil() {
+    func test_onStart_stampsEmptyStringsWhenIdentifiersAreNil() {
         mockDelegate.currentSessionId = nil
+        mockDelegate.currentUserSessionId = nil
         let span = tracer.spanBuilder(spanName: "external").startSpan()
         guard let readable = span as? ReadableSpan else {
             XCTFail("Span does not conform to ReadableSpan")
             return
         }
         let data = readable.toSpanData()
-        XCTAssertNil(data.attributes[SpanSemantics.keySessionId])
+        // Spec: all three identity keys are present even as empty strings.
+        XCTAssertEqual(data.attributes[SpanSemantics.keySessionId], .string(""))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyUserSessionId], .string(""))
+        XCTAssertEqual(data.attributes[SpanSemantics.Session.keyPartId], .string(""))
         span.end()
     }
 
@@ -220,6 +228,7 @@ class MockSpanProcessorDelegate: EmbraceSpanProcessorDelegate {
     var endedSpans: [ReadableSpan] = []
     var currentSessionState: SessionState = .foreground
     var currentSessionId: EmbraceIdentifier? = nil
+    var currentUserSessionId: EmbraceIdentifier? = nil
 
     func isInternalSpan(_ span: ReadableSpan) -> Bool {
         return internalSpanNames.contains(span.name)

--- a/Tests/EmbraceOTelBridgeTests/TestSupport/MockMetadataProvider.swift
+++ b/Tests/EmbraceOTelBridgeTests/TestSupport/MockMetadataProvider.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class MockMetadataProvider: EmbraceMetadataProvider {
     var currentSessionId: EmbraceIdentifier? = EmbraceIdentifier(stringValue: "test-session-id")
+    var currentUserSessionId: EmbraceIdentifier? = EmbraceIdentifier(stringValue: "test-user-session-id")
     var currentProcessId: EmbraceIdentifier = EmbraceIdentifier(stringValue: "test-process-id")
     var currentSessionState: SessionState = .foreground
 }


### PR DESCRIPTION
This PR adds the new  user session related keys to our payloads and generated otel signals.

Note that this PR is pointing to https://github.com/embrace-io/embrace-apple-sdk/pull/613
This PR should be merged first