### PR TITLE
fix: Remove proxy only URLSessionDelegate proxy methods

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -14,8 +14,6 @@
 #define DID_BECOME_INVALID_WITH_ERROR @selector(URLSession:didBecomeInvalidWithError:)
 #define DID_RECEIVE_RESPONSE @selector(URLSession:dataTask:didReceiveResponse:completionHandler:)
 #define WILL_PERFORM_REDIRECTION @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)
-#define DID_RECEIVE_CHALLENGE @selector(URLSession:didReceiveChallenge:completionHandler:)
-#define DID_RECEIVE_TASK_CHALLENGE @selector(URLSession:task:didReceiveChallenge:completionHandler:)
 
 @interface EMBURLSessionLegacyDelegateProxy ()
 
@@ -36,8 +34,7 @@
 {
     if (sel_isEqual(aSelector, DID_FINISH_COLLECTING_METRICS) || sel_isEqual(aSelector, DID_RECEIVE_DATA_SELECTOR) ||
         sel_isEqual(aSelector, DID_FINISH_DOWNLOADING) || sel_isEqual(aSelector, DID_COMPLETE_WITH_ERROR) ||
-        sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION) ||
-        sel_isEqual(aSelector, DID_RECEIVE_CHALLENGE) || sel_isEqual(aSelector, DID_RECEIVE_TASK_CHALLENGE)) {
+        sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION)) {
         return YES;
     }
     return [self.originalDelegate respondsToSelector:aSelector];
@@ -108,36 +105,6 @@
 
     self.originalDelegate = nil;
     self.handler = nil;
-}
-
-- (void)URLSession:(NSURLSession *)session
-    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionDelegate>)delegate URLSession:session
-                                   didReceiveChallenge:challenge
-                                    completionHandler:completionHandler];
-    } else {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-    }
-}
-
-- (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                                      didReceiveChallenge:challenge
-                                       completionHandler:completionHandler];
-    } else {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-    }
 }
 
 #pragma mark - NSURLSessionTaskDelegate Methods

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -50,12 +50,7 @@
     if (sel == @selector(URLSession:task:didCompleteWithError:) ||
         sel == @selector(URLSession:task:didFinishCollectingMetrics:) ||
         sel == @selector(URLSession:dataTask:didReceiveData:) ||
-        sel == @selector(URLSession:didBecomeInvalidWithError:) ||
-        sel == @selector(URLSession:didReceiveChallenge:completionHandler:) ||
-        sel == @selector(URLSession:task:didReceiveChallenge:completionHandler:) ||
-        sel == @selector(URLSession:dataTask:didReceiveResponse:completionHandler:) ||
-        sel == @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:) ||
-        sel == @selector(URLSession:downloadTask:didFinishDownloadingToURL:)) {
+        sel == @selector(URLSession:didBecomeInvalidWithError:)) {
 
         return nil;
     }
@@ -96,36 +91,6 @@
     self.handler = nil;
 }
 
-- (void)URLSession:(NSURLSession *)session
-    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionDelegate>)delegate URLSession:session
-                                   didReceiveChallenge:challenge
-                                    completionHandler:completionHandler];
-    } else {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-    }
-}
-
-- (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                                      didReceiveChallenge:challenge
-                                       completionHandler:completionHandler];
-    } else {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-    }
-}
-
 #pragma mark - NSURLSessionTaskDelegate
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
@@ -154,26 +119,6 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
 }
 
-#pragma mark - NSURLSessionTaskDelegate (redirection)
-
-- (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-willPerformHTTPRedirection:(NSHTTPURLResponse *)response
-        newRequest:(NSURLRequest *)request
- completionHandler:(void (^)(NSURLRequest *))completionHandler
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                               willPerformHTTPRedirection:response
-                                               newRequest:request
-                                        completionHandler:completionHandler];
-    } else {
-        completionHandler(request);  // follow the redirect — URLSession's built-in default
-    }
-}
-
 #pragma mark - NSURLSessionDataDelegate
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
@@ -182,36 +127,6 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 
     if ([self.originalDelegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionDataDelegate>)self.originalDelegate URLSession:session dataTask:dataTask didReceiveData:data];
-    }
-}
-
-- (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didReceiveResponse:(NSURLResponse *)response
- completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionDataDelegate>)delegate URLSession:session
-                                                 dataTask:dataTask
-                                       didReceiveResponse:response
-                                        completionHandler:completionHandler];
-    } else {
-        completionHandler(NSURLSessionResponseAllow);
-    }
-}
-
-#pragma mark - NSURLSessionDownloadDelegate
-
-- (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-didFinishDownloadingToURL:(NSURL *)location
-{
-    id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
-        [(id<NSURLSessionDownloadDelegate>)delegate URLSession:session
-                                                 downloadTask:downloadTask
-                                    didFinishDownloadingToURL:location];
     }
 }
 


### PR DESCRIPTION
## Description. 

https://github.com/embrace-io/embrace-apple-sdk/pull/567/changes introduced changes that were targeted to fix the crash of intercepting URLSessionDelegate methods. While the fix from `nonatomic` to `atomic` property of `originalDelegate` seems valid, adding extra proxies methods introduce a regression into our app.
The regression is connected with intercepting `didReceiveChallenge` methods, that for some reason sometimes are not proxied into the consumer delegate but into initially injected `EmbraceDummyURLSessionDelegate`.
Due that some endpoints SSL pinning challenges are not passed into correct consumer delegate and that results with failing those.

This MR is just removing those methods as my understanding is those are kind of redundant, because if those methods are not implemented in the New/Legacy `EMBURLSessionNewDelegateProxy` those will be passed to the originalDelegate either by: 
```
- (BOOL)respondsToSelector:(SEL)sel
{
    // If we implement it directly (instance methods below), advertise YES.
    if ([super respondsToSelector:sel]) {
        return YES;
    }
    // Otherwise mirror the original delegate’s capabilities.
    return [self.originalDelegate respondsToSelector:sel];
}
```
or

```
- (id)forwardingTargetForSelector:(SEL)sel
{
    // We can't call `-respondsToSelector:` from here.
    if (sel == @selector(URLSession:task:didCompleteWithError:) ||
        sel == @selector(URLSession:task:didFinishCollectingMetrics:) ||
        sel == @selector(URLSession:dataTask:didReceiveData:) ||
        sel == @selector(URLSession:didBecomeInvalidWithError:)) {

        return nil;
    }

    id forwardingTarget = nil;

    forwardingTarget = [super forwardingTargetForSelector:sel];
    if (forwardingTarget) {
        return forwardingTarget == self ? nil : forwardingTarget;
    }

    // is the original doing any forwarding?
    forwardingTarget = [self.originalDelegate forwardingTargetForSelector:sel];
    if (forwardingTarget) {
        return forwardingTarget;
    }

    if ([self.originalDelegate respondsToSelector:sel]) {
        return self.originalDelegate;
    }

    return nil;
}
```

Adding a screenshot showing that somehow the selector of `didReceiveChallange` was attempted to be passed to 
`EmbraceDummyURLSessionDelegate `

<img width="2029" height="978" alt="Screenshot 2026-06-10 at 09 20 00" src="https://github.com/user-attachments/assets/4a8a6978-0fb3-4050-b74d-8dede3aab765" />


## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage 
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
