### PR TITLE
[EMBR-12280] Fix: Fix: Tests: Make LogsBatchTests deterministic to eliminate flaky behavior

### DIFF
--- a/Tests/EmbraceCoreTests/Internal/Logs/LogsBatchTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogsBatchTests.swift
@@ -66,14 +66,11 @@ class LogsBatchTests: XCTestCase {
 
 extension LogsBatchTests {
     fileprivate func givenNonZeroLogLimits() {
-        givenLimits(
-            maxBatchAge: .random(in: 1..<100),
-            maxLogsPerBatch: .random(in: 1..<100)
-        )
+        givenLimits()
     }
 
     fileprivate func givenLimits(
-        maxBatchAge: Double = .random(in: 1..<100), maxLogsPerBatch: Int = .random(in: 1..<100)
+        maxBatchAge: Double = 60, maxLogsPerBatch: Int = 100
     ) {
         limits = .init(maxBatchAge: maxBatchAge, maxLogsPerBatch: maxLogsPerBatch)
     }


### PR DESCRIPTION
`LogsBatchTests.givenLimits` defaulted `maxLogsPerBatch` to `.random(in: 1..<100)`. When the roll landed on `1`, a batch containing a single log was immediately full, causing `testHavingRecentLogs_batchStateShouldBeOpen` to assert `.closed` instead of `.open`. Frequency: ~1% per run, surfacing every ~100 iOS test executions.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
