### PR TITLE
[EMBR-12281] Chore: Examples: Update BrandGame and Benchmarks for 7.0 EmbraceIO public API

### DIFF
--- a/Examples/Benchmarks/Benchmarks.xcodeproj/project.pbxproj
+++ b/Examples/Benchmarks/Benchmarks.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			mainGroup = 2A7143B02E79E41500CCE829;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				2A7143E32E79E45700CCE829 /* XCLocalSwiftPackageReference "../../../embrace-apple-sdk" */,
+				2A7143E32E79E45700CCE829 /* XCLocalSwiftPackageReference "../.." */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2A7143BA2E79E41500CCE829 /* Products */;
@@ -583,9 +583,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		2A7143E32E79E45700CCE829 /* XCLocalSwiftPackageReference "../../../embrace-apple-sdk" */ = {
+		2A7143E32E79E45700CCE829 /* XCLocalSwiftPackageReference "../.." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../../embrace-apple-sdk";
+			relativePath = "../..";
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Examples/Benchmarks/Benchmarks/BenchmarksApp.swift
+++ b/Examples/Benchmarks/Benchmarks/BenchmarksApp.swift
@@ -15,12 +15,7 @@ struct BenchmarksApp: App {
         }
 
         do {
-            try Embrace.setup(
-                options: Embrace.Options(
-                    appId: "bench"
-                )
-            )
-            .start()
+            try EmbraceIO.setup(options: .withAppId("bench"))
         } catch {}
     }
 

--- a/Examples/Benchmarks/Benchmarks/ContentView.swift
+++ b/Examples/Benchmarks/Benchmarks/ContentView.swift
@@ -3,7 +3,6 @@
 //
 
 import Darwin
-@_spi(Private) import EmbraceCore
 import EmbraceIO
 import SwiftUI
 
@@ -16,6 +15,12 @@ struct ContentView: View {
         return sign * mantissa * pow(2.0, exponent)
     }
 
+    // TODO 7.0: restore the per-iteration and post-loop work-drain barrier that was
+    // `Embrace.client?.waitForAllWork()` on 6.x. The 7.0 public surface doesn't expose
+    // an equivalent, and `Embrace` is `package`-internal here. Until a drain is reachable
+    // (e.g. an `@_spi(Testing)` shim on `EmbraceIO`), the benchmark's pre/post measurement
+    // window no longer reliably contains Embrace's flush IO and its numbers should be
+    // treated as indicative rather than authoritative.
     var body: some View {
 
         VStack {
@@ -31,12 +36,8 @@ struct ContentView: View {
                             \(randomDoubleFullRange()),
                             \(randomDoubleFullRange()) #raw #record
                         """
-                    Embrace.client?.add(event: .breadcrumb(value))
-                    Embrace.client?.waitForAllWork()
+                    EmbraceIO.shared.addBreadcrumb(value)
                 }
-
-                // This will cause priority inversion but its for the greater good.
-                Embrace.client?.waitForAllWork()
             }
             .accessibilityIdentifier("logical-writes-test-button")
 
@@ -59,8 +60,7 @@ struct ContentView: View {
                             \(randomDoubleFullRange()),
                             \(randomDoubleFullRange()) #raw #record
                         """
-                    Embrace.client?.add(event: .breadcrumb(value))
-                    Embrace.client?.waitForAllWork()
+                    EmbraceIO.shared.addBreadcrumb(value)
                     #if DEBUG
                         let postWork = EnergyMeasurement.shared.logicalWrites()
                         let countLW = postWork.logicalWrites &- preWork.logicalWrites
@@ -72,9 +72,6 @@ struct ContentView: View {
                         allValuesPF.append(countPF)
                     #endif
                 }
-
-                // This will cause priority inversion but its for the greater good.
-                Embrace.client?.waitForAllWork()
 
                 #if DEBUG
                     let post = EnergyMeasurement.shared.logicalWrites()

--- a/Examples/Benchmarks/Benchmarks/ContentView.swift
+++ b/Examples/Benchmarks/Benchmarks/ContentView.swift
@@ -3,7 +3,7 @@
 //
 
 import Darwin
-import EmbraceIO
+@_spi(Private) import EmbraceIO
 import SwiftUI
 
 struct ContentView: View {
@@ -15,12 +15,6 @@ struct ContentView: View {
         return sign * mantissa * pow(2.0, exponent)
     }
 
-    // TODO 7.0: restore the per-iteration and post-loop work-drain barrier that was
-    // `Embrace.client?.waitForAllWork()` on 6.x. The 7.0 public surface doesn't expose
-    // an equivalent, and `Embrace` is `package`-internal here. Until a drain is reachable
-    // (e.g. an `@_spi(Testing)` shim on `EmbraceIO`), the benchmark's pre/post measurement
-    // window no longer reliably contains Embrace's flush IO and its numbers should be
-    // treated as indicative rather than authoritative.
     var body: some View {
 
         VStack {
@@ -37,7 +31,11 @@ struct ContentView: View {
                             \(randomDoubleFullRange()) #raw #record
                         """
                     EmbraceIO.shared.addBreadcrumb(value)
+                    EmbraceIO.shared.waitForAllWork()
                 }
+
+                // This will cause priority inversion but its for the greater good.
+                EmbraceIO.shared.waitForAllWork()
             }
             .accessibilityIdentifier("logical-writes-test-button")
 
@@ -61,6 +59,7 @@ struct ContentView: View {
                             \(randomDoubleFullRange()) #raw #record
                         """
                     EmbraceIO.shared.addBreadcrumb(value)
+                    EmbraceIO.shared.waitForAllWork()
                     #if DEBUG
                         let postWork = EnergyMeasurement.shared.logicalWrites()
                         let countLW = postWork.logicalWrites &- preWork.logicalWrites
@@ -72,6 +71,9 @@ struct ContentView: View {
                         allValuesPF.append(countPF)
                     #endif
                 }
+
+                // This will cause priority inversion but its for the greater good.
+                EmbraceIO.shared.waitForAllWork()
 
                 #if DEBUG
                     let post = EnergyMeasurement.shared.logicalWrites()

--- a/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
+++ b/Examples/BrandGame/BrandGame.xcodeproj/project.pbxproj
@@ -44,13 +44,11 @@
 		7BCB662E2AC476BC00ABD33A /* NetworkStressTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCB662D2AC476BC00ABD33A /* NetworkStressTest.swift */; };
 		FA0347142E65F63100FB7E87 /* StdoutExporter in Frameworks */ = {isa = PBXBuildFile; productRef = FA0347132E65F63100FB7E87 /* StdoutExporter */; };
 		FA3B0A112C3C2A5600315578 /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A102C3C2A5600315578 /* EmbraceCore */; };
-		FA3B0A152C3C2A5600315578 /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A142C3C2A5600315578 /* EmbraceCrashlyticsSupport */; };
 		FA3B0A172C3C2A5600315578 /* EmbraceIO in Frameworks */ = {isa = PBXBuildFile; productRef = FA3B0A162C3C2A5600315578 /* EmbraceIO */; };
 		FA4C5F332C486E13005C0371 /* CreateSpanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4C5F322C486E13005C0371 /* CreateSpanView.swift */; };
 		FA4C5F352C487B45005C0371 /* AttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4C5F342C487B45005C0371 /* AttributesView.swift */; };
 		FA4FA4FA2C62DBB600E66300 /* NoSpacesTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4FA4F92C62DBB600E66300 /* NoSpacesTextField.swift */; };
 		FA716C7E2C45B94A00AD0161 /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA716C7D2C45B94A00AD0161 /* EmbraceCore */; };
-		FA716C822C45B94A00AD0161 /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FA716C812C45B94A00AD0161 /* EmbraceCrashlyticsSupport */; };
 		FA716C842C45B94A00AD0161 /* EmbraceIO in Frameworks */ = {isa = PBXBuildFile; productRef = FA716C832C45B94A00AD0161 /* EmbraceIO */; };
 		FA7C3FCD2C821A3400EA7344 /* AddCrashInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7C3FCC2C821A3400EA7344 /* AddCrashInfoView.swift */; };
 		FA910EF12C4835B100C2E2E4 /* OpenTelemetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA910EF02C4835B100C2E2E4 /* OpenTelemetryView.swift */; };
@@ -61,11 +59,9 @@
 		FADB905E2C333B8B00079005 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADB905D2C333B8B00079005 /* WebView.swift */; };
 		FADB90602C333BBA00079005 /* BrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADB905F2C333BBA00079005 /* BrowserView.swift */; };
 		FAEF5A112C6BA46F00484474 /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FAEF5A102C6BA46F00484474 /* EmbraceCore */; };
-		FAEF5A152C6BA46F00484474 /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FAEF5A142C6BA46F00484474 /* EmbraceCrashlyticsSupport */; };
 		FAEF5A172C6BA46F00484474 /* EmbraceIO in Frameworks */ = {isa = PBXBuildFile; productRef = FAEF5A162C6BA46F00484474 /* EmbraceIO */; };
 		FAEF5A192C6BA46F00484474 /* EmbraceSemantics in Frameworks */ = {isa = PBXBuildFile; productRef = FAEF5A182C6BA46F00484474 /* EmbraceSemantics */; };
 		FAF85DF52C45B1C6002306FF /* EmbraceCore in Frameworks */ = {isa = PBXBuildFile; productRef = FAF85DF42C45B1C6002306FF /* EmbraceCore */; };
-		FAF85DF92C45B1C6002306FF /* EmbraceCrashlyticsSupport in Frameworks */ = {isa = PBXBuildFile; productRef = FAF85DF82C45B1C6002306FF /* EmbraceCrashlyticsSupport */; };
 		FAF85DFB2C45B1C6002306FF /* EmbraceIO in Frameworks */ = {isa = PBXBuildFile; productRef = FAF85DFA2C45B1C6002306FF /* EmbraceIO */; };
 		FAFDA3D22C333FC900AD17CF /* NetworkRequestBuilderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFDA3CF2C333FC900AD17CF /* NetworkRequestBuilderView.swift */; };
 		FAFDA3D32C333FC900AD17CF /* RequestResponseDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFDA3D02C333FC900AD17CF /* RequestResponseDetail.swift */; };
@@ -153,8 +149,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA716C822C45B94A00AD0161 /* EmbraceCrashlyticsSupport in Frameworks */,
-				FA3B0A152C3C2A5600315578 /* EmbraceCrashlyticsSupport in Frameworks */,
 				FA716C7E2C45B94A00AD0161 /* EmbraceCore in Frameworks */,
 				FA716C842C45B94A00AD0161 /* EmbraceIO in Frameworks */,
 				FAEF5A172C6BA46F00484474 /* EmbraceIO in Frameworks */,
@@ -163,8 +157,6 @@
 				FA3B0A112C3C2A5600315578 /* EmbraceCore in Frameworks */,
 				FA0347142E65F63100FB7E87 /* StdoutExporter in Frameworks */,
 				FAF85DF52C45B1C6002306FF /* EmbraceCore in Frameworks */,
-				FAF85DF92C45B1C6002306FF /* EmbraceCrashlyticsSupport in Frameworks */,
-				FAEF5A152C6BA46F00484474 /* EmbraceCrashlyticsSupport in Frameworks */,
 				FAEF5A192C6BA46F00484474 /* EmbraceSemantics in Frameworks */,
 				FAEF5A112C6BA46F00484474 /* EmbraceCore in Frameworks */,
 			);
@@ -523,16 +515,12 @@
 			name = BrandGame;
 			packageProductDependencies = (
 				FA3B0A102C3C2A5600315578 /* EmbraceCore */,
-				FA3B0A142C3C2A5600315578 /* EmbraceCrashlyticsSupport */,
 				FA3B0A162C3C2A5600315578 /* EmbraceIO */,
 				FAF85DF42C45B1C6002306FF /* EmbraceCore */,
-				FAF85DF82C45B1C6002306FF /* EmbraceCrashlyticsSupport */,
 				FAF85DFA2C45B1C6002306FF /* EmbraceIO */,
 				FA716C7D2C45B94A00AD0161 /* EmbraceCore */,
-				FA716C812C45B94A00AD0161 /* EmbraceCrashlyticsSupport */,
 				FA716C832C45B94A00AD0161 /* EmbraceIO */,
 				FAEF5A102C6BA46F00484474 /* EmbraceCore */,
-				FAEF5A142C6BA46F00484474 /* EmbraceCrashlyticsSupport */,
 				FAEF5A162C6BA46F00484474 /* EmbraceIO */,
 				FAEF5A182C6BA46F00484474 /* EmbraceSemantics */,
 				FA0347132E65F63100FB7E87 /* StdoutExporter */,
@@ -923,10 +911,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceCore;
 		};
-		FA3B0A142C3C2A5600315578 /* EmbraceCrashlyticsSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = EmbraceCrashlyticsSupport;
-		};
 		FA3B0A162C3C2A5600315578 /* EmbraceIO */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceIO;
@@ -935,10 +919,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceCore;
 		};
-		FA716C812C45B94A00AD0161 /* EmbraceCrashlyticsSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = EmbraceCrashlyticsSupport;
-		};
 		FA716C832C45B94A00AD0161 /* EmbraceIO */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceIO;
@@ -946,10 +926,6 @@
 		FAEF5A102C6BA46F00484474 /* EmbraceCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceCore;
-		};
-		FAEF5A142C6BA46F00484474 /* EmbraceCrashlyticsSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = EmbraceCrashlyticsSupport;
 		};
 		FAEF5A162C6BA46F00484474 /* EmbraceIO */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -962,10 +938,6 @@
 		FAF85DF42C45B1C6002306FF /* EmbraceCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = EmbraceCore;
-		};
-		FAF85DF82C45B1C6002306FF /* EmbraceCrashlyticsSupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = EmbraceCrashlyticsSupport;
 		};
 		FAF85DFA2C45B1C6002306FF /* EmbraceIO */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/BrandGame/BrandGame/BrandGameApp.swift
+++ b/Examples/BrandGame/BrandGame/BrandGameApp.swift
@@ -12,9 +12,7 @@ struct BrandGameApp: App {
 
     init() {
         do {
-            try Embrace
-                .setup(options: embraceOptions)
-                .start()
+            try EmbraceIO.setup(options: embraceOptions)
 
             addGitInfoProperties()
             smokeTestIfNecessary()

--- a/Examples/BrandGame/BrandGame/ContentView.swift
+++ b/Examples/BrandGame/BrandGame/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
             TapGesture(count: 3)
                 .onEnded { _ in
                     isShowingMenu = true
-                    try? Embrace.client?.metadata.addProperty(key: "user.menu.open", value: "true")
+                    EmbraceIO.shared.setProperty(key: "user.menu.open", value: "true", lifespan: .session)
                 }
         )
         .ignoresSafeArea(.all)

--- a/Examples/BrandGame/BrandGame/Embrace/App+Embrace.swift
+++ b/Examples/BrandGame/BrandGame/Embrace/App+Embrace.swift
@@ -3,6 +3,7 @@
 //
 
 import EmbraceIO
+import EmbraceSemantics
 import StdoutExporter
 
 extension BrandGameApp {

--- a/Examples/BrandGame/BrandGame/Embrace/App+Embrace.swift
+++ b/Examples/BrandGame/BrandGame/Embrace/App+Embrace.swift
@@ -8,30 +8,28 @@ import StdoutExporter
 extension BrandGameApp {
     #if DEBUG
         // https://dash.embrace.io/app/dcdt4
-        var embraceOptions: Embrace.Options {
-            return .init(
-                appId: "dcdt4",
-                appGroupId: nil,
+        var embraceOptions: EmbraceIO.Options {
+            return .withAppId(
+                "dcdt4",
                 platform: .default,
-                endpoints: Embrace.Endpoints.fromInfoPlist(),
+                endpoints: EmbraceEndpoints.fromInfoPlist(),
                 logLevel: .debug,
-                export: otelExport
+                otel: otelOptions
             )
         }
 
-        private var otelExport: OpenTelemetryExport {
-            OpenTelemetryExport(
-                spanExporter: StdoutSpanExporter(isDebug: true),
-                logExporter: StdoutLogExporter(isDebug: true)
+        private var otelOptions: EmbraceIO.OTelOptions {
+            .init(
+                spanExporters: [StdoutSpanExporter(isDebug: true)],
+                logExporters: [StdoutLogExporter(isDebug: true)]
             )
         }
 
     #else
         // https://dash.embrace.io/app/kj9hd
-        var embraceOptions: Embrace.Options {
-            return .init(
-                appId: "kj9hd",
-                appGroupId: nil,
+        var embraceOptions: EmbraceIO.Options {
+            return .withAppId(
+                "kj9hd",
                 platform: .default
             )
         }

--- a/Examples/BrandGame/BrandGame/Embrace/App+GitInfo.swift
+++ b/Examples/BrandGame/BrandGame/Embrace/App+GitInfo.swift
@@ -11,20 +11,16 @@ extension BrandGameApp {
             return
         }
 
-        guard let metadata = Embrace.client?.metadata else {
-            return
-        }
-
         if let branch = info.branch {
-            try? metadata.addProperty(key: "git.branch", value: branch, lifespan: .process)
+            EmbraceIO.shared.setProperty(key: "git.branch", value: branch, lifespan: .process)
         }
 
         if let sha = info.sha {
-            try? metadata.addProperty(key: "git.sha", value: sha, lifespan: .process)
+            EmbraceIO.shared.setProperty(key: "git.sha", value: sha, lifespan: .process)
         }
 
         if let dirtyCount = info.dirtyFileCount {
-            try? metadata.addProperty(key: "git.dirty_file_count", value: String(dirtyCount), lifespan: .process)
+            EmbraceIO.shared.setProperty(key: "git.dirty_file_count", value: String(dirtyCount), lifespan: .process)
         }
     }
 

--- a/Examples/BrandGame/BrandGame/Embrace/App+SmokeTest.swift
+++ b/Examples/BrandGame/BrandGame/Embrace/App+SmokeTest.swift
@@ -14,9 +14,8 @@ extension BrandGameApp {
 
         switch ProcessInfo.processInfo.arguments[1] {
         case "Metadata":
-            Embrace.client?
-                .buildSpan(name: "Test Started for Metadata", type: .performance)
-                .startSpan()
+            EmbraceIO.shared
+                .createSpan(name: "Test Started for Metadata", type: .performance)?
                 .end()
         default:
             break

--- a/Examples/BrandGame/BrandGame/Embrace/Endpoints+InfoPlist.swift
+++ b/Examples/BrandGame/BrandGame/Embrace/Endpoints+InfoPlist.swift
@@ -2,16 +2,11 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceIO
 import Foundation
 
-#if COCOAPODS
-    import EmbraceIO
-#else
-    import EmbraceCore
-#endif
-
-extension Embrace.Endpoints {
-    static func fromInfoPlist() -> Embrace.Endpoints? {
+extension EmbraceEndpoints {
+    static func fromInfoPlist() -> EmbraceEndpoints? {
         guard let endpoints = Bundle.main.infoDictionary?["EmbraceEndpoints"] as? [String: String],
             let baseURL = value(from: endpoints, key: "baseURL"),
             let configBaseURL = value(from: endpoints, key: "configBaseURL")
@@ -19,7 +14,7 @@ extension Embrace.Endpoints {
             return nil
         }
 
-        return Embrace.Endpoints(
+        return EmbraceEndpoints(
             baseURL: baseURL,
             configBaseURL: configBaseURL
         )

--- a/Examples/BrandGame/BrandGame/Embrace/Endpoints+InfoPlist.swift
+++ b/Examples/BrandGame/BrandGame/Embrace/Endpoints+InfoPlist.swift
@@ -3,6 +3,7 @@
 //
 
 import EmbraceIO
+import EmbraceSemantics
 import Foundation
 
 extension EmbraceEndpoints {

--- a/Examples/BrandGame/BrandGame/View/Menu/Minigames/Reflex/ReflexGameModel.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/Minigames/Reflex/ReflexGameModel.swift
@@ -2,16 +2,9 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceIO
+import EmbraceSemantics
 import Foundation
-import OpenTelemetryApi
-import OpenTelemetrySdk
-
-#if COCOAPODS
-    import EmbraceIO
-#else
-    import EmbraceCore
-    import EmbraceOTelInternal
-#endif
 
 @Observable
 class ReflexGameModel {
@@ -48,7 +41,7 @@ class ReflexGameModel {
     /// The time the reflexIcon was pressed
     private var reflexEndAt: Date?
 
-    private var reflexSpan: Span?
+    private var reflexSpan: EmbraceSpan?
 
     var reflexDuration: TimeInterval? {
         if let startAt = reflexStartAt, let endAt = reflexEndAt {
@@ -111,11 +104,11 @@ class ReflexGameModel {
         reflexEndAt = endAt
         if icon == reflexIcon {
             gameState = .testComplete
-            reflexSpan?.end(time: endAt)
+            reflexSpan?.end(endTime: endAt)
 
         } else {
             gameState = .testError
-            reflexSpan?.end(errorCode: .failure, time: endAt)
+            reflexSpan?.end(errorCode: .failure, endTime: endAt)
         }
 
         resetTimer = Timer.scheduledTimer(
@@ -151,9 +144,7 @@ class ReflexGameModel {
 }
 
 extension ReflexGameModel {
-    private func buildSpan(startTime: Date) -> Span? {
-        return Embrace.client?.buildSpan(name: "reflex-measure", type: .ux)
-            .setStartTime(time: startTime)
-            .startSpan()
+    private func buildSpan(startTime: Date) -> EmbraceSpan? {
+        EmbraceIO.shared.createSpan(name: "reflex-measure", type: .ux, startTime: startTime)
     }
 }

--- a/Examples/BrandGame/BrandGame/View/Menu/Minigames/Simon/SimonGameModel.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/Minigames/Simon/SimonGameModel.swift
@@ -2,16 +2,9 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceIO
+import EmbraceSemantics
 import Foundation
-import OpenTelemetryApi
-import OpenTelemetrySdk
-
-#if COCOAPODS
-    import EmbraceIO
-#else
-    import EmbraceCore
-    import EmbraceOTelInternal
-#endif
 
 @Observable
 class SimonGameModel {
@@ -50,10 +43,10 @@ class SimonGameModel {
     var userPattern: [IconComponent] = []
 
     /// measures a single game. Parent of multiple round spans (hopefully)
-    var gameSpan: Span?
+    var gameSpan: EmbraceSpan?
 
     /// measures a single round. Child of game span
-    var roundSpan: Span?
+    var roundSpan: EmbraceSpan?
 
     func start() {
         reset()
@@ -92,7 +85,7 @@ class SimonGameModel {
         // verify round
         if userPattern == patternPrefix {
             if userPattern.count == pattern.count {
-                roundSpan?.status = .ok
+                roundSpan?.setStatus(.ok)
                 roundSpan?.end()
                 // NEW ROUND
                 gameState = .betweenRounds
@@ -106,7 +99,7 @@ class SimonGameModel {
             // fail
             gameState = .roundFail
             roundSpan?.end(errorCode: .failure)
-            gameSpan?.setAttribute(key: "round.number", value: .string(String(roundNumber)))
+            try? gameSpan?.setAttribute(key: "round.number", value: String(roundNumber))
             gameSpan?.end()
             Timer.scheduledTimer(withTimeInterval: 2.4, repeats: false) { _ in
                 self.reset()
@@ -161,35 +154,17 @@ class SimonGameModel {
         gameState = .waitingForStart
     }
 
-    private func buildGameSpan() -> Span? {
-        guard let embrace = Embrace.client else {
-            return nil
-        }
-
-        return
-            embrace
-            .buildSpan(name: "simon-game", type: .ux)
-            .startSpan()
+    private func buildGameSpan() -> EmbraceSpan? {
+        EmbraceIO.shared.createSpan(name: "simon-game", type: .ux)
     }
 
-    private func buildRoundSpan(round: Int) -> Span? {
-        guard let embrace = Embrace.client else {
-            return nil
-        }
-
-        let builder =
-            embrace
-            .buildSpan(
-                name: "simon-round",
-                type: .ux,
-                attributes: ["round.number": String(round)]
-            )
-
-        if let gameSpan = gameSpan {
-            builder.setParent(gameSpan)
-        }
-
-        return builder.startSpan()
+    private func buildRoundSpan(round: Int) -> EmbraceSpan? {
+        EmbraceIO.shared.createSpan(
+            name: "simon-round",
+            parentSpan: gameSpan,
+            type: .ux,
+            attributes: ["round.number": String(round)]
+        )
     }
 }
 

--- a/Examples/BrandGame/BrandGame/View/Menu/OpenTelemetry/OpenTelemetryView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/OpenTelemetry/OpenTelemetryView.swift
@@ -84,9 +84,11 @@ extension OpenTelemetryView {
     }
 
     fileprivate func getEmbraceTracer() throws -> Tracer {
-        guard let embrace = Embrace.client else { throw CreateTracerError.embraceClientDoesNotExist }
+        // TODO 7.0: Embrace.tracer(instrumentationName:) is not exposed on the public surface yet.
+        // On 7.0 the OTel bridge is the single tracer provider, so this path falls back to
+        // the OTel SDK tracer. Re-enable an Embrace-branded entry point when EmbraceIO ships one.
         guard !name.isEmpty else { throw CreateTracerError.nameCannotBeEmpty }
-        return embrace.tracer(instrumentationName: name)
+        return OpenTelemetry.instance.tracerProvider.get(instrumentationName: name)
     }
 
     fileprivate func getOTelSDKTracer() throws -> Tracer {

--- a/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/SessionAttributes/SessionAttributesView.swift
@@ -83,34 +83,26 @@ extension SessionAttributesView {
     }
 
     fileprivate func execute() {
-        do {
-            switch action {
-            case .add:
-                try addProperty()
-            case .update:
-                try updateProperty()
-            case .delete:
-                try deleteProperty()
-            }
-            showPopUp = true
-            property.key = ""
-            property.value = ""
-        } catch let exception {
-            print(exception.localizedDescription)
+        switch action {
+        case .add, .update:
+            setProperty()
+        case .delete:
+            deleteProperty()
         }
+        showPopUp = true
+        property.key = ""
+        property.value = ""
     }
 
-    fileprivate func addProperty() throws {
-        let metadata = Embrace.client?.metadata
+    fileprivate func setProperty() {
         switch property.type {
         case .resource:
-            try metadata?.addResource(
-                key: property.key,
-                value: property.value,
-                lifespan: metadataLifespan
-            )
+            // TODO 7.0: Resource runtime mutation is not exposed on the EmbraceIO public surface
+            // (resources are now provided at SDK setup via OTel options). Re-enable when/if
+            // EmbraceIO exposes a runtime resource API.
+            break
         case .sessionProperty:
-            try metadata?.addProperty(
+            EmbraceIO.shared.setProperty(
                 key: property.key,
                 value: property.value,
                 lifespan: metadataLifespan
@@ -118,42 +110,20 @@ extension SessionAttributesView {
         }
     }
 
-    fileprivate func updateProperty() throws {
-        let metadata = Embrace.client?.metadata
+    fileprivate func deleteProperty() {
         switch property.type {
         case .resource:
-            try metadata?.updateResource(
-                key: property.key,
-                value: property.value,
-                lifespan: metadataLifespan
-            )
-        case .sessionProperty:
-            try metadata?.updateProperty(
-                key: property.key,
-                value: property.value,
-                lifespan: metadataLifespan
-            )
-        }
-    }
-
-    fileprivate func deleteProperty() throws {
-        let metadata = Embrace.client?.metadata
-        switch property.type {
-        case .resource:
-            if appliesToAllAttributes {
-                metadata?.removeAllResources(lifespans: [metadataLifespan])
-            } else {
-                try metadata?.removeResource(
-                    key: property.key,
-                    lifespan: metadataLifespan
-                )
-            }
+            // TODO 7.0: Resource runtime mutation is not exposed on the EmbraceIO public surface
+            // (resources are now provided at SDK setup via OTel options). Re-enable when/if
+            // EmbraceIO exposes a runtime resource API.
+            break
         case .sessionProperty:
             if appliesToAllAttributes {
-                metadata?.removeAllProperties(lifespans: [metadataLifespan])
+                EmbraceIO.shared.removeAllProperties(lifespans: [metadataLifespan])
             } else {
-                try metadata?.removeProperty(
+                EmbraceIO.shared.setProperty(
                     key: property.key,
+                    value: nil,
                     lifespan: metadataLifespan
                 )
             }

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/CrashExample/AddCrashInfoView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/CrashExample/AddCrashInfoView.swift
@@ -18,12 +18,8 @@ struct AddCrashInfoView: View {
             }
             Section("Actions") {
                 Button("Add") {
-                    do {
-                        try Embrace.client?.appendCrashInfo(key: key, value: value)
-                        dismiss()
-                    } catch let exception {
-                        print(exception.localizedDescription)
-                    }
+                    EmbraceIO.shared.appendCrashInfo(key: key, value: value)
+                    dismiss()
                 }.disabled(key.isEmpty || value.isEmpty)
                 Button("Clear Fields") {
                     key = ""

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/CrashExample/CrashExampleTest.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/CrashExample/CrashExampleTest.swift
@@ -2,22 +2,17 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceIO
 import SwiftUI
 
-#if COCOAPODS
-    import EmbraceIO
-#else
-    import EmbraceCore
-#endif
-
 struct CrashExampleTest: View {
-    @State private var selectedExample: ExampleCrash = .fatalError
+    @State private var selectedExample: EmbraceExampleCrash = .fatalError
     @State private var showAddCrashInfo: Bool = false
 
     var body: some View {
         Form {
             Section("Crash Type") {
-                List(ExampleCrash.allCases, id: \.self) { crashExample in
+                List(EmbraceExampleCrash.allCases, id: \.self) { crashExample in
                     HStack {
                         Text(title(for: crashExample))
                         Spacer()
@@ -43,7 +38,7 @@ struct CrashExampleTest: View {
 
             Section {
                 Button {
-                    Embrace.client?.crash(type: selectedExample)
+                    EmbraceCrashHelper.crash(example: selectedExample)
                 } label: {
                     Text("Submit")
                 }
@@ -63,7 +58,7 @@ struct CrashExampleTest: View {
         .navigationTitle("Crash Examples")
     }
 
-    func title(for example: ExampleCrash) -> String {
+    func title(for example: EmbraceExampleCrash) -> String {
         switch example {
         case .fatalError: "Swift Fatal Error"
         case .unwrapOptional: "Force Unwrap Optional"

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/LoggingView.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Logging/LoggingView.swift
@@ -2,25 +2,20 @@
 //  Copyright © 2023 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceIO
+import EmbraceSemantics
 import SwiftUI
-
-#if COCOAPODS
-    import EmbraceIO
-#else
-    import EmbraceCommonInternal
-    import EmbraceIO
-#endif
 
 struct LoggingView: View {
     @State private var logMessage: String = "This is the log message..."
-    @State private var severity: Int = LogSeverity.info.rawValue
+    @State private var severity: Int = EmbraceLogSeverity.info.rawValue
     @State private var behavior: Int = Behavior.default.rawValue
     @State private var key: String = ""
     @State private var value: String = ""
     @State private var attributes: [String: String] = [:]
     @State private var shouldCleanUp: Bool = false
 
-    private let severities: [LogSeverity] = {
+    private let severities: [EmbraceLogSeverity] = {
         [.info, .warn, .error]
     }()
 
@@ -39,7 +34,7 @@ struct LoggingView: View {
                         .bold()
                     Picker("Severity", selection: $severity) {
                         ForEach(severities, id: \.rawValue) {
-                            Text($0.text)
+                            Text($0.name)
                         }
                     }.pickerStyle(SegmentedPickerStyle())
                 }
@@ -87,7 +82,7 @@ extension LoggingView {
             print("Cant log empty message")
             return
         }
-        guard let severity = LogSeverity(rawValue: severity) else {
+        guard let severity = EmbraceLogSeverity(rawValue: severity) else {
             print("Wrong severity number")
             return
         }
@@ -95,16 +90,17 @@ extension LoggingView {
             print("Wrong stacktrace behavior")
             return
         }
-        Embrace.client?.log(
+        let attributeValues: EmbraceAttributes = attributes.mapValues { $0 as EmbraceAttributeValue }
+        EmbraceIO.shared.log(
             logMessage,
             severity: severity,
-            attributes: attributes,
+            attributes: attributeValues,
             stackTraceBehavior: stackTraceBehavior
         )
         cleanUpFields()
     }
 
-    fileprivate func getStackTraceBehavior() throws -> StackTraceBehavior {
+    fileprivate func getStackTraceBehavior() throws -> EmbraceStackTraceBehavior {
         switch Behavior(rawValue: behavior) {
         case .default:
             return .default
@@ -144,7 +140,7 @@ extension LoggingView {
         case main
         case custom
 
-        static func from(_ stackTraceBehavior: StackTraceBehavior) -> Self {
+        static func from(_ stackTraceBehavior: EmbraceStackTraceBehavior) -> Self {
             switch stackTraceBehavior {
             case .notIncluded:
                 return .notIncluded

--- a/Examples/BrandGame/BrandGame/View/Menu/StressTests/Network/NetworkRequestBuilder/Request.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/StressTests/Network/NetworkRequestBuilder/Request.swift
@@ -10,7 +10,7 @@ class Request: ObservableObject {
 
     func executeRequest(urlString: String, httpMethod: String, requestBody: String?) {
         guard let url = URL(string: urlString) else {
-            Embrace.client?.log("URL is not valid: \(urlString)", severity: .error)
+            EmbraceIO.shared.log("URL is not valid: \(urlString)", severity: .error)
             return
         }
         var request = URLRequest(url: url)

--- a/Examples/BrandGame/BrandGame/View/Menu/UserInfo/PersonaGrid.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/UserInfo/PersonaGrid.swift
@@ -14,9 +14,9 @@ struct PersonaGrid: View {
         Grid(verticalSpacing: 6.0) {
             ForEach(personaGridRows(), id: \.self) { row in
                 GridRow {
-                    ForEach(row) { personaOption in
+                    ForEach(row, id: \.self) { personaOption in
                         PillText(
-                            personaOption.rawValue,
+                            personaOption,
                             selected: user.hasPersona(personaOption),
                             style: colorForPersona(persona: personaOption)
                         ).onTapGesture {
@@ -28,7 +28,7 @@ struct PersonaGrid: View {
         }
     }
 
-    func personaGridRows(size: Int = 3) -> [[PersonaTag]] {
+    func personaGridRows(size: Int = 3) -> [[String]] {
         let count = Self.quickPersonas.count
 
         return stride(from: 0, to: count, by: size).map {
@@ -36,24 +36,15 @@ struct PersonaGrid: View {
         }
     }
 
-    func colorForPersona(persona: PersonaTag) -> Color {
-        let idx = persona.rawValue.count % Self.personaColors.count
+    func colorForPersona(persona: String) -> Color {
+        let idx = persona.count % Self.personaColors.count
         return Self.personaColors[idx]
     }
 }
 
 extension PersonaGrid {
-    static var quickPersonas: [PersonaTag] {
-        [
-            PersonaTag.free,
-            PersonaTag.preview,
-            PersonaTag.subscriber,
-            PersonaTag.payer,
-            PersonaTag.guest,
-            PersonaTag.pro,
-            PersonaTag.mvp,
-            PersonaTag.vip
-        ]
+    static var quickPersonas: [String] {
+        ["free", "preview", "subscriber", "payer", "guest", "pro", "mvp", "vip"]
     }
 
     static var personaColors: [Color] {

--- a/Examples/BrandGame/BrandGame/View/Menu/UserInfo/UserInfo.swift
+++ b/Examples/BrandGame/BrandGame/View/Menu/UserInfo/UserInfo.swift
@@ -3,88 +3,57 @@
 //
 
 import Combine
+import EmbraceIO
 import SwiftUI
-
-#if COCOAPODS
-    import EmbraceIO
-#else
-    import EmbraceCore
-#endif
 
 struct UserInfo: View {
 
     class EmbraceUser: ObservableObject {
-        @Published var username: String = ""
         @Published var identifier: String = ""
-        @Published var email: String = ""
 
         private var cancellables = Set<AnyCancellable>()
 
         func listen() {
             cancellables.removeAll()
 
-            $username
-                .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
-                .sink { output in
-                    Embrace.client?.metadata.userName = output.isEmpty ? nil : output
-                }
-                .store(in: &cancellables)
-
             $identifier
                 .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
                 .sink { output in
-                    Embrace.client?.metadata.userIdentifier = output.isEmpty ? nil : output
-                }
-                .store(in: &cancellables)
-
-            $email
-                .debounce(for: .milliseconds(500), scheduler: RunLoop.main)
-                .sink { output in
-                    Embrace.client?.metadata.userEmail = output.isEmpty ? nil : output
+                    EmbraceIO.shared.userIdentifier = output.isEmpty ? nil : output
                 }
                 .store(in: &cancellables)
         }
 
         func refresh() {
-            guard let metadata = Embrace.client?.metadata else {
-                return
-            }
-
-            username = metadata.userName ?? ""
-            identifier = metadata.userIdentifier ?? ""
-            email = metadata.userEmail ?? ""
+            identifier = EmbraceIO.shared.userIdentifier ?? ""
         }
 
         func clearProperties() {
-            Embrace.client?.metadata.clearUserProperties()
-
-            // Need to clear local state as well
-            username.removeAll()
+            EmbraceIO.shared.userIdentifier = nil
             identifier.removeAll()
-            email.removeAll()
         }
 
         func clearPersonas() {
-            Embrace.client?.metadata.removeAllPersonas()
+            EmbraceIO.shared.removeAllPersonas(lifespans: [.session, .process, .permanent])
             objectWillChange.send()
         }
 
-        func toggle(persona: PersonaTag, lifespan: MetadataLifespan) {
+        func toggle(persona: String, lifespan: MetadataLifespan) {
             if hasPersona(persona) {
-                try? Embrace.client?.metadata.remove(persona: persona, lifespan: lifespan)
+                EmbraceIO.shared.removePersona(persona, lifespan: lifespan)
             } else {
-                try? Embrace.client?.metadata.add(persona: persona, lifespan: lifespan)
+                EmbraceIO.shared.addPersona(persona, lifespan: lifespan)
             }
 
             objectWillChange.send()
         }
 
-        func hasPersona(_ persona: PersonaTag) -> Bool {
+        func hasPersona(_ persona: String) -> Bool {
             let group = DispatchGroup()
             var contains = false
 
             group.enter()
-            Embrace.client?.metadata.getCurrentPersonas { tags in
+            EmbraceIO.shared.getCurrentPersonas { tags in
                 contains = tags.contains(persona)
                 group.leave()
             }
@@ -102,9 +71,7 @@ struct UserInfo: View {
     var body: some View {
         Form {
             Section(header: Text("Properties")) {
-                TextField("Username", text: $user.username)
                 TextField("Identifier", text: $user.identifier)
-                TextField("Email", text: $user.email)
 
                 Button("Clear All") {
                     user.clearProperties()
@@ -131,34 +98,11 @@ struct UserInfo: View {
         }.navigationTitle("User Information")
 
     }
-
-    func personaGridRows(size: Int = 3) -> [[PersonaTag]] {
-        let count = Self.quickPersonas.count
-
-        return stride(from: 0, to: count, by: size).map {
-            Array(Self.quickPersonas[$0..<Swift.min($0 + size, count)])
-        }
-    }
-
-    func colorForPersona(persona: PersonaTag) -> Color {
-        let idx = persona.rawValue.count % Self.personaColors.count
-        return Self.personaColors[idx]
-    }
-
 }
 
 extension UserInfo {
-    static var quickPersonas: [PersonaTag] {
-        [
-            PersonaTag.free,
-            PersonaTag.preview,
-            PersonaTag.subscriber,
-            PersonaTag.payer,
-            PersonaTag.guest,
-            PersonaTag.pro,
-            PersonaTag.mvp,
-            PersonaTag.vip
-        ]
+    static var quickPersonas: [String] {
+        ["free", "preview", "subscriber", "payer", "guest", "pro", "mvp", "vip"]
     }
 
     static var personaColors: [Color] {
@@ -170,12 +114,6 @@ extension UserInfo {
         ]
     }
 }
-
-extension PersonaTag: Identifiable {
-    public var id: String { rawValue }
-}
-
-extension PersonaTag: Hashable {}
 
 #Preview {
     UserInfo()

--- a/Sources/EmbraceCommonInternal/OTelBridge/EmbraceOTelSignalBridge.swift
+++ b/Sources/EmbraceCommonInternal/OTelBridge/EmbraceOTelSignalBridge.swift
@@ -40,4 +40,11 @@ public protocol EmbraceOTelSignalBridge {
 
     /// Called when a log is created
     func createLog(_ log: EmbraceLog)
+
+    /// Waits synchronously for any queued bridge work to drain.
+    func waitForAllWork()
+}
+
+extension EmbraceOTelSignalBridge {
+    public func waitForAllWork() {}
 }

--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -425,6 +425,21 @@ package class Embrace {
         Embrace.resetUploadCache = true
     }
 
+    /// Waits synchronously for all queued SDK work to drain.
+    ///
+    /// Drains the internal processing queue and the OTel bridge's span pipeline so the SDK
+    /// is idle before the caller continues. Intended for benchmarks and tests — exposed
+    /// publicly via `@_spi(Private)` on `EmbraceIO`.
+    package func waitForAllWork() {
+        // Don't use `asyncAndWait(::)` — it crashes on iOS 16.4 sim. Radar: FB21077492.
+        let group = DispatchGroup()
+
+        processingQueue.async(group: group, flags: .assignCurrentContext) {}
+        group.wait()
+
+        otel.bridge.waitForAllWork()
+    }
+
     /// Called every time the remote config changes
     @objc private func onConfigUpdated() {
         Embrace.logger.limits = config.internalLogLimits

--- a/Sources/EmbraceIO/EmbraceIO.swift
+++ b/Sources/EmbraceIO/EmbraceIO.swift
@@ -125,4 +125,12 @@ public class EmbraceIO {
     public func resetUploadCache() {
         Embrace.client?.resetUploadCache()
     }
+
+    /// Waits synchronously for all queued SDK work to drain.
+    ///
+    /// SPI for benchmarks and tests — not part of the public SDK surface.
+    @_spi(Private)
+    public func waitForAllWork() {
+        Embrace.client?.waitForAllWork()
+    }
 }

--- a/Sources/EmbraceOTelBridge/EmbraceOTelBridge.swift
+++ b/Sources/EmbraceOTelBridge/EmbraceOTelBridge.swift
@@ -214,6 +214,10 @@ extension EmbraceOTelBridge: EmbraceOTelSignalBridge {
         spanCache.withLock { $0[id] = nil }
     }
 
+    package func waitForAllWork() {
+        spanProcessor.waitForAllWork()
+    }
+
     package func createLog(_ log: EmbraceLog) {
         let logId = log.id
         // Track the ID so the inbound processor can skip it.

--- a/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessor.swift
+++ b/Sources/EmbraceOTelBridge/Processors/EmbraceSpanProcessor.swift
@@ -104,6 +104,15 @@ class EmbraceSpanProcessor: SpanProcessor {
         }
     }
 
+    /// Drains the internal processor queue synchronously by enqueuing an empty barrier and
+    /// waiting. Used by benchmark/test harnesses to ensure all queued span work is processed
+    /// before measurements are taken.
+    func waitForAllWork() {
+        let group = DispatchGroup()
+        processorQueue.async(group: group, flags: .assignCurrentContext) {}
+        group.wait()
+    }
+
     func shutdown(explicitTimeout: TimeInterval?) {
         processorQueue.sync {
             for var processor in childProcessors {


### PR DESCRIPTION
On the `7.0` branch the SDK's public API surface renamed `Embrace` → `EmbraceIO` and reshaped `Options`. PR #590 already migrated `Examples/EmbraceIOTestApp/`; this PR does the same for the two remaining example apps — `Examples/BrandGame` and `Examples/Benchmarks` — so the `Build Example Apps / Build BrandGame App (26.0)` and `On Device Benchmarks / build` jobs don't fail. on 7.0-descendant PR.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
