### PR TITLE
[EMBR-12377] Fix: Fix: Poll post-conditions in UnsentDataHandler tests instead of using fixed sleeps to fix flaky tests

### DIFF
--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -92,7 +92,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(storage: storage, upload: upload, otel: otel, crashReporter: nil)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { upload.cache.fetchAllUploadData().isEmpty })
 
         // then a session request was sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
@@ -137,7 +137,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when failing to send unsent sessions
         await UnsentDataHandler.sendUnsentData(storage: storage, upload: upload, otel: otel, crashReporter: nil)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { EmbraceHTTPMock.totalRequestCount() == 1 })
 
         // then a session request was attempted
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 1)
@@ -198,7 +198,7 @@ class UnsentDataHandlerTests: XCTestCase {
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(
             storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { upload.cache.fetchAllUploadData().isEmpty })
 
         // then a crash report was sent
         // then a session request was sent
@@ -273,7 +273,7 @@ class UnsentDataHandlerTests: XCTestCase {
             storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
 
         await fulfillment(of: [didSendCrashesExpectation], timeout: .defaultTimeout)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { EmbraceHTTPMock.totalRequestCount() == 2 })
 
         // then a crash report request was attempted
         // then a session request was attempted
@@ -342,7 +342,7 @@ class UnsentDataHandlerTests: XCTestCase {
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(
             storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { upload.cache.fetchAllUploadData().isEmpty })
 
         // then a crash report was sent
         // then a session request was sent
@@ -406,7 +406,7 @@ class UnsentDataHandlerTests: XCTestCase {
             upload: upload,
             otel: otel
         )
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { upload.cache.fetchAllUploadData().isEmpty })
 
         // then a crash log was sent
         XCTAssert(EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count > 0)
@@ -479,7 +479,12 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending unsent sessions
         await UnsentDataHandler.sendUnsentData(storage: storage, upload: upload, otel: otel)
-        wait(delay: .shortTimeout)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: {
+                let spans: [SpanRecord] = storage.fetchAll()
+                return spans.count == 1 && spans[0].endTime != nil
+            })
 
         // then the old closed span was removed
         // and the open span was closed
@@ -565,7 +570,13 @@ class UnsentDataHandlerTests: XCTestCase {
             otel: otel,
             currentSessionId: TestConstants.sessionId
         )
-        wait(delay: .shortTimeout)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: {
+                let records: [MetadataRecord] = storage.fetchAll()
+                return !records.contains(where: { $0.key == "differentSessionId" })
+                    && !records.contains(where: { $0.key == "differentProcessId" })
+            })
 
         // then all metadata is cleaned up
         let records: [MetadataRecord] = storage.fetchAll()
@@ -611,7 +622,13 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when uploading the session
         await UnsentDataHandler.sendSession(session, storage: storage, upload: upload)
-        wait(delay: .shortTimeout)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: {
+                let spans: [SpanRecord] = storage.fetchAll()
+                let sessions: [SessionRecord] = storage.fetchAll()
+                return spans.isEmpty && sessions.isEmpty
+            })
 
         // then the old closed span was removed
         // and the session was removed
@@ -667,7 +684,12 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when uploading the session
         await UnsentDataHandler.sendSession(session, storage: storage, upload: upload)
-        wait(delay: .shortTimeout)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: {
+                let records: [MetadataRecord] = storage.fetchAll()
+                return !records.contains(where: { $0.key == "differentProcessId" })
+            })
 
         // then metadata is correctly cleaned up
         let records: [MetadataRecord] = storage.fetchAll()
@@ -711,7 +733,7 @@ class UnsentDataHandlerTests: XCTestCase {
         // when sending unsent data
         await UnsentDataHandler.sendUnsentData(
             storage: storage, upload: upload, otel: otel, logController: logController)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count == 1 })
 
         // then no sessions were sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testSpansUrl()).count, 0)
@@ -734,7 +756,7 @@ class UnsentDataHandlerTests: XCTestCase {
 
         // when sending critical logs
         await UnsentDataHandler.sendCriticalLogs(fileUrl: criticalLogsFilePath, upload: upload)
-        wait(delay: .shortTimeout)
+        wait(timeout: .longTimeout, interval: .shortInterval, until: { EmbraceHTTPMock.requestsForUrl(self.testLogsUrl()).count == 1 })
 
         // then a log is sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 1)
@@ -749,8 +771,10 @@ class UnsentDataHandlerTests: XCTestCase {
             options: uploadOptions, logger: logger, queue: queue)
 
         // when sending critical logs without a file present
+        // sendCriticalLogs is synchronous when fileUrl has no contents — no upload is
+        // ever enqueued, the closure-completion fires inline, and the continuation
+        // resumes. No async work to wait for after the await returns.
         await UnsentDataHandler.sendCriticalLogs(fileUrl: criticalLogsFilePath, upload: upload)
-        wait(delay: .shortTimeout)
 
         // then no log is sent
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)
@@ -775,7 +799,11 @@ class UnsentDataHandlerTests: XCTestCase {
             pendingFileUrl: pendingLogsFilePath,
             upload: upload
         )
-        wait(delay: .shortTimeout)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: {
+                !FileManager.default.fileExists(atPath: pendingLogsFilePath.path)
+            })
 
         // then nothing is uploaded and the orphan is gone
         XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(testLogsUrl()).count, 0)

--- a/Tests/TestSupport/TimeInterval+Test.swift
+++ b/Tests/TestSupport/TimeInterval+Test.swift
@@ -24,4 +24,11 @@ extension TimeInterval {
     public static var veryLongTimeout: TimeInterval {
         return 7
     }
+
+    /// Polling cadence for `wait(timeout:interval:until:)`. 10 ms is tight enough
+    /// that the dominant cost in poll-based waits is the work itself, not the
+    /// interval — much smaller and we just burn CPU on no-op checks.
+    public static var shortInterval: TimeInterval {
+        return 0.01
+    }
 }


### PR DESCRIPTION
## Summary

- `UnsentDataHandlerTests` slept a fixed 0.5 s after each async send call before asserting on HTTP mock state or storage. 
- CI would fail intermittently because this duration was not sufficient in all cases
- Replaced 13 fixed sleeps with `wait(until: { … })` polling pattern to fix flakiness

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
