### PR TITLE
[EMBR-12371] Fix: Don't check for empty queue in test

### DIFF
--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
@@ -368,7 +368,6 @@ class EmbraceUploadOrderedDeliveryTests: XCTestCase {
 
         // Cancel all operations while they're still retrying
         module.spansQueue.cancelAllOperations()
-        module.spansQueue.waitUntilAllOperationsAreFinished()
 
         // Allow handleOperationFinished to process on coordination queue
         module.queue.sync {}


### PR DESCRIPTION
## Summary

- We should not expect the queue to be empty in a test after we cancel a request since our behavior is to immediately re-enque the request

- ## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
