### PR TITLE
[EMBR-12672] Fix: url challenge response logic for sessions without delegate

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -352,6 +352,7 @@ let package = Package(
         ),
         .target(
             name: "TestSupportObjc",
+            dependencies: ["EmbraceObjCUtilsInternal"],
             path: "Tests/TestSupport/Objc"
         )
     ]

--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -36,8 +36,7 @@
 {
     if (sel_isEqual(aSelector, DID_FINISH_COLLECTING_METRICS) || sel_isEqual(aSelector, DID_RECEIVE_DATA_SELECTOR) ||
         sel_isEqual(aSelector, DID_FINISH_DOWNLOADING) || sel_isEqual(aSelector, DID_COMPLETE_WITH_ERROR) ||
-        sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION) ||
-        sel_isEqual(aSelector, DID_RECEIVE_CHALLENGE) || sel_isEqual(aSelector, DID_RECEIVE_TASK_CHALLENGE)) {
+        sel_isEqual(aSelector, DID_BECOME_INVALID_WITH_ERROR) || sel_isEqual(aSelector, WILL_PERFORM_REDIRECTION)) {
         return YES;
     }
     return [self.originalDelegate respondsToSelector:aSelector];
@@ -112,29 +111,29 @@
 
 - (void)URLSession:(NSURLSession *)session
     didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionDelegate>)delegate URLSession:session
                                    didReceiveChallenge:challenge
-                                    completionHandler:completionHandler];
+                                     completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+                   task:(NSURLSessionTask *)task
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                                      didReceiveChallenge:challenge
-                                       completionHandler:completionHandler];
+                                                      task:task
+                                       didReceiveChallenge:challenge
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -36,7 +36,15 @@
 
 - (BOOL)respondsToSelector:(SEL)sel
 {
-    // If we implement it directly (instance methods below), advertise YES.
+    // Challenge selectors: only advertise YES if the original delegate handles them.
+    // Unconditionally claiming YES changes the OS’s internal challenge handling path for
+    // sessions created without a delegate (where originalDelegate is EmbraceDummyURLSessionDelegate),
+    // which breaks tokenization and SSL-pinning SDKs that depend on the OS-native path.
+    if (sel == @selector(URLSession:didReceiveChallenge:completionHandler:) ||
+        sel == @selector(URLSession:task:didReceiveChallenge:completionHandler:)) {
+        return [self.originalDelegate respondsToSelector:sel];
+    }
+    // For all other directly-implemented methods, advertise YES unconditionally.
     if ([super respondsToSelector:sel]) {
         return YES;
     }
@@ -56,7 +64,6 @@
         sel == @selector(URLSession:dataTask:didReceiveResponse:completionHandler:) ||
         sel == @selector(URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:) ||
         sel == @selector(URLSession:downloadTask:didFinishDownloadingToURL:)) {
-
         return nil;
     }
 
@@ -98,29 +105,29 @@
 
 - (void)URLSession:(NSURLSession *)session
     didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
-     completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionDelegate>)delegate URLSession:session
                                    didReceiveChallenge:challenge
-                                    completionHandler:completionHandler];
+                                     completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
 }
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
- completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
+                   task:(NSURLSessionTask *)task
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                                      didReceiveChallenge:challenge
-                                       completionHandler:completionHandler];
+                                                      task:task
+                                       didReceiveChallenge:challenge
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     }
@@ -157,18 +164,18 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 #pragma mark - NSURLSessionTaskDelegate (redirection)
 
 - (void)URLSession:(NSURLSession *)session
-              task:(NSURLSessionTask *)task
-willPerformHTTPRedirection:(NSHTTPURLResponse *)response
-        newRequest:(NSURLRequest *)request
- completionHandler:(void (^)(NSURLRequest *))completionHandler
+                          task:(NSURLSessionTask *)task
+    willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+                    newRequest:(NSURLRequest *)request
+             completionHandler:(void (^)(NSURLRequest *))completionHandler
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionTaskDelegate>)delegate URLSession:session
-                                                     task:task
-                               willPerformHTTPRedirection:response
-                                               newRequest:request
-                                        completionHandler:completionHandler];
+                                                      task:task
+                                willPerformHTTPRedirection:response
+                                                newRequest:request
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(request);  // follow the redirect — URLSession's built-in default
     }
@@ -186,16 +193,16 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
 }
 
 - (void)URLSession:(NSURLSession *)session
-          dataTask:(NSURLSessionDataTask *)dataTask
-didReceiveResponse:(NSURLResponse *)response
- completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+              dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionDataDelegate>)delegate URLSession:session
-                                                 dataTask:dataTask
-                                       didReceiveResponse:response
-                                        completionHandler:completionHandler];
+                                                  dataTask:dataTask
+                                        didReceiveResponse:response
+                                         completionHandler:completionHandler];
     } else {
         completionHandler(NSURLSessionResponseAllow);
     }
@@ -204,14 +211,14 @@ didReceiveResponse:(NSURLResponse *)response
 #pragma mark - NSURLSessionDownloadDelegate
 
 - (void)URLSession:(NSURLSession *)session
-      downloadTask:(NSURLSessionDownloadTask *)downloadTask
-didFinishDownloadingToURL:(NSURL *)location
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+    didFinishDownloadingToURL:(NSURL *)location
 {
     id delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:_cmd]) {
         [(id<NSURLSessionDownloadDelegate>)delegate URLSession:session
-                                                 downloadTask:downloadTask
-                                    didFinishDownloadingToURL:location];
+                                                  downloadTask:downloadTask
+                                     didFinishDownloadingToURL:location];
     }
 }
 

--- a/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyChallengeHandlingTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyChallengeHandlingTests.swift
@@ -1,0 +1,116 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import TestSupportObjc
+import XCTest
+
+@testable import EmbraceCore
+@testable import EmbraceObjCUtilsInternal
+
+class URLSessionDelegateProxyChallengeHandlingTests: XCTestCase {
+
+    private var handler: MockURLSessionTaskHandler!
+
+    override func setUp() {
+        super.setUp()
+        handler = .init()
+    }
+
+    // MARK: - NewProxy (default proxy)
+
+    func test_newProxy_respondsToSessionChallenge_returnsFalse_whenDelegateIsEmpty() {
+        let proxy = EmbraceMakeURLSessionDelegateProxy(EmbraceDummyURLSessionDelegate(), handler)
+        let sel = NSSelectorFromString("URLSession:didReceiveChallenge:completionHandler:")
+        XCTAssertFalse(proxy.responds(to: sel))
+    }
+
+    func test_newProxy_respondsToTaskChallenge_returnsFalse_whenDelegateIsEmpty() {
+        let proxy = EmbraceMakeURLSessionDelegateProxy(EmbraceDummyURLSessionDelegate(), handler)
+        let sel = NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:")
+        XCTAssertFalse(proxy.responds(to: sel))
+    }
+
+    func test_newProxy_respondsToSessionChallenge_returnsTrue_whenDelegateImplementsIt() {
+        let proxy = EmbraceMakeURLSessionDelegateProxy(FullyImplementedURLSessionDelegate(), handler)
+        let sel = NSSelectorFromString("URLSession:didReceiveChallenge:completionHandler:")
+        XCTAssertTrue(proxy.responds(to: sel))
+    }
+
+    func test_newProxy_respondsToTaskChallenge_returnsTrue_whenDelegateImplementsIt() {
+        let proxy = EmbraceMakeURLSessionDelegateProxy(FullyImplementedURLSessionDelegate(), handler)
+        let sel = NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:")
+        XCTAssertTrue(proxy.responds(to: sel))
+    }
+
+    func test_newProxy_sessionChallenge_isForwardedToDelegate() {
+        let delegate = FullyImplementedURLSessionDelegate()
+        let proxy = EmbraceMakeURLSessionDelegateProxy(delegate, handler)
+
+        let expectation = expectation(description: "challenge completion handler called")
+        let handler: AnyObject = unsafeBitCast(
+            { (_: URLSession.AuthChallengeDisposition, _: URLCredential?) in
+                expectation.fulfill()
+            } as @convention(block) (URLSession.AuthChallengeDisposition, URLCredential?) -> Void,
+            to: AnyObject.self
+        )
+
+        InvocationHelper.invoke(
+            on: proxy,
+            selector: NSSelectorFromString("URLSession:didReceiveChallenge:completionHandler:"),
+            parameters: [URLSession.shared, URLAuthenticationChallenge(), handler]
+        )
+
+        XCTAssertTrue(delegate.didCallDidReceiveChallenge)
+        wait(for: [expectation])
+    }
+
+    func test_newProxy_taskChallenge_isForwardedToDelegate() {
+        let delegate = FullyImplementedURLSessionDelegate()
+        let proxy = EmbraceMakeURLSessionDelegateProxy(delegate, handler)
+
+        InvocationHelper.invoke(
+            on: proxy,
+            selector: NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:"),
+            parameters: [
+                URLSession.shared,
+                URLSession.shared.dataTask(with: URLRequest(url: URL(string: "https://embrace.io")!)),
+                URLAuthenticationChallenge(),
+                unsafeBitCast(
+                    { (_: URLSession.AuthChallengeDisposition, _: URLCredential?) in
+                    } as @convention(block) (URLSession.AuthChallengeDisposition, URLCredential?) -> Void,
+                    to: AnyObject.self
+                )
+            ]
+        )
+
+        XCTAssertTrue(delegate.didCallTaskWithReceivedAuthenticationChallenge)
+    }
+
+    // MARK: - LegacyProxy
+
+    func test_legacyProxy_respondsToSessionChallenge_returnsFalse_whenDelegateIsEmpty() {
+        let proxy = MakeLegacyURLSessionDelegateProxy(EmbraceDummyURLSessionDelegate(), handler!) as AnyObject
+        let sel = NSSelectorFromString("URLSession:didReceiveChallenge:completionHandler:")
+        XCTAssertFalse(proxy.responds(to: sel))
+    }
+
+    func test_legacyProxy_respondsToTaskChallenge_returnsFalse_whenDelegateIsEmpty() {
+        let proxy = MakeLegacyURLSessionDelegateProxy(EmbraceDummyURLSessionDelegate(), handler!) as AnyObject
+        let sel = NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:")
+        XCTAssertFalse(proxy.responds(to: sel))
+    }
+
+    func test_legacyProxy_respondsToSessionChallenge_returnsTrue_whenDelegateImplementsIt() {
+        let proxy = MakeLegacyURLSessionDelegateProxy(FullyImplementedURLSessionDelegate(), handler!) as AnyObject
+        let sel = NSSelectorFromString("URLSession:didReceiveChallenge:completionHandler:")
+        XCTAssertTrue(proxy.responds(to: sel))
+    }
+
+    func test_legacyProxy_respondsToTaskChallenge_returnsTrue_whenDelegateImplementsIt() {
+        let proxy = MakeLegacyURLSessionDelegateProxy(FullyImplementedURLSessionDelegate(), handler!) as AnyObject
+        let sel = NSSelectorFromString("URLSession:task:didReceiveChallenge:completionHandler:")
+        XCTAssertTrue(proxy.responds(to: sel))
+    }
+}

--- a/Tests/TestSupport/Objc/include/LegacyProxyTestFactory.h
+++ b/Tests/TestSupport/Objc/include/LegacyProxyTestFactory.h
@@ -1,0 +1,15 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Creates an `EMBURLSessionLegacyDelegateProxy` directly, bypassing `EmbraceMakeURLSessionDelegateProxy`
+/// (which uses a `dispatch_once` flag and always returns `NewProxy` in the default test environment).
+///
+/// Returns `id` — callers should cast to `EMBURLSessionDelegateProxy` or use as `AnyObject`.
+FOUNDATION_EXPORT id MakeLegacyURLSessionDelegateProxy(id _Nullable delegate, id handler);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/TestSupport/Objc/source/LegacyProxyTestFactory.m
+++ b/Tests/TestSupport/Objc/source/LegacyProxyTestFactory.m
@@ -1,0 +1,14 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#import "LegacyProxyTestFactory.h"
+#import "EMBURLSessionDelegateProtocol.h"
+
+id MakeLegacyURLSessionDelegateProxy(id delegate, id handler)
+{
+    // EMBURLSessionLegacyDelegateProxy is not in the public module headers, so we look it up
+    // by name. initWithDelegate:handler: is declared in EMBURLSessionDelegateProxy protocol.
+    Class klass = NSClassFromString(@"EMBURLSessionLegacyDelegateProxy");
+    return [(id<EMBURLSessionDelegateProxy>)[klass alloc] initWithDelegate:delegate handler:handler];
+}


### PR DESCRIPTION
Addresses an issue where sessions created without a delegate and use our internal delegate would always return `YES` to a ssl pinning challenge. It now checks with original delegate, defaulting to the os default setting.
