### PR TITLE
[EMBR-12306] Chore: CI: Catch test hangs sooner and capture diagnostics on cancellation

### DIFF
--- a/.github/actions/run-xcodebuild/action.yml
+++ b/.github/actions/run-xcodebuild/action.yml
@@ -111,6 +111,15 @@ runs:
           if [[ "$CODE_COVERAGE" == "true" ]]; then
             ARGS+=(-enableCodeCoverage YES)
           fi
+
+          # Per-test timeouts. A hung XCTest method otherwise eats the
+          # job-level cap and leaves no usable xcresult. Not enforced for
+          # hangs outside the test method body (XCTest infra waits, etc.).
+          ARGS+=(
+            -test-timeouts-enabled YES
+            -default-test-execution-time-allowance 120
+            -maximum-test-execution-time-allowance 600
+          )
         fi
 
         # GitHub runners have no signing identity, so `xcodebuild build` against
@@ -142,7 +151,7 @@ runs:
           | xcbeautify --renderer github-actions
 
     - name: Summarize xcodebuild log
-      if: failure()
+      if: failure() || cancelled()
       shell: bash
       env:
         XCODEBUILD_LOG: ${{ runner.temp }}/xcodebuild.log
@@ -187,7 +196,7 @@ runs:
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload xcodebuild log on failure
-      if: failure()
+      if: failure() || cancelled()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: xcodebuild-log-${{ inputs.scheme }}-${{ inputs.platform }}-${{ inputs.action }}-${{ inputs.sanitizer }}

--- a/.github/workflows/cocoapod-lint.yml
+++ b/.github/workflows/cocoapod-lint.yml
@@ -84,7 +84,7 @@ jobs:
           pod lib lint --allow-warnings --verbose --platforms=iOS 2>&1 | tee cocoapod-lint-output.log
 
       - name: Upload Lint Output on Failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cocoapod-lint-output

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,14 +40,15 @@ jobs:
   run-tests:
     needs: prepare
     name: Test ${{ matrix.platform }}, on macOS ${{ matrix.macos-version }}, with Xcode ${{ matrix.xcode_version }}, sanitizer ${{ matrix.sanitizer }}
-    timeout-minutes: 30
+    # 20 min: typical run is ~6 min compile + ~5 min tests. Per-test timeouts
+    # (see .github/actions/run-xcodebuild) catch single-method hangs; this
+    # job-level cap is the backstop for XCTest infra / parallel-worker hangs.
+    timeout-minutes: 20
     runs-on: macos-${{ matrix.macos-version }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
 
-    permissions:
-      checks: write
     steps:
       - name: Select Xcode
         run: |
@@ -89,7 +90,6 @@ jobs:
 
       - name: Run Unit Tests
         uses: ./.github/actions/run-xcodebuild
-        timeout-minutes: 80
         with:
           workspace: ".swiftpm/xcode/package.xcworkspace"
           scheme: EmbraceIO-Package
@@ -101,8 +101,8 @@ jobs:
           code-coverage: 'true'
           result-bundle-path: ./test.xcresult
 
-      - name: Upload xcresult on failure
-        if: failure()
+      - name: Upload xcresult on failure or cancellation
+        if: failure() || cancelled()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: xcresult-${{ matrix.platform }}-xcode${{ matrix.xcode_version }}-${{ matrix.sanitizer }}
@@ -114,7 +114,7 @@ jobs:
       # without downloading the ~75 MB xcresult artifact — especially
       # relevant for TSan aborts.
       - name: Surface failure summary from xcresult
-        if: failure()
+        if: failure() || cancelled()
         run: |
           if [ ! -d test.xcresult ]; then
             echo "test.xcresult not found in $(pwd); skipping summary."


### PR DESCRIPTION
## Summary

The `Test *` jobs in `run-tests.yml` periodically hang for ~19 minutes mid-test-run and get killed by the job-level `timeout-minutes: 30` cap. Two problems make these hangs hard to debug today:

1. The upload-artifact / failure-summary steps gate on `if: failure()`. But a `timeout-minutes` kill is marked **cancelled**, not **failed**, so those steps are skipped — the `xcodebuild.log` and `test.xcresult` from the hung run are never uploaded.
2. There is no per-test timeout, so a single hung XCTest method silently eats the full ~30-minute budget without identifying itself.

## Changes

### `.github/actions/run-xcodebuild/action.yml`
  - Add `-test-timeouts-enabled YES`, `-default-test-execution-time-allowance 120`, `-maximum-test-execution-time-allowance 600` to the test invocation.
  - Flip `Summarize xcodebuild log` and `Upload xcodebuild log` to `if: failure() || cancelled()`.

### `.github/workflows/run-tests.yml`
  - Flip `Upload xcresult` and `Surface failure summary from xcresult` to `if: failure() || cancelled()`.
  - Reduce job-level `timeout-minutes` from 30 → 20.
  - Remove the dead `timeout-minutes: 80` on the test step (the job-level cap was already the binding constraint).
  - Drop unused `checks: write` permission.

### `.github/workflows/cocoapod-lint.yml`
  - Flip `Upload Lint Output on Failure` to `if: failure() || cancelled()`.

## Expected impact on the next hang

  | Hang type | Before | After |
  |-----------|--------|-------|
  | Single-method hang | 30-min black box, no artifact | Test fails at 120s and is named in the xcresult |
  | XCTest infra / parallel-worker hang | 30-min black box, no artifact | 20-min cap, `xcodebuild.log` + `test.xcresult` uploaded |
  | Normal failure | Artifacts uploaded | Artifacts uploaded (no change) |

  ## Caveats

The per-test timeout flag is **not** enforced for hangs outside the test method body — XCTest infra waits, simulator system dialogs, parallel-worker setup. The 20-min job cap is the backstop for those, and the artifact-upload fix is what makes them debuggable when they recur.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
