### PR TITLE
[EMBR-12070] Fix: Fix: Guard EmbraceUploadOperation against cancel/completion race

### DIFF
--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -76,16 +76,16 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
     override func cancel() {
         super.cancel()
 
-        let (taskToCancel, attemptCount, shouldFire) = state.withLock {
-            guard !$0.hasFinished else {
-                return (nil, $0.attemptCount, false)
+        let (taskToCancel, attemptCount, shouldFire) = state.withLock { s -> (URLSessionDataTask?, Int, Bool) in
+            guard !s.hasFinished else {
+                return (nil, s.attemptCount, false)
             }
-            
+
             let taskToCancel = s.task
-            $0.task = nil
-            $0.hasFinished = true
-            
-            return (taskToCancel, $0.attemptCount, true)
+            s.task = nil
+            s.hasFinished = true
+
+            return (taskToCancel, s.attemptCount, true)
         }
 
         taskToCancel?.cancel()
@@ -127,20 +127,18 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
                 )
             })
 
-        // If operation finished meanwhile, cancel the new task immediately.
+        // If operation finished meanwhile, drop the unstarted task; it was never resumed.
         let started = state.withLock {
             guard !$0.hasFinished else { return false }
-            
+
             $0.attemptCount = nextAttemptCount
             $0.task = newTask
-            
+
             return true
         }
 
         if started {
             newTask.resume()
-        } else {
-            newTask.cancel()
         }
     }
 
@@ -184,10 +182,10 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         }
 
         let (shouldFire, attemptCount) = state.withLock {
-            guard !$0.hasFinished else { 
+            guard !$0.hasFinished else {
                 return (false, $0.attemptCount)
             }
-            
+
             $0.hasFinished = true
             return (true, $0.attemptCount)
         }

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -76,14 +76,16 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
     override func cancel() {
         super.cancel()
 
-        let (taskToCancel, attemptCount, shouldFire) = state.withLock { s -> (URLSessionDataTask?, Int, Bool) in
-            guard !s.hasFinished else {
-                return (nil, s.attemptCount, false)
+        let (taskToCancel, attemptCount, shouldFire) = state.withLock {
+            guard !$0.hasFinished else {
+                return (nil, $0.attemptCount, false)
             }
+            
             let taskToCancel = s.task
-            s.task = nil
-            s.hasFinished = true
-            return (taskToCancel, s.attemptCount, true)
+            $0.task = nil
+            $0.hasFinished = true
+            
+            return (taskToCancel, $0.attemptCount, true)
         }
 
         taskToCancel?.cancel()
@@ -126,10 +128,12 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
             })
 
         // If operation finished meanwhile, cancel the new task immediately.
-        let started = state.withLock { s -> Bool in
-            guard !s.hasFinished else { return false }
-            s.attemptCount = nextAttemptCount
-            s.task = newTask
+        let started = state.withLock {
+            guard !$0.hasFinished else { return false }
+            
+            $0.attemptCount = nextAttemptCount
+            $0.task = newTask
+            
             return true
         }
 
@@ -148,7 +152,7 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         retryCount: Int
     ) {
         // Fast path: operation already completed or cancelled.
-        if state.withLock({ $0.hasFinished }) { return }
+        guard !state.safeValue.hasFinished else { return }
 
         // Check retry budget: -1 = unlimited, 0 = none, >0 = that many remaining
         let hasRetryBudget = (retryCount != 0)
@@ -179,10 +183,13 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
             result = .failure
         }
 
-        let (shouldFire, attemptCount) = state.withLock { s -> (Bool, Int) in
-            guard !s.hasFinished else { return (false, s.attemptCount) }
-            s.hasFinished = true
-            return (true, s.attemptCount)
+        let (shouldFire, attemptCount) = state.withLock {
+            guard !$0.hasFinished else { 
+                return (false, $0.attemptCount)
+            }
+            
+            $0.hasFinished = true
+            return (true, $0.attemptCount)
         }
 
         if shouldFire {

--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -26,11 +26,24 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
     private let payloadTypes: String?
     private let retryCount: Int
     private let exponentialBackoffBehavior: EmbraceUpload.ExponentialBackoff
-    private var attemptCount: Int
     private let logger: InternalLogger?
     private let completion: EmbraceUploadOperationCompletion?
 
-    private var task: URLSessionDataTask?
+    /// Mutable state guarded by `state`. `hasFinished` guarantees completion
+    /// and `finish()` fire exactly once.
+    private struct State {
+        var attemptCount: Int
+        var task: URLSessionDataTask?
+        var hasFinished: Bool
+
+        init(attemptCount: Int) {
+            self.attemptCount = attemptCount
+            self.task = nil
+            self.hasFinished = false
+        }
+    }
+
+    private let state: EmbraceMutex<State>
 
     init(
         urlSession: URLSession,
@@ -55,18 +68,29 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         self.payloadTypes = payloadTypes
         self.retryCount = retryCount
         self.exponentialBackoffBehavior = exponentialBackoffBehavior
-        self.attemptCount = attemptCount
+        self.state = EmbraceMutex(State(attemptCount: attemptCount))
         self.logger = logger
         self.completion = completion
     }
 
     override func cancel() {
         super.cancel()
-        task?.cancel()
-        task = nil
 
-        completion?(.cancelled, attemptCount)
-        finish()
+        let (taskToCancel, attemptCount, shouldFire) = state.withLock { s -> (URLSessionDataTask?, Int, Bool) in
+            guard !s.hasFinished else {
+                return (nil, s.attemptCount, false)
+            }
+            let taskToCancel = s.task
+            s.task = nil
+            s.hasFinished = true
+            return (taskToCancel, s.attemptCount, true)
+        }
+
+        taskToCancel?.cancel()
+        if shouldFire {
+            completion?(.cancelled, attemptCount)
+            finish()
+        }
     }
 
     override func execute() {
@@ -81,16 +105,15 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
     }
 
     private func sendRequest(_ r: URLRequest, retryCount: Int) {
-        var request = r
+        // Build next attempt outside lock, then commit attempt + task atomically.
+        let nextAttemptCount: Int? = state.withLock {
+            $0.hasFinished ? nil : $0.attemptCount + 1
+        }
+        guard let nextAttemptCount else { return }
 
-        // increment attempt count
-        attemptCount += 1
+        let request = updateRequest(r, attemptCount: nextAttemptCount)
 
-        // update request's attempt count header
-        request = updateRequest(request, attemptCount: attemptCount)
-
-        // Use completion handler directly on all platforms
-        task = urlSession.dataTask(
+        let newTask = urlSession.dataTask(
             with: request,
             completionHandler: { [weak self] data, response, error in
                 self?.handleTaskCompletion(
@@ -102,7 +125,19 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
                 )
             })
 
-        task?.resume()
+        // If operation finished meanwhile, cancel the new task immediately.
+        let started = state.withLock { s -> Bool in
+            guard !s.hasFinished else { return false }
+            s.attemptCount = nextAttemptCount
+            s.task = newTask
+            return true
+        }
+
+        if started {
+            newTask.resume()
+        } else {
+            newTask.cancel()
+        }
     }
 
     private func handleTaskCompletion(
@@ -112,17 +147,15 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
         request: URLRequest,
         retryCount: Int
     ) {
-        // If the operation was cancelled, cancel() already fired the completion and called finish().
-        // Just return to avoid double-completion and double-finish.
-        guard !isCancelled else {
-            return
-        }
+        // Fast path: operation already completed or cancelled.
+        if state.withLock({ $0.hasFinished }) { return }
 
         // Check retry budget: -1 = unlimited, 0 = none, >0 = that many remaining
         let hasRetryBudget = (retryCount != 0)
         if hasRetryBudget && shouldRetry(basedOn: response, error: error) {
+            let attemptCountForDelay = state.withLock { $0.attemptCount }
             let delay = exponentialBackoffBehavior.calculateDelay(
-                forRetryNumber: attemptCount,
+                forRetryNumber: attemptCountForDelay,
                 appending: TimeInterval(getSuggestedDelay(fromResponse: response))
             )
 
@@ -136,21 +169,26 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
             return
         }
 
-        // No retries left or non-retriable — determine result
+        let result: EmbraceUploadOperationResult
         if let response = response as? HTTPURLResponse {
             logger?.debug(
                 "Upload operation complete. Status: \(response.statusCode) URL: \(String(describing: response.url))"
             )
-            if response.statusCode >= 200 && response.statusCode < 300 {
-                completion?(.success, attemptCount)
-            } else {
-                completion?(.failure, attemptCount)
-            }
+            result = (response.statusCode >= 200 && response.statusCode < 300) ? .success : .failure
         } else {
-            completion?(.failure, attemptCount)
+            result = .failure
         }
 
-        finish()
+        let (shouldFire, attemptCount) = state.withLock { s -> (Bool, Int) in
+            guard !s.hasFinished else { return (false, s.attemptCount) }
+            s.hasFinished = true
+            return (true, s.attemptCount)
+        }
+
+        if shouldFire {
+            completion?(result, attemptCount)
+            finish()
+        }
     }
 
     private func shouldRetry(

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
@@ -25,6 +25,9 @@ class EmbraceUploadOperationTests: XCTestCase {
     var queue: DispatchQueue!
 
     override func setUpWithError() throws {
+        // EmbraceHTTPMock state is process-wide; reset between methods.
+        EmbraceHTTPMock.clearRequests()
+
         let urlSessionconfig = URLSessionConfiguration.ephemeral
         urlSessionconfig.httpMaximumConnectionsPerHost = .max
         urlSessionconfig.protocolClasses = [EmbraceHTTPMock.self]

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
@@ -226,6 +226,40 @@ class EmbraceUploadOperationTests: XCTestCase {
         wait(for: [expectation], timeout: .defaultTimeout)
     }
 
+    // Regression: cancel after success must not trigger completion twice.
+    func test_completionFiresExactlyOnceWhenCancelledAfterSuccess() throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on WatchOS")
+        EmbraceHTTPMock.mock(url: TestConstants.url)
+
+        let completionFired = XCTestExpectation(description: "completion fires once")
+
+        let operation = EmbraceUploadOperation(
+            urlSession: urlSession,
+            queue: queue,
+            metadataOptions: testMetadataOptions,
+            endpoint: TestConstants.url,
+            identifier: "id",
+            data: Data(),
+            retryCount: 0,
+            exponentialBackoffBehavior: .init(),
+            attemptCount: 0
+        ) { result, _ in
+            XCTAssertEqual(result, .success)
+            completionFired.fulfill()
+        }
+
+        operation.start()
+        wait(for: [completionFired], timeout: .defaultTimeout)
+
+        // Cancelling after completion must not re-fire completion.
+        operation.cancel()
+
+        // Give any erroneous async re-fire a chance to land before the test ends.
+        let noSecondFire = XCTestExpectation(description: "no second completion")
+        noSecondFire.isInverted = true
+        wait(for: [noSecondFire], timeout: 0.1)
+    }
+
     func test_onExecuting_whenReceivingNonRetryableError_shouldntRetry() throws {
         try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on WatchOS")
 

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
@@ -52,6 +52,12 @@ private func makeModule(
 
 class EmbraceUploadOrderedDeliveryTests: XCTestCase {
 
+    override func setUp() {
+        super.setUp()
+        // EmbraceHTTPMock state is process-wide; reset between methods.
+        EmbraceHTTPMock.clearRequests()
+    }
+
     // MARK: - 1. Ordering guarantee
 
     func test_spansAreUploadedInInsertionOrder() throws {

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadTests.swift
@@ -20,6 +20,9 @@ class EmbraceUploadTests: XCTestCase {
     var module: EmbraceUpload!
 
     override func setUpWithError() throws {
+        // EmbraceHTTPMock state is process-wide; reset between methods.
+        EmbraceHTTPMock.clearRequests()
+
         let urlSessionconfig = URLSessionConfiguration.ephemeral
         urlSessionconfig.httpMaximumConnectionsPerHost = .max
         urlSessionconfig.protocolClasses = [EmbraceHTTPMock.self]


### PR DESCRIPTION
`EmbraceUploadOperation.task` (`URLSessionDataTask?`) was written from a GCD worker thread inside `sendRequest(_:retryCount:)` and read from the main thread inside `cancel()` with no synchronization. The class is `@unchecked Sendable`, so the compiler didn't catch it. PR #562 added `test_cancelKeepsRecordInCache` which made this failure observable. TSan reports `Crash: xctest at EmbraceUploadOperation.task.getter`and on a simulator without TSan, the race deadlocks.

This PR adds a `State` struct guarded by `EmbraceMutex<State>` that bundles `attemptCount`, `task`, and a new `hasFinished` one-shot gate. 

Two correctness properties land together:

- **Race-free reads/writes** of `task` and `attemptCount` across `cancel()` (main) and `sendRequest()` (worker).
- **Exactly-once completion**: whichever of `cancel()` or `handleTaskCompletion` flips `hasFinished` inside the lock fires `completion` + `finish()`; the other returns. Replaces the racy `guard !isCancelled` check at the top of `handleTaskCompletion`.

`sendRequest` uses a tentative-then-commit pattern: the post-increment `attemptCount` is computed inside one lock acquisition, the `URLSessionDataTask` is built outside the lock (so we don't hold the mutex across `URLSession.dataTask(...)`), then committed under a second acquisition. If `cancel()` flips `hasFinished` between the two, the just-built task is `cancel()`-ed without `resume()` (avoiding a leaked network call) and the function returns.

Lock discipline: foreign code (`URLSessionDataTask.cancel()`, `completion`, `finish()`) is never invoked from inside `state.withLock` — the underlying `EmbraceMutex` is non-recursive.

### How to repro the issue

Run the existing single test under TSan with hang detection. This must be run on the branch for #630 or on `main` after #630 has been merged  :

```sh
xcodebuild test -workspace .swiftpm/xcode/package.xcworkspace -scheme EmbraceIO-Package \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -enableThreadSanitizer YES -test-iterations 50 \
  -test-timeouts-enabled YES -default-test-execution-time-allowance 60 \
  -only-testing:EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests/test_cancelKeepsRecordInCache
```

Iteration 1 hangs past the 60s allowance → `TEST FAILED`. On this branch, the same test completes in ~0.028s per iteration; 50 iterations clean.

### Stacking

Stacked on  PR #630 which adds `EmbraceHTTPMock.clearRequests()` to the three upload-tests classes so
`-test-iterations` runs no longer accumulate static-dict state. Without it, the new `test_completionFiresExactlyOnceWhenCancelledAfterSuccess` and `test_genericRequestHeaders` collide in the full suite. Merge the mock-fix PR first.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
