### PR TITLE
[EMBR-12307] Fix: Tests: Make upload tests safe to run under -test-iterations

### DIFF
--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
@@ -25,6 +25,9 @@ class EmbraceUploadOperationTests: XCTestCase {
     var queue: DispatchQueue!
 
     override func setUpWithError() throws {
+        // EmbraceHTTPMock state is process-wide; reset between methods.
+        EmbraceHTTPMock.clearRequests()
+
         let urlSessionconfig = URLSessionConfiguration.ephemeral
         urlSessionconfig.httpMaximumConnectionsPerHost = .max
         urlSessionconfig.protocolClasses = [EmbraceHTTPMock.self]

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
@@ -52,6 +52,12 @@ private func makeModule(
 
 class EmbraceUploadOrderedDeliveryTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        // EmbraceHTTPMock state is process-wide; reset between methods.
+        EmbraceHTTPMock.clearRequests()
+    }
+
     // MARK: - 1. Ordering guarantee
 
     func test_spansAreUploadedInInsertionOrder() throws {

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -20,6 +20,9 @@ class EmbraceUploadTests: XCTestCase {
     var module: EmbraceUpload!
 
     override func setUpWithError() throws {
+        // EmbraceHTTPMock state is process-wide; reset between methods.
+        EmbraceHTTPMock.clearRequests()
+
         let urlSessionconfig = URLSessionConfiguration.ephemeral
         urlSessionconfig.httpMaximumConnectionsPerHost = .max
         urlSessionconfig.protocolClasses = [EmbraceHTTPMock.self]


### PR DESCRIPTION
 ## Summary

`EmbraceHTTPMock` (Tests/TestSupport/EmbraceHTTPMock.swift) backs `requestsForUrl(_:)` / `requestBodiesForUrl(_:)` with process-wide static dictionaries. Three test classes in `Tests/EmbraceUploadInternalTests/` register mocks and read counts from this shared state but never reset it. CI doesn't observe the leak today because each method runs exactly once. Under `-test-iterations N`, every iteration leaves entries in the dict and the next iteration's `.count` / `.first` / `.last` reads observe stale + fresh entries — assertions monotonically inflate (`actual = N` against `expected = 1`).


## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
