### PR TITLE
[EMBR-12321] Fix: Tests: watchOS DataTask*Swizzler flake + harden SwizzleCache against test residue

### DIFF
--- a/Sources/EmbraceCommonInternal/Swizzling/SwizzleCache.swift
+++ b/Sources/EmbraceCommonInternal/Swizzling/SwizzleCache.swift
@@ -51,6 +51,17 @@ import Foundation
             return SwizzleCache()
         }()
 
+        /// Signal raised when `addMethodImplementation` sees a duplicate install for the same
+        /// `(method, baseClass, swizzler)` key. Default fires `assertionFailure`. Tests that
+        /// intentionally exercise the duplicate-install contract override this (e.g. to record
+        /// the call) and are responsible for any logging they need.
+        ///
+        /// Whether or not this signal traps, the duplicate write is always skipped — the cached
+        /// "true original" stays intact so a subsequent unswizzle still restores it correctly.
+        public static var onDuplicateInstall: (String) -> Void = { message in
+            assertionFailure(message)
+        }
+
         private let lock = NSLock()
         private var originalImplementations: [OriginalMethod: IMP] = [:]
 
@@ -64,13 +75,37 @@ import Foundation
         ) {
             lock.lock()
             defer { lock.unlock() }
-            originalImplementations[
-                OriginalMethod(
-                    method: method,
-                    baseClass: baseClass,
-                    swizzlerClass: swizzler
+            let key = OriginalMethod(
+                method: method,
+                baseClass: baseClass,
+                swizzlerClass: swizzler
+            )
+            if originalImplementations[key] != nil {
+                let className = NSStringFromClass(baseClass)
+                let selectorName = NSStringFromSelector(method_getName(method))
+                Self.onDuplicateInstall(
+                    "SwizzleCache: \(swizzler) installed twice on \(className).\(selectorName) without an unswizzle in between."
                 )
-            ] = imp
+                return
+            }
+            originalImplementations[key] = imp
+        }
+
+        /// Whether the cache currently holds any swizzled-method entries. Intended for tests.
+        public var isEmpty: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return originalImplementations.isEmpty
+        }
+
+        /// Snapshot of cache contents as human-readable strings, sorted for stable output.
+        /// Intended for tests.
+        public var residueDescription: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return originalImplementations.keys.map { key in
+                "\(key.swizzlerClass) on \(NSStringFromClass(key.baseClass)).\(NSStringFromSelector(method_getName(key.method)))"
+            }.sorted()
         }
 
         public func getOriginalMethodImplementation(

--- a/Sources/EmbraceCommonInternal/Swizzling/SwizzleCache.swift
+++ b/Sources/EmbraceCommonInternal/Swizzling/SwizzleCache.swift
@@ -52,15 +52,15 @@ import Foundation
         }()
 
         /// Signal raised when `addMethodImplementation` sees a duplicate install for the same
-        /// `(method, baseClass, swizzler)` key. Default fires `assertionFailure`. Tests that
-        /// intentionally exercise the duplicate-install contract override this (e.g. to record
-        /// the call) and are responsible for any logging they need.
+        /// `(method, baseClass, swizzler)` key. Default is a no-op — leak detection in
+        /// swizzler tests is handled per-test via `assertNoNewSwizzleCacheEntries`, and the
+        /// duplicate path is a legitimate pattern for any test that re-starts Embrace via
+        /// `Embrace.setup`. Tests that intentionally exercise the duplicate-install contract
+        /// override this to record the message.
         ///
         /// Whether or not this signal traps, the duplicate write is always skipped — the cached
         /// "true original" stays intact so a subsequent unswizzle still restores it correctly.
-        public static var onDuplicateInstall: (String) -> Void = { message in
-            assertionFailure(message)
-        }
+        public static var onDuplicateInstall: (String) -> Void = { _ in }
 
         private let lock = NSLock()
         private var originalImplementations: [OriginalMethod: IMP] = [:]
@@ -103,9 +103,25 @@ import Foundation
         public var residueDescription: [String] {
             lock.lock()
             defer { lock.unlock() }
-            return originalImplementations.keys.map { key in
-                "\(key.swizzlerClass) on \(NSStringFromClass(key.baseClass)).\(NSStringFromSelector(method_getName(key.method)))"
-            }.sorted()
+            return originalImplementations.keys.map(Self.identifier(for:)).sorted()
+        }
+
+        /// Restores the original IMP for, and removes from the cache, every entry whose
+        /// identifier is NOT present in `baseline`. Intended for capture-service tests
+        /// that install via `EmbraceSwizzler` directly and have no uninstall API; pair
+        /// it with a `residueDescription` snapshot taken in `setUp` so unrelated entries
+        /// from previous test classes are left intact.
+        public func restoreEntries(addedSince baseline: Set<String>) {
+            lock.lock()
+            defer { lock.unlock() }
+            for (key, imp) in originalImplementations where !baseline.contains(Self.identifier(for: key)) {
+                method_setImplementation(key.method, imp)
+                originalImplementations.removeValue(forKey: key)
+            }
+        }
+
+        fileprivate static func identifier(for key: OriginalMethod) -> String {
+            "\(key.swizzlerClass) on \(NSStringFromClass(key.baseClass)).\(NSStringFromSelector(method_getName(key.method)))"
         }
 
         public func getOriginalMethodImplementation(

--- a/Tests/EmbraceCommonInternalTests/Swizzling/SwizzleCacheTests.swift
+++ b/Tests/EmbraceCommonInternalTests/Swizzling/SwizzleCacheTests.swift
@@ -1,0 +1,163 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import ObjectiveC.runtime
+import XCTest
+
+@testable import EmbraceCommonInternal
+
+final class SwizzleCacheTests: XCTestCase {
+
+    @objc private class DummySwizzleTarget: NSObject {
+        @objc dynamic func dummyMethod() {}
+    }
+
+    private struct TestSwizzler: Swizzlable {
+        typealias ImplementationType = @convention(c) (AnyObject, Selector) -> Void
+        typealias BlockImplementationType = @convention(block) (AnyObject) -> Void
+        static let selector: Selector = #selector(DummySwizzleTarget.dummyMethod)
+        let baseClass: AnyClass = DummySwizzleTarget.self
+
+        func install() throws {
+            try swizzleInstanceMethod { original -> BlockImplementationType in
+                return { receiver in original(receiver, Self.selector) }
+            }
+        }
+    }
+
+    private var method: Method!
+    private var trueOriginalIMP: IMP!
+    private let swizzlerName = "TestSwizzler"
+    private var duplicateInstallMessages: [String] = []
+    private var originalDuplicateHandler: ((String) -> Void)!
+
+    override func setUpWithError() throws {
+        XCTAssertTrue(
+            SwizzleCache.shared.isEmpty,
+            "test pollution from prior tests: \(SwizzleCache.shared.residueDescription)"
+        )
+        method = try XCTUnwrap(
+            class_getInstanceMethod(DummySwizzleTarget.self, #selector(DummySwizzleTarget.dummyMethod))
+        )
+        trueOriginalIMP = method_getImplementation(method)
+        duplicateInstallMessages = []
+        originalDuplicateHandler = SwizzleCache.onDuplicateInstall
+        SwizzleCache.onDuplicateInstall = { [weak self] message in
+            self?.duplicateInstallMessages.append(message)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        SwizzleCache.shared.removeOriginalMethodImplementation(
+            forMethod: method, inClass: DummySwizzleTarget.self, swizzler: swizzlerName)
+        SwizzleCache.shared.removeOriginalMethodImplementation(
+            forMethod: method, inClass: DummySwizzleTarget.self, swizzler: "SwizzlerA")
+        SwizzleCache.shared.removeOriginalMethodImplementation(
+            forMethod: method, inClass: DummySwizzleTarget.self, swizzler: "SwizzlerB")
+        method_setImplementation(method, trueOriginalIMP)
+        SwizzleCache.onDuplicateInstall = originalDuplicateHandler
+    }
+
+    /// Duplicate installs without an unswizzle in between must not overwrite the cached "true
+    /// original" with an already-swizzled IMP — otherwise a later unswizzle would restore stale
+    /// state.
+    func test_duplicateInstall_preservesTrueOriginalImplementation() {
+        let stalePostSwizzleIMP = imp_implementationWithBlock(({} as @convention(block) () -> Void))
+        addToCache(trueOriginalIMP)
+        addToCache(stalePostSwizzleIMP)
+
+        let cached = SwizzleCache.shared.getOriginalMethodImplementation(
+            forMethod: method,
+            inClass: DummySwizzleTarget.self,
+            swizzler: swizzlerName
+        )
+        XCTAssertEqual(cached, trueOriginalIMP)
+        XCTAssertNotEqual(cached, stalePostSwizzleIMP)
+        XCTAssertEqual(SwizzleCache.shared.residueDescription.count, 1)
+        XCTAssertEqual(duplicateInstallMessages.count, 1)
+        XCTAssertTrue(duplicateInstallMessages[0].contains(swizzlerName))
+        imp_removeBlock(stalePostSwizzleIMP)
+    }
+
+    /// A swizzler that unswizzles between installs is the legitimate cross-test scenario — the
+    /// second install must succeed (not be misclassified as a leak).
+    func test_installAfterRemove_treatsSecondInstallAsFirst() {
+        let firstIMP = trueOriginalIMP!
+        let secondIMP = imp_implementationWithBlock(({} as @convention(block) () -> Void))
+
+        addToCache(firstIMP)
+        SwizzleCache.shared.removeOriginalMethodImplementation(
+            forMethod: method,
+            inClass: DummySwizzleTarget.self,
+            swizzler: swizzlerName
+        )
+        addToCache(secondIMP)
+
+        let cached = SwizzleCache.shared.getOriginalMethodImplementation(
+            forMethod: method,
+            inClass: DummySwizzleTarget.self,
+            swizzler: swizzlerName
+        )
+        XCTAssertEqual(cached, secondIMP)
+        XCTAssertEqual(duplicateInstallMessages.count, 0)
+        imp_removeBlock(secondIMP)
+    }
+
+    /// Cache keys are `(method, baseClass, swizzlerClass)`. Two different swizzler classes
+    /// targeting the same method must both be able to install once.
+    func test_duplicateRejection_isScopedToSwizzlerClass() {
+        addToCache(trueOriginalIMP, swizzler: "SwizzlerA")
+        let otherIMP = imp_implementationWithBlock(({} as @convention(block) () -> Void))
+        addToCache(otherIMP, swizzler: "SwizzlerB")
+
+        XCTAssertEqual(
+            SwizzleCache.shared.getOriginalMethodImplementation(
+                forMethod: method, inClass: DummySwizzleTarget.self, swizzler: "SwizzlerA"),
+            trueOriginalIMP
+        )
+        XCTAssertEqual(
+            SwizzleCache.shared.getOriginalMethodImplementation(
+                forMethod: method, inClass: DummySwizzleTarget.self, swizzler: "SwizzlerB"),
+            otherIMP
+        )
+        XCTAssertEqual(duplicateInstallMessages.count, 0)
+        imp_removeBlock(otherIMP)
+    }
+
+    /// End-to-end: the user-visible contract is that unswizzle restores the method's IMP to the
+    /// pre-first-swizzle IMP, even when a duplicate install corrupted the live method chain in
+    /// between. Exercises `Swizzlable.swizzleInstanceMethod` (not just the cache directly) so any
+    /// future changes that decoupled the cache from unswizzle would be caught.
+    func test_endToEnd_unswizzleAfterDuplicateInstall_restoresTrueOriginal() throws {
+        let swizzler = TestSwizzler()
+
+        try swizzler.install()
+        let firstSwizzledIMP = method_getImplementation(method)
+        XCTAssertNotEqual(firstSwizzledIMP, trueOriginalIMP)
+
+        try swizzler.install()
+        XCTAssertEqual(duplicateInstallMessages.count, 1)
+
+        let cachedOriginal = try XCTUnwrap(
+            SwizzleCache.shared.getOriginalMethodImplementation(
+                forMethod: method,
+                inClass: DummySwizzleTarget.self,
+                swizzler: String(describing: TestSwizzler.self)
+            )
+        )
+        XCTAssertEqual(cachedOriginal, trueOriginalIMP)
+
+        method_setImplementation(method, cachedOriginal)
+        XCTAssertEqual(method_getImplementation(method), trueOriginalIMP)
+    }
+
+    private func addToCache(_ imp: IMP, swizzler: String? = nil) {
+        SwizzleCache.shared.addMethodImplementation(
+            imp,
+            forMethod: method,
+            inClass: DummySwizzleTarget.self,
+            swizzler: swizzler ?? swizzlerName
+        )
+    }
+}

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 // swiftlint:disable force_try
 
-class DataTaskWithURLAndCompletionSwizzlerTests: XCTestCase {
+class DataTaskWithURLAndCompletionSwizzlerTests: SwizzlerTestCase {
     private var session: URLSession!
     private var sut: DataTaskWithURLAndCompletionSwizzler!
     private var sut2: DataTaskWithURLRequestAndCompletionSwizzler!
@@ -22,7 +22,7 @@ class DataTaskWithURLAndCompletionSwizzlerTests: XCTestCase {
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
         try? sut2.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
@@ -21,6 +21,7 @@ class DataTaskWithURLAndCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        try? sut2.unswizzleInstanceMethod()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
@@ -22,6 +22,7 @@ class DataTaskWithURLAndCompletionSwizzlerTests: XCTestCase {
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
         try? sut2.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestAndCompletionSwizzlerTests.swift
@@ -18,6 +18,7 @@ class DataTaskWithURLRequestAndCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestAndCompletionSwizzlerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import EmbraceCommonInternal
 @testable import EmbraceCore
 
-class DataTaskWithURLRequestAndCompletionSwizzlerTests: XCTestCase {
+class DataTaskWithURLRequestAndCompletionSwizzlerTests: SwizzlerTestCase {
     private var session: URLSession!
     private var sut: DataTaskWithURLRequestAndCompletionSwizzler!
     private var handler: MockURLSessionTaskHandler!
@@ -18,7 +18,7 @@ class DataTaskWithURLRequestAndCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestSwizzlerTests.swift
@@ -16,6 +16,7 @@ class DataTaskWithURLRequestSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestSwizzlerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import EmbraceCommonInternal
 @testable import EmbraceCore
 
-class DataTaskWithURLRequestSwizzlerTests: XCTestCase {
+class DataTaskWithURLRequestSwizzlerTests: SwizzlerTestCase {
     private var session: URLSession!
     private var sut: DataTaskWithURLRequestSwizzler!
     private var handler: MockURLSessionTaskHandler!
@@ -16,7 +16,7 @@ class DataTaskWithURLRequestSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import EmbraceCommonInternal
 @testable import EmbraceCore
 
-class DataTaskWithURLSwizzlerTests: XCTestCase {
+class DataTaskWithURLSwizzlerTests: SwizzlerTestCase {
     private var session: URLSession!
     private var sut: DataTaskWithURLSwizzler!
     private var sut2: DataTaskWithURLRequestSwizzler!
@@ -18,7 +18,7 @@ class DataTaskWithURLSwizzlerTests: XCTestCase {
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
         try? sut2.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
@@ -17,6 +17,7 @@ class DataTaskWithURLSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        try? sut2.unswizzleInstanceMethod()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
@@ -18,6 +18,7 @@ class DataTaskWithURLSwizzlerTests: XCTestCase {
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
         try? sut2.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestSwizzlerTests.swift
@@ -17,6 +17,7 @@ class DownloadTaskWithURLRequestSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestSwizzlerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class DownloadTaskWithURLRequestSwizzlerTests: XCTestCase {
+class DownloadTaskWithURLRequestSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: DownloadTaskWithURLRequestSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class DownloadTaskWithURLRequestSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestWithCompletionSwizzler.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestWithCompletionSwizzler.swift
@@ -17,6 +17,7 @@ class DownloadTaskWithURLWithCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestWithCompletionSwizzler.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestWithCompletionSwizzler.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class DownloadTaskWithURLWithCompletionSwizzlerTests: XCTestCase {
+class DownloadTaskWithURLWithCompletionSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: DownloadTaskWithURLRequestWithCompletionSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class DownloadTaskWithURLWithCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyAsTaskDelegateTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyAsTaskDelegateTests.swift
@@ -18,6 +18,12 @@ final class URLSessionDelegateProxyAsTaskDelegateTests: XCTestCase {
 
     static let timeoutQuick = 0.2
 
+    override func tearDownWithError() throws {
+        if urlSessionCaptureService != nil { unswizzleDefaultCaptureService() }
+        if otherSwizzler != nil { unswizzleOtherSwizzler() }
+        assertSwizzleCacheEmpty()
+    }
+
     // MARK: - Setup
     func givenCaptureServiceInstalled() {
         urlSessionCaptureService = URLSessionCaptureService(options: .init())

--- a/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyAsTaskDelegateTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyAsTaskDelegateTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-final class URLSessionDelegateProxyAsTaskDelegateTests: XCTestCase {
+final class URLSessionDelegateProxyAsTaskDelegateTests: SwizzlerTestCase {
     private var otherSwizzler: DummyURLSessionInitWithDelegateSwizzler?
     private var urlSessionCaptureService: URLSessionCaptureService!
     private var openTelemetry: MockEmbraceOpenTelemetry!
@@ -21,7 +21,7 @@ final class URLSessionDelegateProxyAsTaskDelegateTests: XCTestCase {
     override func tearDownWithError() throws {
         if urlSessionCaptureService != nil { unswizzleDefaultCaptureService() }
         if otherSwizzler != nil { unswizzleOtherSwizzler() }
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     // MARK: - Setup

--- a/Tests/EmbraceCoreTests/Capture/Network/SessionTaskResumeSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/SessionTaskResumeSwizzlerTests.swift
@@ -15,6 +15,7 @@ class SessionTaskResumeSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() async throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/SessionTaskResumeSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/SessionTaskResumeSwizzlerTests.swift
@@ -8,14 +8,14 @@ import XCTest
 @testable import EmbraceCommonInternal
 @testable import EmbraceCore
 
-class SessionTaskResumeSwizzlerTests: XCTestCase {
+class SessionTaskResumeSwizzlerTests: SwizzlerTestCase {
     private var session: URLSession!
     private var sut: SessionTaskResumeSwizzler!
     private var handler: MockURLSessionTaskHandler!
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() async throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/URLSessionInitWithDelegateSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/URLSessionInitWithDelegateSwizzlerTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class DummyURLSessionDelegate: NSObject, URLSessionDelegate {}
 
-class URLSessionInitWithDelegateSwizzlerTests: XCTestCase {
+class URLSessionInitWithDelegateSwizzlerTests: SwizzlerTestCase {
     private var sut: URLSessionInitWithDelegateSwizzler!
     private var session: URLSession!
     private var originalDelegate: URLSessionDelegate!
@@ -18,7 +18,7 @@ class URLSessionInitWithDelegateSwizzlerTests: XCTestCase {
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
         try? sut.unswizzleClassMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func testAfterInstall_onCreateURLSessionWithDelegate_originalShouldBeWrapped() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/URLSessionInitWithDelegateSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/URLSessionInitWithDelegateSwizzlerTests.swift
@@ -18,6 +18,7 @@ class URLSessionInitWithDelegateSwizzlerTests: XCTestCase {
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
         try? sut.unswizzleClassMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func testAfterInstall_onCreateURLSessionWithDelegate_originalShouldBeWrapped() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataAndCompletionSwizzlerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class UploadTaskWithRequestFromDataAndCompletionSwizzlerTests: XCTestCase {
+class UploadTaskWithRequestFromDataAndCompletionSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: UploadTaskWithRequestFromDataWithCompletionSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class UploadTaskWithRequestFromDataAndCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataAndCompletionSwizzlerTests.swift
@@ -17,6 +17,7 @@ class UploadTaskWithRequestFromDataAndCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataSwizzlerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class UploadTaskWithRequestFromDataSwizzlerTests: XCTestCase {
+class UploadTaskWithRequestFromDataSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: UploadTaskWithRequestFromDataSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class UploadTaskWithRequestFromDataSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataSwizzlerTests.swift
@@ -17,6 +17,7 @@ class UploadTaskWithRequestFromDataSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileSwizzlerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class UploadTaskWithRequestFromFileSwizzlerTests: XCTestCase {
+class UploadTaskWithRequestFromFileSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: UploadTaskWithRequestFromFileSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class UploadTaskWithRequestFromFileSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileSwizzlerTests.swift
@@ -17,6 +17,7 @@ class UploadTaskWithRequestFromFileSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileWithCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileWithCompletionSwizzlerTests.swift
@@ -17,6 +17,7 @@ class UploadTaskWithRequestFromFileWithCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileWithCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileWithCompletionSwizzlerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class UploadTaskWithRequestFromFileWithCompletionSwizzlerTests: XCTestCase {
+class UploadTaskWithRequestFromFileWithCompletionSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: UploadTaskWithRequestFromFileWithCompletionSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class UploadTaskWithRequestFromFileWithCompletionSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func testAfterInstall_onExecutingRequest_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithStreamedRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithStreamedRequestSwizzlerTests.swift
@@ -17,6 +17,7 @@ class UploadTaskWithStreamedRequestSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
+        assertSwizzleCacheEmpty()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithStreamedRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithStreamedRequestSwizzlerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 @testable import EmbraceCore
 
-class UploadTaskWithStreamedRequestSwizzlerTests: XCTestCase {
+class UploadTaskWithStreamedRequestSwizzlerTests: SwizzlerTestCase {
     private var handler: MockURLSessionTaskHandler!
     private var sut: UploadTaskWithStreamedRequestSwizzler!
     private var session: URLSession!
@@ -17,7 +17,7 @@ class UploadTaskWithStreamedRequestSwizzlerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try? sut.unswizzleInstanceMethod()
-        assertSwizzleCacheEmpty()
+        try super.tearDownWithError()
     }
 
     func test_afterInstall_taskWillBeCreatedInHandler() throws {

--- a/Tests/EmbraceCoreTests/Capture/UX/TapCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/TapCaptureServiceTests.swift
@@ -11,16 +11,19 @@
 
     // swiftlint:disable force_cast
 
-    final class TapCaptureServiceTests: XCTestCase {
+    final class TapCaptureServiceTests: SwizzlerTestCase {
 
         private var otel: MockEmbraceOpenTelemetry!
 
         override func setUpWithError() throws {
+            try super.setUpWithError()
             otel = MockEmbraceOpenTelemetry()
         }
 
         override func tearDownWithError() throws {
             otel = nil
+            restoreSwizzleCacheAdditions()
+            try super.tearDownWithError()
         }
 
         func test_tap() throws {

--- a/Tests/EmbraceCoreTests/Capture/UX/View/CaptureServicesUIViewControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/View/CaptureServicesUIViewControllerTests.swift
@@ -11,7 +11,7 @@
     import TestSupport
     import EmbraceCommonInternal
 
-    class CaptureServicesUIViewControllerTests: XCTestCase {
+    class CaptureServicesUIViewControllerTests: SwizzlerTestCase {
 
         let context = CrashReporterContext(
             appId: nil,
@@ -24,6 +24,11 @@
 
         let enabledConfig = EditableConfig(isUiLoadInstrumentationEnabled: true)
         let disabledConfig = EditableConfig(isUiLoadInstrumentationEnabled: false)
+
+        override func tearDownWithError() throws {
+            restoreSwizzleCacheAdditions()
+            try super.tearDownWithError()
+        }
 
         func test_onInteractionReady_noService() {
             // given capture services without a ViewCaptureService

--- a/Tests/EmbraceCoreTests/Capture/UX/View/ViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/UX/View/ViewCaptureServiceTests.swift
@@ -10,16 +10,22 @@
     import EmbraceOTelInternal
     import TestSupport
 
-    class ViewCaptureServiceTests: XCTestCase {
+    class ViewCaptureServiceTests: SwizzlerTestCase {
 
         var handler: MockUIViewControllerHandler!
         var service: ViewCaptureService!
 
         override func setUpWithError() throws {
+            try super.setUpWithError()
             handler = MockUIViewControllerHandler()
             service = ViewCaptureService(options: ViewCaptureService.Options(), handler: handler, lock: NSLock())
             service.install(otel: nil)
             service.start()
+        }
+
+        override func tearDownWithError() throws {
+            restoreSwizzleCacheAdditions()
+            try super.tearDownWithError()
         }
 
         func test_viewDidLoad() {

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
@@ -11,14 +11,20 @@
     import EmbraceCommonInternal
 
     @MainActor
-    class WebViewCaptureServiceTests: XCTestCase {
+    class WebViewCaptureServiceTests: SwizzlerTestCase {
 
         let otel: MockEmbraceOpenTelemetry! = MockEmbraceOpenTelemetry()
         let service: WebViewCaptureService! = WebViewCaptureService()
         static let pids: EmbraceMutex<Set<Int32>> = EmbraceMutex(Set<Int32>())
 
-        override func setUp() {
+        override func setUpWithError() throws {
+            try super.setUpWithError()
             service.install(otel: otel)
+        }
+
+        override func tearDownWithError() throws {
+            restoreSwizzleCacheAdditions()
+            try super.tearDownWithError()
         }
 
         internal func checkTestAllowed() throws {

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift
@@ -5,6 +5,22 @@
 import EmbraceCommonInternal
 import EmbraceCore
 import Foundation
+import XCTest
+
+extension XCTestCase {
+    /// Asserts the global `SwizzleCache` is empty. Call from `tearDownWithError` in swizzler-style
+    /// tests so a test that installs without unswizzling fails immediately on the offending case,
+    /// instead of surfacing later as cross-test residue.
+    public func assertSwizzleCacheEmpty(file: StaticString = #file, line: UInt = #line) {
+        let residue = SwizzleCache.shared.residueDescription
+        XCTAssertTrue(
+            residue.isEmpty,
+            "SwizzleCache leak after \(name): \(residue.joined(separator: ", "))",
+            file: file,
+            line: line
+        )
+    }
+}
 
 extension Swizzlable {
     public func unswizzleInstanceMethod() throws {

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift
@@ -5,51 +5,7 @@
 import EmbraceCommonInternal
 import EmbraceCore
 import Foundation
-import ObjectiveC.runtime
 import XCTest
-
-extension XCTestCase {
-    /// Records the current global `SwizzleCache` contents as a per-test baseline. Call from
-    /// `setUp` / `setUpWithError`. `assertNoNewSwizzleCacheEntries` and
-    /// `restoreSwizzleCacheAdditions` use this baseline to ignore residue left by earlier
-    /// test classes — a leak surfaces at the test that actually caused it.
-    public func captureSwizzleCacheBaseline() {
-        let baseline = Set(SwizzleCache.shared.residueDescription)
-        objc_setAssociatedObject(self, &swizzleCacheBaselineKey, baseline, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-
-    /// Asserts no swizzler entries were added to the global `SwizzleCache` since the baseline
-    /// recorded by `captureSwizzleCacheBaseline`. Call from `tearDownWithError`. If no baseline
-    /// was recorded the comparison treats the baseline as empty.
-    public func assertNoNewSwizzleCacheEntries(file: StaticString = #file, line: UInt = #line) {
-        let added = newSwizzleCacheEntries()
-        XCTAssertTrue(
-            added.isEmpty,
-            "SwizzleCache leak after \(name): \(added.joined(separator: ", "))",
-            file: file,
-            line: line
-        )
-    }
-
-    /// Restores the original IMPs for every cache entry added since the baseline and removes
-    /// them from the cache. Intended for capture-service tests that install via `EmbraceSwizzler`
-    /// directly and have no uninstall API — call from `tearDownWithError` before
-    /// `assertNoNewSwizzleCacheEntries`.
-    public func restoreSwizzleCacheAdditions() {
-        SwizzleCache.shared.restoreEntries(addedSince: swizzleCacheBaseline())
-    }
-
-    private func swizzleCacheBaseline() -> Set<String> {
-        (objc_getAssociatedObject(self, &swizzleCacheBaselineKey) as? Set<String>) ?? []
-    }
-
-    private func newSwizzleCacheEntries() -> [String] {
-        let baseline = swizzleCacheBaseline()
-        return SwizzleCache.shared.residueDescription.filter { !baseline.contains($0) }
-    }
-}
-
-private nonisolated(unsafe) var swizzleCacheBaselineKey: UInt8 = 0
 
 extension Swizzlable {
     public func unswizzleInstanceMethod() throws {

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift
@@ -5,22 +5,51 @@
 import EmbraceCommonInternal
 import EmbraceCore
 import Foundation
+import ObjectiveC.runtime
 import XCTest
 
 extension XCTestCase {
-    /// Asserts the global `SwizzleCache` is empty. Call from `tearDownWithError` in swizzler-style
-    /// tests so a test that installs without unswizzling fails immediately on the offending case,
-    /// instead of surfacing later as cross-test residue.
-    public func assertSwizzleCacheEmpty(file: StaticString = #file, line: UInt = #line) {
-        let residue = SwizzleCache.shared.residueDescription
+    /// Records the current global `SwizzleCache` contents as a per-test baseline. Call from
+    /// `setUp` / `setUpWithError`. `assertNoNewSwizzleCacheEntries` and
+    /// `restoreSwizzleCacheAdditions` use this baseline to ignore residue left by earlier
+    /// test classes — a leak surfaces at the test that actually caused it.
+    public func captureSwizzleCacheBaseline() {
+        let baseline = Set(SwizzleCache.shared.residueDescription)
+        objc_setAssociatedObject(self, &swizzleCacheBaselineKey, baseline, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    /// Asserts no swizzler entries were added to the global `SwizzleCache` since the baseline
+    /// recorded by `captureSwizzleCacheBaseline`. Call from `tearDownWithError`. If no baseline
+    /// was recorded the comparison treats the baseline as empty.
+    public func assertNoNewSwizzleCacheEntries(file: StaticString = #file, line: UInt = #line) {
+        let added = newSwizzleCacheEntries()
         XCTAssertTrue(
-            residue.isEmpty,
-            "SwizzleCache leak after \(name): \(residue.joined(separator: ", "))",
+            added.isEmpty,
+            "SwizzleCache leak after \(name): \(added.joined(separator: ", "))",
             file: file,
             line: line
         )
     }
+
+    /// Restores the original IMPs for every cache entry added since the baseline and removes
+    /// them from the cache. Intended for capture-service tests that install via `EmbraceSwizzler`
+    /// directly and have no uninstall API — call from `tearDownWithError` before
+    /// `assertNoNewSwizzleCacheEntries`.
+    public func restoreSwizzleCacheAdditions() {
+        SwizzleCache.shared.restoreEntries(addedSince: swizzleCacheBaseline())
+    }
+
+    private func swizzleCacheBaseline() -> Set<String> {
+        (objc_getAssociatedObject(self, &swizzleCacheBaselineKey) as? Set<String>) ?? []
+    }
+
+    private func newSwizzleCacheEntries() -> [String] {
+        let baseline = swizzleCacheBaseline()
+        return SwizzleCache.shared.residueDescription.filter { !baseline.contains($0) }
+    }
 }
+
+private nonisolated(unsafe) var swizzleCacheBaselineKey: UInt8 = 0
 
 extension Swizzlable {
     public func unswizzleInstanceMethod() throws {

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/SwizzlerTestCase.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/SwizzlerTestCase.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+/// Base class for tests that touch the global `SwizzleCache`. Captures a baseline
+/// snapshot in `setUp` and asserts no new entries remain in `tearDown` — a swizzler
+/// install without a matching unswizzle fails at the test that caused it, not as
+/// cross-class residue downstream.
+///
+/// Subclasses that override `tearDownWithError` must call `try super.tearDownWithError()`
+/// after their own cleanup so the assertion runs against post-cleanup state. Capture-
+/// service tests that install via `EmbraceSwizzler` directly (no uninstall API) call
+/// `restoreSwizzleCacheAdditions()` before `super` to drain what they added.
+open class SwizzlerTestCase: XCTestCase {
+    open override func setUpWithError() throws {
+        try super.setUpWithError()
+        captureSwizzleCacheBaseline()
+    }
+
+    open override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        assertNoNewSwizzleCacheEntries()
+    }
+}

--- a/Tests/EmbraceCoreTests/TestSupport/Utilities/SwizzlerTestCase.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/Utilities/SwizzlerTestCase.swift
@@ -2,6 +2,8 @@
 //  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceCommonInternal
+import ObjectiveC.runtime
 import XCTest
 
 /// Base class for tests that touch the global `SwizzleCache`. Captures a baseline
@@ -24,3 +26,46 @@ open class SwizzlerTestCase: XCTestCase {
         assertNoNewSwizzleCacheEntries()
     }
 }
+
+extension XCTestCase {
+    /// Records the current global `SwizzleCache` contents as a per-test baseline. Call from
+    /// `setUp` / `setUpWithError`. `assertNoNewSwizzleCacheEntries` and
+    /// `restoreSwizzleCacheAdditions` use this baseline to ignore residue left by earlier
+    /// test classes — a leak surfaces at the test that actually caused it.
+    public func captureSwizzleCacheBaseline() {
+        let baseline = Set(SwizzleCache.shared.residueDescription)
+        objc_setAssociatedObject(self, &swizzleCacheBaselineKey, baseline, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    /// Asserts no swizzler entries were added to the global `SwizzleCache` since the baseline
+    /// recorded by `captureSwizzleCacheBaseline`. Call from `tearDownWithError`. If no baseline
+    /// was recorded the comparison treats the baseline as empty.
+    public func assertNoNewSwizzleCacheEntries(file: StaticString = #file, line: UInt = #line) {
+        let added = newSwizzleCacheEntries()
+        XCTAssertTrue(
+            added.isEmpty,
+            "SwizzleCache leak after \(name): \(added.joined(separator: ", "))",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Restores the original IMPs for every cache entry added since the baseline and removes
+    /// them from the cache. Intended for capture-service tests that install via `EmbraceSwizzler`
+    /// directly and have no uninstall API — call from `tearDownWithError` before
+    /// `assertNoNewSwizzleCacheEntries`.
+    public func restoreSwizzleCacheAdditions() {
+        SwizzleCache.shared.restoreEntries(addedSince: swizzleCacheBaseline())
+    }
+
+    private func swizzleCacheBaseline() -> Set<String> {
+        (objc_getAssociatedObject(self, &swizzleCacheBaselineKey) as? Set<String>) ?? []
+    }
+
+    private func newSwizzleCacheEntries() -> [String] {
+        let baseline = swizzleCacheBaseline()
+        return SwizzleCache.shared.residueDescription.filter { !baseline.contains($0) }
+    }
+}
+
+private nonisolated(unsafe) var swizzleCacheBaselineKey: UInt8 = 0


### PR DESCRIPTION
## Summary

Fixes a swizzle-cache residue bug that surfaced as a flake in `DataTask*SwizzlerTests.test_afterInstall_taskWillBeCreatedInHandler` ([three independent failures in
~24h](https://github.com/embrace-io/embrace-apple-sdk/actions/runs/26169996918) on `main` and unrelated PR branches). All observed failures were on watchOS, but the residue mechanism is platform-agnostic — watchOS surfaces it consistently because its smaller test surface produces stable predecessor ordering; other matrix legs likely happen to clear
state via intervening tests.

## Root cause

`SwizzleCache.shared.saveInCache` (guarded by DEBUG) keys cached "original" IMPs by `(method, class, swizzlerClassName)`. A second install of the same swizzler class without an unswizzle in between **silently overwrites** the cached original with the previously-swizzled IMP. From then on, the unswizzle path restores the method to a stale swizzled IMP that captured a dead test's `[weak handler]`.

`DataTaskWithURLSwizzlerTests` and `DataTaskWithURLAndCompletionSwizzlerTests` install two swizzlers in `givenSwizzlingWasDone()` but only unswizzle one in `tearDownWithError`. The leaked swizzler is the SUT of sibling test classes. When those sibling tests run, they trigger the double-install path, the cache gets corrupted, and the test method now runs through a chain of orphan blocks plus the current handler. watchOS surfaces it because that matrix leg has a smaller test surface and predecessor ordering is stable enough to hit the residue.

## Changes

### 1. Immediate fix

  - `DataTaskWithURLSwizzlerTests.tearDownWithError` now unswizzles `sut2`.
  - `DataTaskWithURLAndCompletionSwizzlerTests.tearDownWithError` same.

These were the only two files in the swizzler test suite that installed `sut2` without unswizzling it.

### 2. SwizzleCache contract change (limited to DEBUG-only)

`SwizzleCache.addMethodImplementation` no longer silently overwrites on duplicate `(method, baseClass, swizzler)`. It:

- Skips the cache write so the true-original IMP stays correct.
- Calls a public `static var onDuplicateInstall: (String) -> Void` (defaults to `assertionFailure`). Tests inject a recorder to verify behavior without trapping the runner.

`SwizzleCache` is `#if DEBUG`-only and both `saveInCache` call sites are also `#if DEBUG`, so this has **zero release-build effect**. Production's `CaptureService.install()` uses a `state.compareExchange(.uninstalled → .installed)` guard, and there is no enable/disable cycle in the SDK lifecycle that could trigger double-install in prod. This is purely done to remove a testing footgun.

Added `isEmpty` and `residueDescription` for diagnostics. `residueDescription` is sorted for deterministic output.

### 3. Per-test residue assertion

New `XCTestCase.assertSwizzleCacheEmpty()` in `Tests/EmbraceCoreTests/TestSupport/Utilities/Swizzlable+Unswizzle.swift`. Called from `tearDownWithError` in 13 swizzler unit tests under `Tests/EmbraceCoreTests/Capture/Network/` and from `URLSessionDelegateProxyAsTaskDelegateTests`. A swizzler-test that forgets to unswizzle now fails immediately in its own teardown — not as cross-test flake on a downstream platform.

### Audit notes

  - `URLSessionCaptureServiceTests` uses mock swizzlers that don't touch `SwizzleCache`, so the residue assertion isn't applicable. Left alone.
  - `Proxy/URLSessionDelegateProxyAsTaskDelegateTests` had no centralized `tearDown` — added a `tearDownWithError` that runs the existing per-test cleanup helpers and then asserts cache empty. Confirms the helpers cover every swizzler the capture service installs (all 8 tests pass).

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
