### PR TITLE
[EMBR-12649] Fix: session delegate swizzles: replace _cmd with @selector()

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -56,7 +56,6 @@
         sel == @selector(URLSession:dataTask:didReceiveResponse:completionHandler:) ||
         sel == @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:) ||
         sel == @selector(URLSession:downloadTask:didFinishDownloadingToURL:)) {
-
         return nil;
     }
 
@@ -89,7 +88,7 @@
 
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error
 {
-    if ([self.originalDelegate respondsToSelector:_cmd]) {
+    if ([self.originalDelegate respondsToSelector:@selector(URLSession:didBecomeInvalidWithError:)]) {
         [(id<NSURLSessionDelegate>)self.originalDelegate URLSession:session didBecomeInvalidWithError:error];
     }
     self.originalDelegate = nil;
@@ -98,29 +97,29 @@
 
 - (void)URLSession:(NSURLSession *)session
     didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
     id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
+    if (delegate && [delegate respondsToSelector:@selector(URLSession:didReceiveChallenge:completionHandler:)]) {
         [(id<NSURLSessionDelegate>)delegate URLSession:session
                                    didReceiveChallenge:challenge
-                                    completionHandler:completionHandler];
+                                     completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+                   task:(NSURLSessionTask *)task
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
     id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
+    if (delegate && [delegate respondsToSelector:@selector(URLSession:task:didReceiveChallenge:completionHandler:)]) {
         [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                                      didReceiveChallenge:challenge
-                                       completionHandler:completionHandler];
+                                                      task:task
+                                       didReceiveChallenge:challenge
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
@@ -132,7 +131,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 {
     [self.handler finishWithTask:task data:nil error:error];
 
-    if ([self.originalDelegate respondsToSelector:_cmd]) {
+    if ([self.originalDelegate respondsToSelector:@selector(URLSession:task:didCompleteWithError:)]) {
         [(id<NSURLSessionTaskDelegate>)self.originalDelegate URLSession:session task:task didCompleteWithError:error];
     }
 }
@@ -147,7 +146,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
     [self.handler finishWithTask:task bodySize:totalBytes error:nil];
 
-    if ([self.originalDelegate respondsToSelector:_cmd]) {
+    if ([self.originalDelegate respondsToSelector:@selector(URLSession:task:didFinishCollectingMetrics:)]) {
         [(id<NSURLSessionTaskDelegate>)self.originalDelegate URLSession:session
                                                                    task:task
                                              didFinishCollectingMetrics:metrics];
@@ -157,18 +156,19 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 #pragma mark - NSURLSessionTaskDelegate (redirection)
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-willPerformHTTPRedirection:(NSHTTPURLResponse *)response
-        newRequest:(NSURLRequest *)request
- completionHandler:(void (^)(NSURLRequest *))completionHandler
+                          task:(NSURLSessionTask *)task
+    willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+                    newRequest:(NSURLRequest *)request
+             completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
     id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
+    if (delegate && [delegate respondsToSelector:@selector
+                              (URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:)]) {
         [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                               willPerformHTTPRedirection:response
-                                               newRequest:request
-                                        completionHandler:completionHandler];
+                                                      task:task
+                                willPerformHTTPRedirection:response
+                                                newRequest:request
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(request);  // follow the redirect — URLSession's built-in default
     }
@@ -180,22 +180,23 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 {
     [self.handler addData:data dataTask:dataTask];
 
-    if ([self.originalDelegate respondsToSelector:_cmd]) {
+    if ([self.originalDelegate respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)]) {
         [(id<NSURLSessionDataDelegate>)self.originalDelegate URLSession:session dataTask:dataTask didReceiveData:data];
     }
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didReceiveResponse:(NSURLResponse *)response
- completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+              dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
 {
     id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
+    if (delegate && [delegate respondsToSelector:@selector(URLSession:
+                                                             dataTask:didReceiveResponse:completionHandler:)]) {
         [(id<NSURLSessionDataDelegate>)delegate URLSession:session
-                                                 dataTask:dataTask
-                                       didReceiveResponse:response
-                                        completionHandler:completionHandler];
+                                                  dataTask:dataTask
+                                        didReceiveResponse:response
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionResponseAllow);
     }
@@ -204,14 +205,14 @@ didReceiveResponse:(NSURLResponse *)response
 #pragma mark - NSURLSessionDownloadDelegate
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-didFinishDownloadingToURL:(NSURL *)location
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+    didFinishDownloadingToURL:(NSURL *)location
 {
     id delegate = self.originalDelegate;
-    if (delegate && [delegate respondsToSelector:_cmd]) {
+    if (delegate && [delegate respondsToSelector:@selector(URLSession:downloadTask:didFinishDownloadingToURL:)]) {
         [(id<NSURLSessionDownloadDelegate>)delegate URLSession:session
-                                                 downloadTask:downloadTask
-                                    didFinishDownloadingToURL:location];
+                                                  downloadTask:downloadTask
+                                     didFinishDownloadingToURL:location];
     }
 }
 

--- a/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxySwizzleResistanceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxySwizzleResistanceTests.swift
@@ -9,8 +9,6 @@ import XCTest
 @testable import EmbraceCore
 @testable import EmbraceObjCUtilsInternal
 
-// Regression tests for EMBR-12649.
-//
 // 3rd party debugging tools rename Embrace's original IMP to a prefixed selector, e.g.
 // `_sdk_swizzle_XXX_URLSession:dataTask:didReceiveData:`. When the runtime dispatches to
 // that renamed IMP, `_cmd` equals the prefix — not the canonical protocol selector — so

--- a/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxySwizzleResistanceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxySwizzleResistanceTests.swift
@@ -1,0 +1,144 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import ObjectiveC.runtime
+import XCTest
+
+@testable import EmbraceCore
+@testable import EmbraceObjCUtilsInternal
+
+// Regression tests for EMBR-12649.
+//
+// 3rd party debugging tools rename Embrace's original IMP to a prefixed selector, e.g.
+// `_sdk_swizzle_XXX_URLSession:dataTask:didReceiveData:`. When the runtime dispatches to
+// that renamed IMP, `_cmd` equals the prefix — not the canonical protocol selector — so
+// any `respondsToSelector:_cmd` check against the host delegate returns NO, silently
+// dropping the callback.
+//
+// Each test reproduces this exact dispatch-time state by extracting the proxy's IMP and
+// calling it directly under a fake selector, then asserting the original delegate was
+// still reached.
+class URLSessionDelegateProxySwizzleResistanceTests: XCTestCase {
+
+    private var originalDelegate: FullyImplementedURLSessionDelegate!
+    private var handler: MockURLSessionTaskHandler!
+    private var proxy: EMBURLSessionDelegateProxy!
+    private var proxyClass: AnyClass!
+
+    // A selector that no real delegate ever implements, standing in for the 3rd party generated prefix.
+    private let swizzledCmd = NSSelectorFromString("_testSwizzle_fakeSelector")
+
+    override func setUp() {
+        super.setUp()
+        handler = .init()
+        originalDelegate = .init()
+        proxy = EmbraceMakeURLSessionDelegateProxy(originalDelegate, handler)
+        proxyClass = object_getClass(proxy)
+    }
+
+    // MARK: - NSURLSessionDelegate
+
+    func test_didBecomeInvalidWithError_forwardsUnderSwizzledSelector() {
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, NSError?) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:didBecomeInvalidWithError:"))
+        fn(proxy, swizzledCmd, URLSession.shared, nil)
+        XCTAssertTrue(originalDelegate.didCallDidBecomeInvalidWithError)
+    }
+
+    func test_didReceiveChallenge_sessionLevel_forwardsUnderSwizzledSelector() {
+        typealias Handler = @convention(block) (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLAuthenticationChallenge, Handler) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:didReceiveChallenge:completionHandler:"))
+        fn(proxy, swizzledCmd, URLSession.shared, URLAuthenticationChallenge()) { _, _ in }
+        XCTAssertTrue(originalDelegate.didCallDidReceiveChallenge)
+    }
+
+    func test_didReceiveChallenge_taskLevel_forwardsUnderSwizzledSelector() {
+        typealias Handler = @convention(block) (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionTask, URLAuthenticationChallenge, Handler) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aTask(), URLAuthenticationChallenge()) { _, _ in }
+        XCTAssertTrue(originalDelegate.didCallTaskWithReceivedAuthenticationChallenge)
+    }
+
+    // MARK: - NSURLSessionTaskDelegate
+
+    func test_didCompleteWithError_forwardsUnderSwizzledSelector() {
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionTask, NSError?) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:task:didCompleteWithError:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aTask(), nil)
+        XCTAssertTrue(originalDelegate.didCallDidCompleteWithError)
+    }
+
+    func test_didFinishCollectingMetrics_forwardsUnderSwizzledSelector() {
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionTask, URLSessionTaskMetrics) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:task:didFinishCollectingMetrics:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aTask(), makeMetrics())
+        XCTAssertTrue(originalDelegate.didCallDidFinishCollecting)
+    }
+
+    func test_willPerformHTTPRedirection_forwardsUnderSwizzledSelector() {
+        typealias Handler = @convention(block) (URLRequest?) -> Void
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionTask, HTTPURLResponse, URLRequest, Handler) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aTask(), HTTPURLResponse(), URLRequest(url: URL(string: "https://embrace.io")!)) { _ in }
+        XCTAssertTrue(originalDelegate.didCallWillPerformHTTPRedirection)
+    }
+
+    // MARK: - NSURLSessionDataDelegate
+
+    func test_didReceiveData_forwardsUnderSwizzledSelector() {
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionDataTask, Data) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:dataTask:didReceiveData:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aTask(), Data())
+        XCTAssertTrue(originalDelegate.didCallDidReceiveData)
+    }
+
+    func test_didReceiveResponse_forwardsUnderSwizzledSelector() {
+        typealias Handler = @convention(block) (URLSession.ResponseDisposition) -> Void
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionDataTask, URLResponse, Handler) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:dataTask:didReceiveResponse:completionHandler:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aTask(), URLResponse()) { _ in }
+        XCTAssertTrue(originalDelegate.didCallDidReceiveResponseWithHandler)
+    }
+
+    // MARK: - NSURLSessionDownloadDelegate
+
+    func test_didFinishDownloadingToURL_forwardsUnderSwizzledSelector() {
+        typealias F = @convention(c) (AnyObject, Selector, URLSession, URLSessionDownloadTask, URL) -> Void
+        let fn: F = extractIMP(for: NSSelectorFromString("URLSession:downloadTask:didFinishDownloadingToURL:"))
+        fn(proxy, swizzledCmd, URLSession.shared, aDownloadTask(), URL(string: "https://embrace.io")!)
+        XCTAssertTrue(originalDelegate.didCallDidFinishDownloadingTo)
+    }
+}
+
+// MARK: - Private helpers
+
+extension URLSessionDelegateProxySwizzleResistanceTests {
+
+    // Extracts the IMP for `selector` from the proxy's runtime class and casts it to `T`.
+    // The caller then invokes it with `swizzledCmd` in place of the real `_cmd`, which is
+    // precisely what a 3rd party sdk method_exchangeImplementations produces at dispatch time.
+    fileprivate func extractIMP<T>(for selector: Selector, file: StaticString = #file, line: UInt = #line) -> T {
+        guard let method = class_getInstanceMethod(proxyClass, selector) else {
+            XCTFail("Method \(selector) not found on \(proxyClass!)", file: file, line: line)
+            fatalError()
+        }
+        return unsafeBitCast(method_getImplementation(method), to: T.self)
+    }
+
+    fileprivate func aTask() -> URLSessionDataTask {
+        URLSession.shared.dataTask(with: URLRequest(url: URL(string: "https://embrace.io")!))
+    }
+
+    fileprivate func aDownloadTask() -> URLSessionDownloadTask {
+        URLSession.shared.downloadTask(with: URLRequest(url: URL(string: "https://embrace.io")!))
+    }
+
+    fileprivate func makeMetrics() -> URLSessionTaskMetrics {
+        let klass: AnyClass = NSClassFromString("NSURLSessionTaskMetrics")!
+        return klass.alloc().perform(NSSelectorFromString("init")).takeUnretainedValue() as! URLSessionTaskMetrics
+    }
+}


### PR DESCRIPTION
- Replaces usages of `_cmd` with `@selector(...)` in EMBURLSessionNewDelegateProxy. When 3rd party tools swizzle the proxy class, our `IMP` runs under a renamed selector, causing `_cmd` to differ from the original protocol selector causing it to silently break. Using compile-time `@selector(...)` makes the check immune to swizzle-induced renaming, allowing these tools to function.

- Adds tests that reproduce the exact dispatch-time state a swizzler produces by calling the `IMP` directly under a fake `_cmd`.