### PR TITLE
[EMBR-12265] Chore: Chore: CI: Surface example-app build errors, skip absent projects

### DIFF
--- a/.github/actions/run-xcodebuild/action.yml
+++ b/.github/actions/run-xcodebuild/action.yml
@@ -1,14 +1,19 @@
 name: Run xcodebuild
 description: >
-  Runs `xcodebuild build` or `xcodebuild test` against a workspace, with a
-  destination resolved from `platform`+`platform-version`, optional sanitizer
-  and code-coverage flags, output piped through xcbeautify, and an inline
-  xcresult summary on failure. Replaces mxcl/xcodebuild for Node-24 readiness.
+  Runs `xcodebuild build` or `xcodebuild test` against a workspace or project,
+  with a destination resolved from `platform`+`platform-version`, optional
+  sanitizer and code-coverage flags, output piped through xcbeautify, and an
+  inline xcresult summary on failure.
 
 inputs:
   workspace:
-    description: Path to the .xcworkspace.
-    required: true
+    description: Path to the .xcworkspace. Mutually exclusive with `project`.
+    required: false
+    default: ''
+  project:
+    description: Path to the .xcodeproj. Mutually exclusive with `workspace`.
+    required: false
+    default: ''
   scheme:
     description: Scheme to build/test.
     required: true
@@ -47,6 +52,7 @@ runs:
       shell: bash
       env:
         WORKSPACE: ${{ inputs.workspace }}
+        PROJECT: ${{ inputs.project }}
         SCHEME: ${{ inputs.scheme }}
         PLATFORM: ${{ inputs.platform }}
         PLATFORM_VERSION: ${{ inputs.platform-version }}
@@ -58,6 +64,17 @@ runs:
         XCODEBUILD_LOG: ${{ runner.temp }}/xcodebuild.log
       run: |
         set -euo pipefail
+
+        # Exactly one of workspace/project must be provided — they map to
+        # mutually exclusive xcodebuild flags.
+        if [[ -n "$WORKSPACE" && -n "$PROJECT" ]]; then
+          echo "::error::run-xcodebuild: set either 'workspace' or 'project', not both"
+          exit 1
+        fi
+        if [[ -z "$WORKSPACE" && -z "$PROJECT" ]]; then
+          echo "::error::run-xcodebuild: one of 'workspace' or 'project' is required"
+          exit 1
+        fi
 
         # An unset matrix field interpolates to empty string in the caller, which
         # would land here as `OS=,name=...` — coerce empty back to `latest`.
@@ -77,12 +94,16 @@ runs:
         # SwiftPM plugins and Swift macros, which would hang non-interactive CI.
         # These are the local equivalent of mxcl/xcodebuild's `trust-plugins: false`.
         ARGS=(
-          -workspace "$WORKSPACE"
           -scheme "$SCHEME"
           -destination "$DESTINATION"
           -skipPackagePluginValidation
           -skipMacroValidation
         )
+        if [[ -n "$WORKSPACE" ]]; then
+          ARGS=(-workspace "$WORKSPACE" "${ARGS[@]}")
+        else
+          ARGS=(-project "$PROJECT" "${ARGS[@]}")
+        fi
 
         if [[ "$XCODE_ACTION" == "test" ]]; then
           rm -rf "$RESULT_BUNDLE_PATH"
@@ -90,6 +111,13 @@ runs:
           if [[ "$CODE_COVERAGE" == "true" ]]; then
             ARGS+=(-enableCodeCoverage YES)
           fi
+        fi
+
+        # GitHub runners have no signing identity, so `xcodebuild build` against
+        # an app target fails at the codesign phase without these. The `test`
+        # path doesn't trip this — its test-runner driver skips install/sign.
+        if [[ "$XCODE_ACTION" == "build" ]]; then
+          ARGS+=(CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO)
         fi
 
         case "$SANITIZER" in
@@ -162,7 +190,7 @@ runs:
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: xcodebuild-log-${{ inputs.platform }}-${{ inputs.action }}-${{ inputs.sanitizer }}
+        name: xcodebuild-log-${{ inputs.scheme }}-${{ inputs.platform }}-${{ inputs.action }}-${{ inputs.sanitizer }}
         path: ${{ runner.temp }}/xcodebuild.log
         if-no-files-found: ignore
         retention-days: 7

--- a/.github/workflows/build-example-apps.yml
+++ b/.github/workflows/build-example-apps.yml
@@ -17,36 +17,39 @@ jobs:
       fail-fast: false
       matrix:
         xcode_version: ["26.0"]
+    env:
+      PROJECT_DIR: ./Examples/BrandGame
+      PROJECT_NAME: BrandGame.xcodeproj
+      SCHEME: BrandGame
     steps:
-      - name: Select Xcode
-        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-        run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
-          xcodebuild -version
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 4
         with:
           persist-credentials: false
 
-      - name: xcodebuild
-        env:
-          PROJECT_DIR: ./Examples/BrandGame
-          PROJECT_NAME: BrandGame.xcodeproj
-          SCHEME: BrandGame
-          IS_XCTEST: true # Needed to disable SwiftLint -> SwiftSyntax plugin dependency build issue
+      - name: Check project exists
+        id: check
         run: |
-          set -o pipefail
+          if [[ ! -d "$PROJECT_DIR/$PROJECT_NAME" ]]; then
+            echo "::notice title=Example app not on this branch::$PROJECT_DIR/$PROJECT_NAME is absent — skipping the build"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
 
-          BUILD_DIR="$PROJECT_DIR/.build"
+      - name: Select Xcode
+        if: steps.check.outputs.skip != 'true'
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
+          xcodebuild -version
 
-          xcodebuild build -project "$PROJECT_DIR/$PROJECT_NAME" \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
-            -scheme $SCHEME \
-            -sdk iphonesimulator \
-            -derivedDataPath $BUILD_DIR/DerivedData \
-            -clonedSourcePackagesDirPath $BUILD_DIR \
-          | xcpretty
+      - name: Build
+        if: steps.check.outputs.skip != 'true'
+        uses: ./.github/actions/run-xcodebuild
+        with:
+          project: ${{ env.PROJECT_DIR }}/${{ env.PROJECT_NAME }}
+          scheme: ${{ env.SCHEME }}
+          platform: iOS
+          action: build
 
   build-demoobjc-app:
     name: Build Objc Demo App
@@ -56,33 +59,36 @@ jobs:
       fail-fast: false
       matrix:
         xcode_version: ["26.0"]
+    env:
+      PROJECT_DIR: ./Examples/DemoObjectiveC
+      PROJECT_NAME: DemoObjectiveC.xcodeproj
+      SCHEME: DemoObjectiveC
     steps:
-      - name: Select Xcode
-        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
-        run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
-          xcodebuild -version
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 4
         with:
           persist-credentials: false
 
-      - name: xcodebuild
-        env:
-          PROJECT_DIR: ./Examples/DemoObjectiveC
-          PROJECT_NAME: DemoObjectiveC.xcodeproj
-          SCHEME: DemoObjectiveC
-          IS_XCTEST: true # Needed to disable SwiftLint -> SwiftSyntax plugin dependency build issue
+      - name: Check project exists
+        id: check
         run: |
-          set -o pipefail
+          if [[ ! -d "$PROJECT_DIR/$PROJECT_NAME" ]]; then
+            echo "::notice title=Example app not on this branch::$PROJECT_DIR/$PROJECT_NAME is absent — skipping the build"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
 
-          BUILD_DIR="$PROJECT_DIR/.build"
+      - name: Select Xcode
+        if: steps.check.outputs.skip != 'true'
+        # See https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
+          xcodebuild -version
 
-          xcodebuild build -project "$PROJECT_DIR/$PROJECT_NAME" \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
-            -scheme $SCHEME \
-            -sdk iphonesimulator \
-            -derivedDataPath $BUILD_DIR/DerivedData \
-            -clonedSourcePackagesDirPath $BUILD_DIR \
-          | xcpretty
+      - name: Build
+        if: steps.check.outputs.skip != 'true'
+        uses: ./.github/actions/run-xcodebuild
+        with:
+          project: ${{ env.PROJECT_DIR }}/${{ env.PROJECT_NAME }}
+          scheme: ${{ env.SCHEME }}
+          platform: iOS
+          action: build


### PR DESCRIPTION
## Summary

Two workflow-hygiene fixes to `build-example-apps.yml`. Both affect 7.0-descendant PRs today 

### 1. Surface real xcodebuild errors

`build-example-apps.yml` piped `xcodebuild` into `xcpretty` with no `set -o pipefail`, so failures showed up as `** BUILD FAILED ** / exit 65` with the actual `error:` lines swallowed into unreadable escape sequences. PR #586's `Build BrandGame App` failure hid a plain `cannot find 'Embrace' in scope`.

Migrated both jobs to the `./.github/actions/run-xcodebuild` composite action (the same one #594 introduced for `run-tests.yml`), which already does `pipefail` + raw-log `tee` + grep-and-annotate `error:` lines + log artifact upload. To make that work for projects, the action grew an optional `project` input alongside `workspace` (exactly one required), and folds `CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO` in when `action: build` since example-app builds always want unsigned. Artifact name now includes `scheme` so the two example-app jobs in one run don't   collide.

### 2. Skip per-app jobs when the project file is absent

`Examples/DemoObjectiveC/DemoObjectiveC.xcodeproj` exists on `main` but not on `7.0`, so every 7.0-descendant PR carried a permanent red ✕ on `Build Objc Demo App` with `does not exist`.

Each job now begins with a `Check project exists` step. If the `.xcodeproj` is missing, it emits a `::notice::` and sets `skip=true`, and the downstream `Select Xcode` / `Build` steps are gated on `steps.check.outputs.skip != 'true'`. 

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
