### PR TITLE
[EMBR-12282] Fix: Fix: CI: Grant pull-requests: write to run-danger.yml

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
`run-danger.yml` declared only `permissions: contents: read`, so Danger could detect a rule failure but couldn't post the explanatory PR comment  or commit status — it got `403 Resource not accessible by integration` on `POST /repos/.../issues/{n}/comments`. Contributors saw a red Danger check with no explanation of what to fix.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
