### PR TITLE
[EMBR-12275] Fix: Fix: CocoaPods: Declare EmbraceSemantics dependency for EmbraceConfiguration subspec

### DIFF
--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -77,6 +77,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'EmbraceConfiguration' do |subs|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
+    subs.dependency "EmbraceIO/EmbraceSemantics"
   end
 
   spec.subspec 'EmbraceOTelInternal' do |subs|

--- a/bin/templates/EmbraceIO.podspec.tpl
+++ b/bin/templates/EmbraceIO.podspec.tpl
@@ -75,6 +75,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'EmbraceConfiguration' do |subs|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
+    subs.dependency "EmbraceIO/EmbraceSemantics"
   end
 
   spec.subspec 'EmbraceOTelInternal' do |subs|


### PR DESCRIPTION
The `EmbraceConfiguration` subspec in `EmbraceIO.podspec` is missing its dependency on `EmbraceSemantics`. The Swift sources under `Sources/EmbraceConfiguration` import `EmbraceSemantics`, so consumers installing via CocoaPods hit unresolved-import errors at compile time  while SwiftPM consumers — whose dependency graph is generated from `Package.swift` — are unaffected.

 ## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
