### PR TITLE
[EMBR-12368] Fix: Tests: Platform-aware verifyCreated to silence watchOS flake

### DIFF
--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLAndCompletionSwizzlerTests.swift
@@ -128,8 +128,7 @@ extension DataTaskWithURLAndCompletionSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, dataTask)
+        handler.verifyCreated(dataTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestAndCompletionSwizzlerTests.swift
@@ -127,8 +127,7 @@ extension DataTaskWithURLRequestAndCompletionSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, dataTask)
+        handler.verifyCreated(dataTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLRequestSwizzlerTests.swift
@@ -67,8 +67,7 @@ extension DataTaskWithURLRequestSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, dataTask)
+        handler.verifyCreated(dataTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DataTaskWithURLSwizzlerTests.swift
@@ -61,8 +61,7 @@ extension DataTaskWithURLSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, dataTask)
+        handler.verifyCreated(dataTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestSwizzlerTests.swift
@@ -68,8 +68,7 @@ extension DownloadTaskWithURLRequestSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, downloadTask)
+        handler.verifyCreated(downloadTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestWithCompletionSwizzler.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/DownloadTaskWithURLRequestWithCompletionSwizzler.swift
@@ -131,8 +131,7 @@ extension DownloadTaskWithURLWithCompletionSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, downloadTask)
+        handler.verifyCreated(downloadTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataAndCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataAndCompletionSwizzlerTests.swift
@@ -130,8 +130,7 @@ extension UploadTaskWithRequestFromDataAndCompletionSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, uploadTask)
+        handler.verifyCreated(uploadTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromDataSwizzlerTests.swift
@@ -84,8 +84,7 @@ extension UploadTaskWithRequestFromDataSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, uploadTask)
+        handler.verifyCreated(uploadTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileSwizzlerTests.swift
@@ -85,8 +85,7 @@ extension UploadTaskWithRequestFromFileSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, uploadTask)
+        handler.verifyCreated(uploadTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileWithCompletionSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithRequestFromFileWithCompletionSwizzlerTests.swift
@@ -135,8 +135,7 @@ extension UploadTaskWithRequestFromFileWithCompletionSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, uploadTask)
+        handler.verifyCreated(uploadTask)
     }
 
     fileprivate func thenHandlerShouldHaveInvokedFinishTask() {

--- a/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithStreamedRequestSwizzlerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/UploadTaskWithStreamedRequestSwizzlerTests.swift
@@ -82,8 +82,7 @@ extension UploadTaskWithStreamedRequestSwizzlerTests {
     }
 
     fileprivate func thenHandlerShouldHaveInvokedCreateWithTask() {
-        XCTAssertTrue(handler.didInvokeCreate)
-        XCTAssertEqual(handler.createReceivedTask, uploadTask)
+        handler.verifyCreated(uploadTask)
     }
 
     fileprivate func thenHandlerShouldntHaveInvokedCreate() {

--- a/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockURLSessionTaskHandler.swift
+++ b/Tests/EmbraceCoreTests/TestSupport/TestDoubles/MockURLSessionTaskHandler.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import XCTest
 
 @testable import EmbraceCommonInternal
 @testable import EmbraceCore
@@ -48,12 +49,54 @@ class MockURLSessionTaskHandler: NSObject, URLSessionTaskHandler {
         return _createReceivedTask
     }
 
+    /// All tasks passed to `create(task:)`, in invocation order. Used by
+    /// `verifyCreated(_:)` to handle watchOS's CFNetwork URLProtocol behavior — see
+    /// the doc comment there.
+    private var _createInvocations: [URLSessionTask] = []
+    var createInvocations: [URLSessionTask] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _createInvocations
+    }
+
     func create(task: URLSessionTask) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         _didInvokeCreate = true
         _createReceivedTask = task
+        _createInvocations.append(task)
         return shouldHandleTasks
+    }
+
+    /// Asserts the handler saw `task` from a `create(task:)` call.
+    ///
+    /// iOS/tvOS/macOS: `create(task:)` was called exactly once with `task`.
+    /// watchOS: `task` appears anywhere in `createInvocations`. CFNetwork's
+    /// URLProtocol driver spawns an internal `URLSessionDataTask` on a background
+    /// queue when a `URLProtocol` is registered; it hits the swizzled IMP and
+    /// produces spurious `create(task:)` calls the test never requested. A queued
+    /// `.resume()` from a prior test can also leak across methods. Strict
+    /// checking is unsalvageable without dropping URLProtocol-based mocking.
+    func verifyCreated(_ task: URLSessionTask, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(didInvokeCreate, "create(task:) was never called", file: file, line: line)
+        #if os(watchOS)
+            XCTAssertTrue(
+                createInvocations.contains(task),
+                "createInvocations \(createInvocations) does not contain expected \(task)",
+                file: file,
+                line: line
+            )
+        #else
+            XCTAssertEqual(createReceivedTask, task, file: file, line: line)
+            XCTAssertEqual(
+                createInvocations.count,
+                1,
+                "expected exactly one create invocation on non-watchOS, got \(createInvocations.count): "
+                    + "\(createInvocations)",
+                file: file,
+                line: line
+            )
+        #endif
     }
 
     private var _didInvokeFinishWithData = false


### PR DESCRIPTION
## Summary

Fixes a watchOS-only flake in `DataTask*SwizzlerTests` (and the URLRequest/Download/Upload siblings) without weakening assertions on platforms unaffected by the issue.

## Root cause

When a `URLProtocol` is registered (as `URLTestProxy` is in `ProxiedURLSessionProvider`), CFNetwork's URLProtocol driver spawns an internal `URLSessionDataTask` on a background queue that hits the same class-level swizzled IMP, triggering `handler.create(task:)` for a task the test never requested. The dispatch is fast enough on watchOS to land within the test window; it can also leak across methods if the prior `.resume()` is still queued when the next test re-installs the swizzler. iOS/tvOS/macOS don't take this path.

The behavior was confirmed to only happen on watchOS by  inserting `Thread.sleep` after `.resume()` in tests. Passes with ≤5 s sleep on iOS, ≤1 s on tvOS/macOS, flips to 100% failure at 1 ms on watchOS

## Production impact

Likely none --  we don't register a URLProtocol in production; the proxy-connection path never fires outside the test harness.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
