### PR TITLE
[EMBR-12209] Chore: CI: Replace mxcl/xcodebuild with local composite action in cocoapod-lint.yml

### DIFF
--- a/.github/workflows/cocoapod-lint.yml
+++ b/.github/workflows/cocoapod-lint.yml
@@ -69,12 +69,12 @@ jobs:
         run: pod install
 
       - name: Build BrandGame-CocoaPods
-        uses: mxcl/xcodebuild@d3ee9b419c1be9a988086c58fe0988f32d99cfc5 # v3.6.0
+        uses: ./.github/actions/run-xcodebuild
         with:
-          action: build
           workspace: Examples/BrandGame-CocoaPods/BrandGame.xcworkspace
           scheme: BrandGame
           platform: iOS
+          action: build
 
       - name: Lint Podspec
         id: lint


### PR DESCRIPTION
  - Mirrors PR #596, which removed `mxcl/xcodebuild` from `run-tests.yml`. The `cocoapod-lint` workflow was the only remaining caller of the deprecated Node-20 action, so this completes the migration and silences the "Node.js 20 actions are deprecated" annotation on every CI run.
- Behavior delta: the composite action pins the iOS Simulator destination to `iPhone 16, OS=latest` for `action: build`. Functionally equivalent for the BrandGame example.
- `permissions: checks: write` + `pull-requests: write` on the job are now unused; deliberately left in place for a follow-up cleanup.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
