### PR TITLE
Add crash-resilient file-backed profiling persistence and recovery.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,6 @@ Examples/Benchmarks/Benchmarks.xcworkspace/xcuserdata
 # Claude
 .claude/
 claude/
+
+# Embrace upload cache (EmbraceUpload diskPath: "embrace") created at repo root when tests run
 /embrace/

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ Examples/Benchmarks/Benchmarks.xcworkspace/xcuserdata
 # Claude
 .claude/
 claude/
+/embrace/

--- a/Sources/EmbraceProfiling/ProfilingEngine.swift
+++ b/Sources/EmbraceProfiling/ProfilingEngine.swift
@@ -2,6 +2,8 @@
 //  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
+import Foundation  // URL / FileManager / String(format:) — used in the public API and file-backed paths
+
 #if !os(watchOS)
     import Darwin
     import EmbraceAtomicsShim
@@ -51,6 +53,9 @@ public final class ProfilingEngine: @unchecked Sendable {
         /// The sampler has entered an unrecoverable faulted state (bug or broken runtime).
         /// The associated string describes the fault reason.
         case faulted(reason: String)
+        /// File-backed storage setup failed (open/ftruncate/mmap/mprotect). The associated
+        /// string describes the cause (e.g. an errno). Only returned for file-backed starts.
+        case storageSetupFailed(reason: String)
         /// Profiling is not supported on this platform (e.g. watchOS).
         case notSupported
     }
@@ -76,6 +81,11 @@ public final class ProfilingEngine: @unchecked Sendable {
         internal var ringBuffer: UnsafeMutablePointer<emb_ring_buffer_t>?
         internal var readBuffer: UnsafeMutableRawPointer?
         internal var readBufferSize: Int = 0
+        /// File-backed store (persistent mode). nil for in-memory mode. When set, `ringBuffer`
+        /// points into the store's mapping and is owned by the store, not the engine.
+        internal var store: OpaquePointer?
+        /// Filename of the active file-backed session (so `recoverableSessions(in:)` skips it). nil if in-memory.
+        internal var activeSessionFileName: String?
         /// Atomic gate. CAS-based, no kernel ownership tracking.
         private let gateIsAcquired: UnsafeMutablePointer<emb_atomic_bool_t>
     #endif
@@ -183,8 +193,23 @@ public final class ProfilingEngine: @unchecked Sendable {
     /// - Parameter configuration: Profiling parameters. Defaults are suitable
     ///   for most use cases (10 Hz, 1MB buffer).
     /// - Returns: A ``StartResult`` indicating the outcome.
+    /// Start sampling.
+    ///
+    /// - Parameters:
+    ///   - configuration: profiling parameters.
+    ///   - directory: when non-nil, samples are persisted to a file-backed buffer in this directory
+    ///     (created if needed) so they survive a crash/Jetsam; recover them next launch via
+    ///     `recoverableSessions(in:)` + `recover(_:)`. When nil, the buffer is in-memory (the default).
+    ///   - sessionId: opaque 16-byte id for the file-backed session (becomes the filename). Must be
+    ///     unique per launch. Ignored for in-memory mode; a random id is used if nil.
+    ///
+    /// - Note: For a file-backed session, on a *clean* stop call ``finalizeStorage()`` after the worker
+    ///   has exited (poll ``isActive`` until `false`). Otherwise that session looks crash-like and is
+    ///   listed by ``recoverableSessions(in:)`` on the next launch.
     @discardableResult
-    public func start(configuration: ProfilingConfiguration = ProfilingConfiguration()) -> StartResult {
+    public func start(configuration: ProfilingConfiguration = ProfilingConfiguration(),
+                      directory: URL? = nil,
+                      sessionId: [UInt8]? = nil) -> StartResult {
         #if os(watchOS)
             return .notSupported
         #else
@@ -203,56 +228,42 @@ public final class ProfilingEngine: @unchecked Sendable {
 
             let wasActive = emb_sampler_is_active()
 
-            // If the sampler is already active, skip buffer manipulation
-            // (the worker thread may be writing to it) and let
-            // emb_sampler_start() report the accurate state.
-            let needsNewBuffer: Bool
+            // Decide the backing. If the sampler is already active, leave it untouched (the worker
+            // may be writing) and let emb_sampler_start() report the accurate state.
+            let createdNewBacking: Bool
             if wasActive {
-                needsNewBuffer = false
-            } else if let existing = ringBuffer {
-                if configuration.bufferCapacityBytes == activeConfiguration?.bufferCapacityBytes {
-                    // Retry briefly: the Dekker protocol in reset can fail if a
-                    // concurrent reader is briefly inside read_range. Under the
-                    // Swift gate this is unlikely, but defensive retries are cheap.
+                createdNewBacking = false
+            } else if let directory {
+                // FILE-BACKED: a new session is a new file — always fresh, no reuse. Drop any prior
+                // backing (in-memory buffer or a previous store) first.
+                tearDownBacking()
+                if let failure = setUpFileBackedBuffer(configuration: configuration,
+                                                       directory: directory, sessionId: sessionId) {
+                    return failure
+                }
+                createdNewBacking = true
+            } else {
+                // IN-MEMORY. If we were previously file-backed, drop the store first.
+                if store != nil { tearDownBacking() }
+                if let existing = ringBuffer,
+                    configuration.bufferCapacityBytes == activeConfiguration?.bufferCapacityBytes {
+                    // Same-capacity restart: reuse the buffer. Retry briefly — the Dekker protocol in
+                    // reset can fail if a concurrent reader is briefly inside read_range.
                     var resetOK = false
                     for _ in 0..<3 {
-                        if emb_ring_buffer_reset(existing) {
-                            resetOK = true
-                            break
-                        }
+                        if emb_ring_buffer_reset(existing) { resetOK = true; break }
                         usleep(200)
                     }
-                    if !resetOK {
-                        return .samplerBusy
-                    }
-                    needsNewBuffer = false
+                    if !resetOK { return .samplerBusy }
+                    createdNewBacking = false
                 } else {
-                    emb_ring_buffer_destroy(existing)
-                    if let ptr = readBuffer { free(ptr) }
-                    activeConfiguration = nil
-                    ringBuffer = nil
-                    readBuffer = nil
-                    readBufferSize = 0
-                    needsNewBuffer = true
+                    // First start, or capacity changed → fresh in-memory buffer.
+                    if ringBuffer != nil { tearDownBacking() }
+                    guard setUpInMemoryBuffer(configuration: configuration) else {
+                        return .bufferCreationFailed
+                    }
+                    createdNewBacking = true
                 }
-            } else {
-                needsNewBuffer = true
-            }
-
-            if needsNewBuffer {
-                guard let buffer = emb_ring_buffer_create(Int(configuration.bufferCapacityBytes), nil) else {
-                    return .bufferCreationFailed
-                }
-                ringBuffer = buffer
-
-                let capacity = emb_ring_buffer_capacity(buffer)
-                guard let newReadBuffer = malloc(capacity) else {
-                    emb_ring_buffer_destroy(buffer)
-                    ringBuffer = nil
-                    return .bufferCreationFailed
-                }
-                readBuffer = UnsafeMutableRawPointer(newReadBuffer)
-                readBufferSize = capacity
             }
 
             let config = emb_sampler_config_t(
@@ -266,12 +277,8 @@ public final class ProfilingEngine: @unchecked Sendable {
 
             let startResult = emb_sampler_start(ringBuffer, config)
 
-            if startResult != EMB_SAMPLER_START_OK, needsNewBuffer {
-                emb_ring_buffer_destroy(ringBuffer)
-                if let ptr = readBuffer { free(ptr) }
-                ringBuffer = nil
-                readBuffer = nil
-                readBufferSize = 0
+            if startResult != EMB_SAMPLER_START_OK, createdNewBacking {
+                tearDownBacking()
             }
 
             switch startResult {
@@ -292,6 +299,130 @@ public final class ProfilingEngine: @unchecked Sendable {
                 }
                 return .samplerStartFailed
             }
+        #endif
+    }
+
+    #if !os(watchOS)
+    /// Tear down whatever backing exists (in-memory ring buffer or file-backed store) + the read buffer.
+    /// For a store, this frees the attached ring-buffer wrapper and unmaps the file; it does NOT delete
+    /// the file or write a tombstone (use `finalizeStorage()` for a clean stop).
+    private func tearDownBacking() {
+        if let s = store {
+            emb_profile_store_destroy(s)  // frees the attached ring-buffer wrapper + unmaps
+            store = nil
+            ringBuffer = nil
+        } else if let existing = ringBuffer {
+            emb_ring_buffer_destroy(existing)
+            ringBuffer = nil
+        }
+        if let ptr = readBuffer { free(ptr) }
+        readBuffer = nil
+        readBufferSize = 0
+        activeConfiguration = nil
+        activeSessionFileName = nil
+    }
+
+    /// Create a fresh in-memory ring buffer + read buffer. Returns false on allocation failure.
+    private func setUpInMemoryBuffer(configuration: ProfilingConfiguration) -> Bool {
+        guard let buffer = emb_ring_buffer_create(Int(configuration.bufferCapacityBytes), nil) else {
+            return false
+        }
+        let capacity = emb_ring_buffer_capacity(buffer)
+        guard let rb = malloc(capacity) else {
+            emb_ring_buffer_destroy(buffer)
+            return false
+        }
+        ringBuffer = buffer
+        readBuffer = UnsafeMutableRawPointer(rb)
+        readBufferSize = capacity
+        return true
+    }
+
+    /// Create a file-backed store + read buffer in `directory`. Returns nil on success, or a failing
+    /// `StartResult` on error (the engine is left with no backing).
+    private func setUpFileBackedBuffer(configuration: ProfilingConfiguration,
+                                       directory: URL,
+                                       sessionId: [UInt8]?) -> StartResult? {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            return .storageSetupFailed(reason: "mkdir failed: \(error.localizedDescription)")
+        }
+
+        let sid = sessionId ?? (0..<16).map { _ in UInt8.random(in: 0...255) }
+        guard sid.count == 16 else {
+            return .storageSetupFailed(reason: "sessionId must be 16 bytes")
+        }
+        let fileName = sid.map { String(format: "%02x", $0) }.joined() + ".embprof"
+        let path = directory.appendingPathComponent(fileName).path
+
+        var err: Int32 = 0
+        let storePtr: OpaquePointer? = path.withCString { cpath in
+            sid.withUnsafeBufferPointer { sidBuf in
+                emb_profile_store_create(cpath, Int(configuration.bufferCapacityBytes), sidBuf.baseAddress, &err)
+            }
+        }
+        guard let storePtr else {
+            return .storageSetupFailed(reason: "store create failed (errno \(err))")
+        }
+        guard let buf = emb_profile_store_buffer(storePtr) else {
+            emb_profile_store_destroy(storePtr)
+            return .storageSetupFailed(reason: "store buffer unavailable")
+        }
+        let capacity = emb_ring_buffer_capacity(buf)
+        guard let rb = malloc(capacity) else {
+            emb_profile_store_destroy(storePtr)
+            return .storageSetupFailed(reason: "read-buffer allocation failed (\(capacity) bytes)")
+        }
+        store = storePtr
+        ringBuffer = buf
+        readBuffer = UnsafeMutableRawPointer(rb)
+        readBufferSize = capacity
+        activeSessionFileName = fileName
+        return nil
+    }
+    #endif
+
+    /// Flush persisted samples to disk (`msync(MS_ASYNC)`). No-op in in-memory mode. The CaptureService
+    /// wrapper calls this on `willResignActive` / `didEnterBackground` (and `willTerminate`) so samples
+    /// are durable before a possible background Jetsam kill. Cheap, non-blocking, off the hot path.
+    ///
+    /// - Note: Best-effort — it skips silently if the engine's gate is briefly contended (e.g. a
+    ///   concurrent `start`/`retrieveSamples`). `MAP_SHARED` pages are still flushed by the kernel on
+    ///   normal termination; this only matters for an abrupt Jetsam within that small window.
+    /// - Note: `msync` runs concurrently with the live sampler writing the same mapping — this is by
+    ///   design. A page captured mid-write is just re-flushed later, and recovery's seqlock/torn-tail
+    ///   handling discards any partial record, so a torn flush is never observable as corruption.
+    public func flush() {
+        #if !os(watchOS)
+            // Gate-protected: `store` is torn down (destroyed + niled) under the gate by start()/reset.
+            // Without this, a background/terminate-thread flush could msync a freed/unmapped store.
+            guard acquireGate() else { return }
+            defer { releaseGate() }
+            if let s = store { emb_profile_store_flush(s) }
+        #endif
+    }
+
+    /// Mark the file-backed session cleanly finalized (writes the version-0 tombstone), so recovery
+    /// reports nothing for it. No-op in in-memory mode. Call on a clean stop, after the worker has
+    /// exited (poll `isActive` until false) — the wrapper sequences this.
+    ///
+    /// - Important: This DISCARDS the session's on-disk samples — the tombstone marks the *entire* file
+    ///   "disregard". Only call it once you have retrieved everything you need (e.g. via
+    ///   ``retrieveSamples(from:through:)``); there is no recovery after finalize.
+    /// - Important: This is a NO-OP while sampling is still active. Writing the tombstone before the
+    ///   worker has drained would silently discard not-yet-reported samples, so if called early it
+    ///   leaves the session recoverable (reported next launch) rather than lost. Conversely, if you
+    ///   never call it on a clean stop, that session is listed by ``recoverableSessions(in:)`` next
+    ///   launch (a harmless false positive you can ``delete(_:)``).
+    public func finalizeStorage() {
+        #if !os(watchOS)
+            // Gate-protected for the same reason as flush(): guards against a concurrent store teardown.
+            guard acquireGate() else { return }
+            defer { releaseGate() }
+            // Refuse to tombstone a live buffer (see note above) — leave it recoverable instead.
+            guard !emb_sampler_is_active() else { return }
+            if let s = store { emb_profile_store_finalize(s) }
         #endif
     }
 
@@ -441,8 +572,8 @@ public final class ProfilingEngine: @unchecked Sendable {
                 // Defense-in-depth: reject implausibly large frame_count values.
                 // The C read path already bounds-checks via record_size > (write_pos -
                 // scan_pos), but a corruption check is cheap.
-                guard header.frame_count <= UInt32(EMB_MAX_STACK_FRAMES) else { break }
-                let recordSize = Int(emb_ring_record_size(header.frame_count))
+                guard Int(header.frame_count) <= Int(EMB_MAX_STACK_FRAMES) else { break }
+                let recordSize = Int(emb_ring_record_size(UInt32(header.frame_count)))
                 guard offset + recordSize <= validEnd else { break }
                 totalFrames += Int(header.frame_count)
                 offset += recordSize
@@ -458,9 +589,9 @@ public final class ProfilingEngine: @unchecked Sendable {
             for _ in 0..<result.record_count {
                 guard offset + headerSize <= validEnd else { break }
                 let header = rawBuffer.load(fromByteOffset: offset, as: emb_ring_record_header_t.self)
-                guard header.frame_count <= UInt32(EMB_MAX_STACK_FRAMES) else { break }
+                guard Int(header.frame_count) <= Int(EMB_MAX_STACK_FRAMES) else { break }
                 let frameCount = Int(header.frame_count)
-                let recordSize = Int(emb_ring_record_size(header.frame_count))
+                let recordSize = Int(emb_ring_record_size(UInt32(header.frame_count)))
                 guard offset + recordSize <= validEnd else { break }
 
                 let framesStart = frames.count
@@ -474,7 +605,8 @@ public final class ProfilingEngine: @unchecked Sendable {
 
                 samples.append(ProfilingSample(
                     timestamp: header.timestamp_ns,
-                    frameRange: framesStart..<frames.count
+                    frameRange: framesStart..<frames.count,
+                    threadState: ThreadState(rawValue: header.thread_state) ?? .unknown
                 ))
 
                 offset += recordSize

--- a/Sources/EmbraceProfiling/ProfilingEngine.swift
+++ b/Sources/EmbraceProfiling/ProfilingEngine.swift
@@ -32,6 +32,9 @@ import Foundation  // URL / FileManager / String(format:) — used in the public
 public final class ProfilingEngine: @unchecked Sendable {
     public static let shared = ProfilingEngine()
 
+    /// File extension (without the leading dot) for a persisted profiling session file.
+    internal static let sessionFileExtension = "embprof"
+
     /// Result of calling ``start(configuration:)``.
     public enum StartResult: Equatable, Sendable {
         /// Successfully started the sampler.
@@ -203,6 +206,9 @@ public final class ProfilingEngine: @unchecked Sendable {
     ///   - sessionId: opaque 16-byte id for the file-backed session (becomes the filename). Must be
     ///     unique per launch. Ignored for in-memory mode; a random id is used if nil.
     ///
+    /// - Important: A file-backed start (`directory != nil`) performs synchronous filesystem work on the
+    ///   calling thread (`createDirectory`, `ftruncate`, `mmap`) and never dispatches internally — call
+    ///   it off the main thread. In-memory mode (the default) does no filesystem I/O.
     /// - Note: For a file-backed session, on a *clean* stop call ``finalizeStorage()`` after the worker
     ///   has exited (poll ``isActive`` until `false`). Otherwise that session looks crash-like and is
     ///   listed by ``recoverableSessions(in:)`` on the next launch.
@@ -353,7 +359,7 @@ public final class ProfilingEngine: @unchecked Sendable {
         guard sid.count == 16 else {
             return .storageSetupFailed(reason: "sessionId must be 16 bytes")
         }
-        let fileName = sid.map { String(format: "%02x", $0) }.joined() + ".embprof"
+        let fileName = sid.map { String(format: "%02x", $0) }.joined() + "." + Self.sessionFileExtension
         let path = directory.appendingPathComponent(fileName).path
 
         var err: Int32 = 0
@@ -381,7 +387,7 @@ public final class ProfilingEngine: @unchecked Sendable {
         activeSessionFileName = fileName
         return nil
     }
-    #endif
+    #endif  // !os(watchOS)
 
     /// Flush persisted samples to disk (`msync(MS_ASYNC)`). No-op in in-memory mode. The CaptureService
     /// wrapper calls this on `willResignActive` / `didEnterBackground` (and `willTerminate`) so samples

--- a/Sources/EmbraceProfiling/ProfilingEngine.swift
+++ b/Sources/EmbraceProfiling/ProfilingEngine.swift
@@ -6,8 +6,13 @@ import Foundation  // URL / FileManager / String(format:) — used in the public
 
 #if !os(watchOS)
     import Darwin
-    import EmbraceAtomicsShim
-    import EmbraceProfilingSampler
+
+    // Under CocoaPods every subspec compiles into the single EmbraceIO module, so these
+    // sibling modules must not be imported by name — see EmbraceIO.podspec.
+    #if !EMBRACE_COCOAPOD_BUILDING_SDK
+        import EmbraceAtomicsShim
+        import EmbraceProfilingSampler
+    #endif
 #endif
 
 /// A sampling-based profiling engine that captures main thread stack traces
@@ -154,7 +159,8 @@ public final class ProfilingEngine: @unchecked Sendable {
     }
 
     #if !os(watchOS)
-    /// Try to acquire the gate.
+    /// Try to acquire the backing gate — the CAS flag guarding the engine's backing store and buffers
+    /// (`ringBuffer`, `readBuffer`, `store`, …). Unrelated to the C sampler's own run-state machine.
     /// Sleeps ``gateSleepNs`` between attempts, up to ``gateTimeoutNs``
     /// cumulative actual elapsed time.
     ///
@@ -163,7 +169,7 @@ public final class ProfilingEngine: @unchecked Sendable {
     /// 2-3 CAS attempts within the 10ms deadline rather than the ~100 attempts
     /// that the arithmetic suggests. This is acceptable because contention is
     /// expected to be extremely rare (only start/retrieve overlap).
-    internal func acquireGate() -> Bool {
+    internal func acquireBackingGate() -> Bool {
         let deadlineNs = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) + Self.gateTimeoutNs
         while true {
             var expected: Bool = false
@@ -177,8 +183,8 @@ public final class ProfilingEngine: @unchecked Sendable {
         }
     }
 
-    /// Release the gate.
-    internal func releaseGate() {
+    /// Release the backing gate.
+    internal func releaseBackingGate() {
         emb_atomic_bool_store(gateIsAcquired, false, .release)
     }
     #endif
@@ -227,12 +233,20 @@ public final class ProfilingEngine: @unchecked Sendable {
                 return .faulted(reason: reason)
             }
 
-            guard acquireGate() else {
+            guard acquireBackingGate() else {
                 return .operationInProgress
             }
-            defer { releaseGate() }
+            defer { releaseBackingGate() }
 
             let wasActive = emb_sampler_is_active()
+
+            // KNOWN RACE (dormant; no production caller of start() yet): is_active() is true for
+            // STOPPING, and this Swift gate doesn't block the C worker's autonomous STOPPING→ZOMBIE
+            // transition. If the worker finishes here, emb_sampler_start() below reaps the zombie and
+            // wins a fresh CAS, so a genuinely new session reports .alreadyActive — and in file-backed
+            // mode skips the setUpFileBackedBuffer branch, dropping the caller's sessionId. The real fix
+            // is to have the C layer distinguish "fresh start" from "already running" in its return
+            // instead of re-reading is_active() here; tracked as a follow-up.
 
             // Decide the backing. If the sampler is already active, leave it untouched (the worker
             // may be writing) and let emb_sampler_start() report the accurate state.
@@ -403,8 +417,8 @@ public final class ProfilingEngine: @unchecked Sendable {
         #if !os(watchOS)
             // Gate-protected: `store` is torn down (destroyed + niled) under the gate by start()/reset.
             // Without this, a background/terminate-thread flush could msync a freed/unmapped store.
-            guard acquireGate() else { return }
-            defer { releaseGate() }
+            guard acquireBackingGate() else { return }
+            defer { releaseBackingGate() }
             if let s = store { emb_profile_store_flush(s) }
         #endif
     }
@@ -424,8 +438,8 @@ public final class ProfilingEngine: @unchecked Sendable {
     public func finalizeStorage() {
         #if !os(watchOS)
             // Gate-protected for the same reason as flush(): guards against a concurrent store teardown.
-            guard acquireGate() else { return }
-            defer { releaseGate() }
+            guard acquireBackingGate() else { return }
+            defer { releaseBackingGate() }
             // Refuse to tombstone a live buffer (see note above) — leave it recoverable instead.
             guard !emb_sampler_is_active() else { return }
             if let s = store { emb_profile_store_finalize(s) }
@@ -546,8 +560,8 @@ public final class ProfilingEngine: @unchecked Sendable {
                 return .faulted(reason: reason)
             }
 
-            guard acquireGate() else { return .busy }
-            defer { releaseGate() }
+            guard acquireBackingGate() else { return .busy }
+            defer { releaseBackingGate() }
 
             guard let ringBuffer, let readBuffer else {
                 return .notStarted

--- a/Sources/EmbraceProfiling/ProfilingRecovery.swift
+++ b/Sources/EmbraceProfiling/ProfilingRecovery.swift
@@ -5,7 +5,10 @@
 import Foundation
 
 #if !os(watchOS)
-    import EmbraceProfilingSampler
+    // See ProfilingEngine.swift: under CocoaPods this module is part of EmbraceIO, not importable.
+    #if !EMBRACE_COCOAPOD_BUILDING_SDK
+        import EmbraceProfilingSampler
+    #endif
 #endif
 
 /// An opaque handle to one previous session's persisted profiling file, discovered via
@@ -17,7 +20,8 @@ public struct RecoverableSession: Sendable, Equatable {
     public enum Status: Sendable {
         /// Has (or may have) un-reported samples — worth recovering.
         case recoverable
-        /// Cleanly finalized (the app stopped normally); nothing to recover, safe to delete.
+        /// Nothing to recover, safe to delete. Reached by a clean stop (`finalize`), and — because
+        /// both write a 0 version marker — also by a crash mid-`reset`. Not a proof of normal shutdown.
         case finalized
     }
 
@@ -67,12 +71,13 @@ public enum SessionRecoveryResult: Sendable {
             threadState: ThreadState(rawValue: state) ?? .unknown))
     }
 
-    private func describe(_ status: emb_profile_recover_status_t) -> String {
+    private func describe(_ status: emb_profile_recover_status_t, errno errnoValue: Int32) -> String {
         switch status {
         case EMB_PROFILE_RECOVER_NOT_OURS: return "not an Embrace profiling file"
         case EMB_PROFILE_RECOVER_UNSUPPORTED: return "unsupported format version"
         case EMB_PROFILE_RECOVER_CORRUPT: return "corrupt (failed validation)"
-        case EMB_PROFILE_RECOVER_IO_ERROR: return "I/O error"
+        case EMB_PROFILE_RECOVER_IO_ERROR:
+            return errnoValue != 0 ? "I/O error (errno \(errnoValue))" : "I/O error"
         default: return "unknown status \(status.rawValue)"
         }
     }
@@ -106,9 +111,9 @@ extension ProfilingEngine {
             // handing the caller the active session's file — bail conservatively (contention is
             // extremely rare and the caller can retry). A successful acquire with a nil name simply
             // means nothing is active, which is safe.
-            guard acquireGate() else { return [] }
+            guard acquireBackingGate() else { return [] }
             let activeName = activeSessionFileName
-            releaseGate()
+            releaseBackingGate()
 
             var sessions: [RecoverableSession] = []
             for url in entries
@@ -127,6 +132,11 @@ extension ProfilingEngine {
                     continue
                 default: continue  // not ours → skip
                 }
+                // `keys` were pre-fetched by contentsOfDirectory above, so this read hits the cache and
+                // effectively only fails if the file vanished mid-enumeration — in which case the handle
+                // is about to be useless anyway. The sentinels aren't neutral (`.distantPast` sorts to the
+                // front of the oldest-first list below), so the values stay non-optional deliberately:
+                // callers shouldn't have to unwrap for a case that doesn't meaningfully occur.
                 let values = try? url.resourceValues(forKeys: Set(keys))
                 sessions.append(RecoverableSession(
                     sessionId: url.deletingPathExtension().lastPathComponent,
@@ -147,8 +157,9 @@ extension ProfilingEngine {
             return .notSupported
         #else
             let sink = FileSink()
+            var errnoOut: Int32 = 0
             let status = session.url.path.withCString { path in
-                emb_profile_recover(path, recoverEmit, Unmanaged.passUnretained(sink).toOpaque())
+                emb_profile_recover(path, recoverEmit, Unmanaged.passUnretained(sink).toOpaque(), &errnoOut)
             }
             switch status {
             case EMB_PROFILE_RECOVER_OK:
@@ -156,7 +167,7 @@ extension ProfilingEngine {
             case EMB_PROFILE_RECOVER_FINALIZED:
                 return .finalized
             default:
-                return .unreadable(reason: describe(status))
+                return .unreadable(reason: describe(status, errno: errnoOut))
             }
         #endif
     }
@@ -172,9 +183,9 @@ extension ProfilingEngine {
             // Gate acquisition failure means we can't confirm the file isn't the live session, so
             // treat it as a hard "don't delete" rather than falling through to a nil active name
             // (which would let us delete the currently-active file — a data-loss bug).
-            guard acquireGate() else { return false }
+            guard acquireBackingGate() else { return false }
             let activeName = activeSessionFileName
-            releaseGate()
+            releaseBackingGate()
             guard session.url.lastPathComponent != activeName else { return false }
             return (try? FileManager.default.removeItem(at: session.url)) != nil
         #endif

--- a/Sources/EmbraceProfiling/ProfilingRecovery.swift
+++ b/Sources/EmbraceProfiling/ProfilingRecovery.swift
@@ -102,17 +102,30 @@ extension ProfilingEngine {
             }
 
             // Snapshot the active file name under the gate so we don't race start()/teardown.
-            var activeName: String?
-            if acquireGate() { activeName = activeSessionFileName; releaseGate() }
+            // If we can't acquire the gate we can't prove which file is live, so we must not risk
+            // handing the caller the active session's file — bail conservatively (contention is
+            // extremely rare and the caller can retry). A successful acquire with a nil name simply
+            // means nothing is active, which is safe.
+            guard acquireGate() else { return [] }
+            let activeName = activeSessionFileName
+            releaseGate()
 
             var sessions: [RecoverableSession] = []
-            for url in entries where url.pathExtension == "embprof" && url.lastPathComponent != activeName {
+            for url in entries
+                where url.pathExtension == Self.sessionFileExtension && url.lastPathComponent != activeName {
                 let peek = url.path.withCString { emb_profile_peek($0) }
                 let status: RecoverableSession.Status
                 switch peek {
                 case EMB_PROFILE_PEEK_RECOVERABLE: status = .recoverable
                 case EMB_PROFILE_PEEK_FINALIZED: status = .finalized
-                default: continue  // not ours / unreadable → skip
+                case EMB_PROFILE_PEEK_INDETERMINATE:
+                    // Couldn't read the file this launch (e.g. still locked under data protection at
+                    // boot, or a transient I/O error). It may be one of ours and recoverable — we just
+                    // can't tell yet — so skip it this pass rather than misclassify it. It stays on disk
+                    // (we never delete here) and is re-examined on the next launch. Kept distinct from
+                    // NOT_OURS so retention/cleanup logic won't treat it as safe to delete.
+                    continue
+                default: continue  // not ours → skip
                 }
                 let values = try? url.resourceValues(forKeys: Set(keys))
                 sessions.append(RecoverableSession(
@@ -156,8 +169,12 @@ extension ProfilingEngine {
         #if os(watchOS)
             return false
         #else
-            var activeName: String?
-            if acquireGate() { activeName = activeSessionFileName; releaseGate() }
+            // Gate acquisition failure means we can't confirm the file isn't the live session, so
+            // treat it as a hard "don't delete" rather than falling through to a nil active name
+            // (which would let us delete the currently-active file — a data-loss bug).
+            guard acquireGate() else { return false }
+            let activeName = activeSessionFileName
+            releaseGate()
             guard session.url.lastPathComponent != activeName else { return false }
             return (try? FileManager.default.removeItem(at: session.url)) != nil
         #endif

--- a/Sources/EmbraceProfiling/ProfilingRecovery.swift
+++ b/Sources/EmbraceProfiling/ProfilingRecovery.swift
@@ -38,14 +38,40 @@ public struct RecoverableSession: Sendable, Equatable {
     let url: URL
 }
 
+/// Why a ``RecoverableSession`` couldn't be parsed. Typed (rather than a flat string) so the caller can
+/// choose an action per case: `corrupt` → safe to ``ProfilingEngine/delete(_:)``; `ioError` is often
+/// transient (file still locked under data protection at boot, `EINTR`, `EIO`) → leave it and retry next
+/// launch; `unsupportedVersion` → keep it for a future build that understands the format. Its
+/// `description` is a human-readable one-liner for logs.
+public enum RecoveryFailure: Sendable, CustomStringConvertible {
+    /// The file exists but isn't one of ours (magic mismatch).
+    case notOurs
+    /// Ours, but written by a newer format version this build doesn't understand.
+    case unsupportedVersion
+    /// Ours and the right version, but failed structural validation.
+    case corrupt
+    /// A syscall (open/fstat/pread/mmap) failed; carries the causing `errno` (0 if none was set).
+    case ioError(errno: Int32)
+
+    public var description: String {
+        switch self {
+        case .notOurs: return "not an Embrace profiling file"
+        case .unsupportedVersion: return "unsupported format version"
+        case .corrupt: return "corrupt (failed validation)"
+        case .ioError(let errno):
+            return errno != 0 ? "I/O error (errno \(errno))" : "I/O error"
+        }
+    }
+}
+
 /// Outcome of recovering a single ``RecoverableSession``.
 public enum SessionRecoveryResult: Sendable {
     /// Parsed successfully; the (possibly empty) samples for this session.
     case recovered(ProfilingResult)
     /// The file was cleanly finalized — nothing to recover.
     case finalized
-    /// The file could not be parsed (not ours / unsupported / corrupt / I/O error).
-    case unreadable(reason: String)
+    /// The file could not be parsed. Carries a typed ``RecoveryFailure`` so callers can act on the cause.
+    case unreadable(RecoveryFailure)
     /// Profiling is not supported on this platform (e.g. watchOS).
     case notSupported
 }
@@ -71,14 +97,16 @@ public enum SessionRecoveryResult: Sendable {
             threadState: ThreadState(rawValue: state) ?? .unknown))
     }
 
-    private func describe(_ status: emb_profile_recover_status_t, errno errnoValue: Int32) -> String {
+    /// Map a C recovery status (+ threaded `errno`) to a typed ``RecoveryFailure``. Only called for the
+    /// non-success, non-finalized statuses; an unexpected value is treated as `corrupt` (discardable)
+    /// rather than inventing a case, since the file is unusable by this build either way.
+    private func recoveryFailure(_ status: emb_profile_recover_status_t, errno errnoValue: Int32)
+        -> RecoveryFailure {
         switch status {
-        case EMB_PROFILE_RECOVER_NOT_OURS: return "not an Embrace profiling file"
-        case EMB_PROFILE_RECOVER_UNSUPPORTED: return "unsupported format version"
-        case EMB_PROFILE_RECOVER_CORRUPT: return "corrupt (failed validation)"
-        case EMB_PROFILE_RECOVER_IO_ERROR:
-            return errnoValue != 0 ? "I/O error (errno \(errnoValue))" : "I/O error"
-        default: return "unknown status \(status.rawValue)"
+        case EMB_PROFILE_RECOVER_NOT_OURS: return .notOurs
+        case EMB_PROFILE_RECOVER_UNSUPPORTED: return .unsupportedVersion
+        case EMB_PROFILE_RECOVER_IO_ERROR: return .ioError(errno: errnoValue)
+        default: return .corrupt
         }
     }
 
@@ -167,7 +195,7 @@ extension ProfilingEngine {
             case EMB_PROFILE_RECOVER_FINALIZED:
                 return .finalized
             default:
-                return .unreadable(reason: describe(status, errno: errnoOut))
+                return .unreadable(recoveryFailure(status, errno: errnoOut))
             }
         #endif
     }

--- a/Sources/EmbraceProfiling/ProfilingRecovery.swift
+++ b/Sources/EmbraceProfiling/ProfilingRecovery.swift
@@ -1,0 +1,165 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+#if !os(watchOS)
+    import EmbraceProfilingSampler
+#endif
+
+/// An opaque handle to one previous session's persisted profiling file, discovered via
+/// ``ProfilingEngine/recoverableSessions(in:)``. Carries identifying metadata so the caller can decide
+/// what to recover or delete without touching the underlying file directly. Recover it with
+/// ``ProfilingEngine/recover(_:)`` and remove it with ``ProfilingEngine/delete(_:)``.
+public struct RecoverableSession: Sendable, Equatable {
+    /// What a cheap identity peek says about the file.
+    public enum Status: Sendable {
+        /// Has (or may have) un-reported samples — worth recovering.
+        case recoverable
+        /// Cleanly finalized (the app stopped normally); nothing to recover, safe to delete.
+        case finalized
+    }
+
+    /// Hex session id (the file-name stem).
+    public let sessionId: String
+    /// When the file was last written (its most recent sample or the finalize tombstone).
+    public let lastModified: Date
+    /// On-disk size in bytes.
+    public let byteSize: Int
+    /// Whether this session has data to recover or was cleanly finalized.
+    public let status: Status
+
+    /// The backing file. Internal so callers act through `recover(_:)`/`delete(_:)`, never the raw path.
+    let url: URL
+}
+
+/// Outcome of recovering a single ``RecoverableSession``.
+public enum SessionRecoveryResult: Sendable {
+    /// Parsed successfully; the (possibly empty) samples for this session.
+    case recovered(ProfilingResult)
+    /// The file was cleanly finalized — nothing to recover.
+    case finalized
+    /// The file could not be parsed (not ours / unsupported / corrupt / I/O error).
+    case unreadable(reason: String)
+    /// Profiling is not supported on this platform (e.g. watchOS).
+    case notSupported
+}
+
+#if !os(watchOS)
+
+    /// Per-file accumulator the C recovery callback writes into (a class so it can be mutated via the
+    /// opaque `ctx` pointer from a non-capturing C function pointer).
+    private final class FileSink {
+        var samples: [ProfilingSample] = []
+        var frames: [UInt] = []
+    }
+
+    private let recoverEmit: emb_profile_record_cb = { ctx, ts, state, _, framesPtr, count in
+        let sink = Unmanaged<FileSink>.fromOpaque(ctx!).takeUnretainedValue()
+        let start = sink.frames.count
+        if let framesPtr, count > 0 {
+            sink.frames.append(contentsOf: UnsafeBufferPointer(start: framesPtr, count: Int(count)))
+        }
+        sink.samples.append(ProfilingSample(
+            timestamp: ts,
+            frameRange: start..<sink.frames.count,
+            threadState: ThreadState(rawValue: state) ?? .unknown))
+    }
+
+    private func describe(_ status: emb_profile_recover_status_t) -> String {
+        switch status {
+        case EMB_PROFILE_RECOVER_NOT_OURS: return "not an Embrace profiling file"
+        case EMB_PROFILE_RECOVER_UNSUPPORTED: return "unsupported format version"
+        case EMB_PROFILE_RECOVER_CORRUPT: return "corrupt (failed validation)"
+        case EMB_PROFILE_RECOVER_IO_ERROR: return "I/O error"
+        default: return "unknown status \(status.rawValue)"
+        }
+    }
+
+#endif
+
+extension ProfilingEngine {
+    /// List previous sessions persisted in `directory` (the same directory passed to a file-backed
+    /// `start`). **Cheap and read-only** — reads only file metadata + a 16-byte identity peek per file,
+    /// never loading samples — so it's safe to call at launch. Skips the currently-active session's file
+    /// and anything that isn't one of ours. Returns handles sorted oldest-first by `lastModified`.
+    ///
+    /// Recover each with ``recover(_:)`` and remove it with ``delete(_:)`` (Embrace owns retention).
+    public func recoverableSessions(in directory: URL) -> [RecoverableSession] {
+        #if os(watchOS)
+            return []
+        #else
+            let fm = FileManager.default
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: directory.path, isDirectory: &isDir), isDir.boolValue else {
+                return []
+            }
+            let keys: [URLResourceKey] = [.contentModificationDateKey, .fileSizeKey]
+            guard let entries = try? fm.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: keys) else {
+                return []
+            }
+
+            // Snapshot the active file name under the gate so we don't race start()/teardown.
+            var activeName: String?
+            if acquireGate() { activeName = activeSessionFileName; releaseGate() }
+
+            var sessions: [RecoverableSession] = []
+            for url in entries where url.pathExtension == "embprof" && url.lastPathComponent != activeName {
+                let peek = url.path.withCString { emb_profile_peek($0) }
+                let status: RecoverableSession.Status
+                switch peek {
+                case EMB_PROFILE_PEEK_RECOVERABLE: status = .recoverable
+                case EMB_PROFILE_PEEK_FINALIZED: status = .finalized
+                default: continue  // not ours / unreadable → skip
+                }
+                let values = try? url.resourceValues(forKeys: Set(keys))
+                sessions.append(RecoverableSession(
+                    sessionId: url.deletingPathExtension().lastPathComponent,
+                    lastModified: values?.contentModificationDate ?? .distantPast,
+                    byteSize: values?.fileSize ?? 0,
+                    status: status,
+                    url: url))
+            }
+            return sessions.sorted { $0.lastModified < $1.lastModified }
+        #endif
+    }
+
+    /// Recover one session's samples. **Read-only** — never writes, tombstones, or deletes the file.
+    /// Runs synchronously; call it off the main thread. Recovering a `.finalized` handle returns
+    /// ``SessionRecoveryResult/finalized``.
+    public func recover(_ session: RecoverableSession) -> SessionRecoveryResult {
+        #if os(watchOS)
+            return .notSupported
+        #else
+            let sink = FileSink()
+            let status = session.url.path.withCString { path in
+                emb_profile_recover(path, recoverEmit, Unmanaged.passUnretained(sink).toOpaque())
+            }
+            switch status {
+            case EMB_PROFILE_RECOVER_OK:
+                return .recovered(ProfilingResult(samples: sink.samples, frames: sink.frames))
+            case EMB_PROFILE_RECOVER_FINALIZED:
+                return .finalized
+            default:
+                return .unreadable(reason: describe(status))
+            }
+        #endif
+    }
+
+    /// Delete a previous session's file (Embrace owns retention — call when you're done with it,
+    /// whether recovered or finalized). Refuses to delete the currently-active session's file. Returns
+    /// `true` if the file was removed.
+    @discardableResult
+    public func delete(_ session: RecoverableSession) -> Bool {
+        #if os(watchOS)
+            return false
+        #else
+            var activeName: String?
+            if acquireGate() { activeName = activeSessionFileName; releaseGate() }
+            guard session.url.lastPathComponent != activeName else { return false }
+            return (try? FileManager.default.removeItem(at: session.url)) != nil
+        #endif
+    }
+}

--- a/Sources/EmbraceProfiling/ProfilingSample.swift
+++ b/Sources/EmbraceProfiling/ProfilingSample.swift
@@ -7,6 +7,20 @@
 /// Frame addresses are stored in a flat array shared across all samples in a
 /// ``ProfilingResult``. Use ``frameRange`` to index into that array, or use
 /// ``ProfilingResult/frames(for:)`` for convenient per-sample access.
+/// Run state of the sampled (main) thread at the moment a sample was captured.
+///
+/// Raw values mirror the Mach `TH_STATE_*` constants (and the C
+/// `emb_thread_run_state_t`). `.unknown` (255) means the state could not be
+/// captured (e.g. `thread_info` failed).
+public enum ThreadState: UInt8, Sendable {
+    case running = 1
+    case stopped = 2
+    case waiting = 3
+    case uninterruptible = 4
+    case halted = 5
+    case unknown = 255
+}
+
 public struct ProfilingSample: Equatable, Hashable, Sendable {
     /// `CLOCK_MONOTONIC_RAW` timestamp in nanoseconds when this sample was captured.
     public let timestamp: UInt64
@@ -14,9 +28,13 @@ public struct ProfilingSample: Equatable, Hashable, Sendable {
     /// Index range into the shared frames array for this sample's return addresses.
     public let frameRange: Range<Int>
 
-    init(timestamp: UInt64, frameRange: Range<Int>) {
+    /// Run state of the sampled thread when this sample was captured.
+    public let threadState: ThreadState
+
+    init(timestamp: UInt64, frameRange: Range<Int>, threadState: ThreadState) {
         self.timestamp = timestamp
         self.frameRange = frameRange
+        self.threadState = threadState
     }
 }
 

--- a/Sources/EmbraceProfilingSampler/PROFILING-DISK-FORMAT.md
+++ b/Sources/EmbraceProfilingSampler/PROFILING-DISK-FORMAT.md
@@ -1,0 +1,252 @@
+# EmbraceProfiling — on-disk file format (`.embprof`, v1)
+
+This document specifies the on-disk format written by `EmbraceProfilingSampler` when a profiling
+session is started in **file-backed mode** (`ProfilingEngine.start(directory:)`). It is the reference
+for anyone who needs to read, validate, or recover one of these files independently of the SDK.
+
+The format is versioned. This document describes **format version 1**. All structs are little-endian
+and 64-bit; the SDK only supports 64-bit Apple platforms and rejects anything else on recovery.
+
+## 1. Why the format exists
+
+File-backed sessions persist profiling samples so they survive **any** form of process death — a
+signal crash, a fatal exception, `abort()`, a watchdog termination, or an OOM / Jetsam `SIGKILL` — and
+can be recovered on the next launch.
+
+The mechanism is a **file-backed `MAP_SHARED` memory mapping**: the sampler's ring buffer is backed by
+a file instead of anonymous memory. The sampler writes records into mapped memory exactly as it does
+in-memory; the kernel's unified buffer cache owns the dirty pages and writes them back to the file.
+When the process dies, the kernel still flushes those dirty pages to the file — so the file reflects
+recent samples **with no explicit I/O on the sampling hot path**.
+
+The one case this does *not* cover is hard device power loss or a kernel panic (dirty pages not yet
+written to flash are lost). That is out of scope for app-crash recovery.
+
+## 2. File layout
+
+Descriptive metadata lives in a **footer at the tail of the file**, not a header at the front. The
+data region sits at file offset 0; everything that describes it — and everything that may grow or
+change across future format versions — follows it. The file ends with a **frozen identity struct**
+(`magic` + `format_version`) that is the only part of the format guaranteed never to change.
+
+```
+┌──────────────────────────────────────────────┐  offset 0
+│  Data region  (data_capacity bytes)           │  ← page-aligned; same record layout as the
+│  variable-length profiling records            │    in-memory ring buffer (§4)
+├──────────────────────────────────────────────┤  offset = data_capacity
+│  Footer  (footer_bytes, = 2 pages)            │
+│   ├─ control page   (hot, read/write)         │  write_pos, oldest_pos, next_seq, status_flags
+│   └─ metadata page  (write-once, read-only)   │
+│        ├─ descriptor  (at page start)         │  created times, session_id
+│        │        …                             │
+│        ├─ trailer     (before identity)       │  offsets, page size, record sizes  (v1-specific)
+│        └─ identity    (last bytes of file)    │  magic + format_version  (FROZEN, all versions)
+└──────────────────────────────────────────────┘  EOF
+```
+
+- **File size** is exactly `data_capacity + footer_bytes`. The file is **pre-sized** at creation
+  (`ftruncate`) and never appended to at runtime, so a crash can never truncate away the footer.
+- **`data_capacity`** is the page-aligned ring capacity (the SDK default is 1 MB; the configurable
+  request must be greater than 128 KB and at most 10 MB, then rounded up to a page).
+- **`footer_bytes`** is two pages: one read/write *control page* followed by one write-once
+  *metadata page*.
+- **`page_size`** is `vm_page_size` at creation time (16 KB on Apple-silicon devices and macOS, 4 KB
+  on the x86_64 simulator). It is recorded in the trailer so recovery never has to assume it.
+
+### 2.1 Why the metadata is at the tail
+
+- **The data region stays at offset 0 in every format version.** Growing the metadata never moves
+  it, and the data region maps cleanly from offset 0.
+- **A fixed-position identity at EOF is a capacity-independent discovery point.** A reader does
+  `fstat` → reads the last 16 bytes → checks `magic` → reads `format_version` → then parses the rest
+  with the parser for that version. The version is known *before* any layout that could have changed
+  between versions is touched. (This is the classic extensible-container pattern, e.g. ZIP's
+  end-of-central-directory record.)
+- **"At the tail" means spatially at the end of the file, not "written last."** The descriptor,
+  trailer, and identity are all written **at create time** into pre-sized, page-aligned pages, so
+  they flush early and stay on disk regardless of how the process dies.
+
+## 3. On-disk structures (format version 1)
+
+All of these are defined in `Sources/EmbraceProfilingSampler/include/emb_profile_store.h` and
+`emb_ring_buffer.h`.
+
+```c
+#define EMB_PROFILE_FILE_MAGIC     0x454D422D50524F46ULL  // "EMB-PROF"; also an endianness marker
+#define EMB_PROFILE_FORMAT_VER     1u                     // this document
+#define EMB_PROFILE_FORMAT_INVALID 0u                     // "disregard this file" — see §5
+
+// Frozen identity — the LAST 16 bytes of the file. Same layout in every format version, forever.
+// Discovered via fstat + read(EOF − 16).
+typedef struct {
+    uint64_t magic;           // EMB_PROFILE_FILE_MAGIC
+    uint64_t format_version;  // selects the parser for everything else; 0 = disregard (§5)
+} emb_profile_ident_t;        // exactly 16 bytes, no padding — never change this layout
+
+// Version-1 trailer — sits immediately before the identity struct. May change in a future version;
+// a reader only parses it after the identity has told it the version is 1.
+typedef struct {
+    uint64_t footer_offset;        // == data_capacity; where the footer begins
+    uint64_t data_capacity;        // data region size in bytes (page-aligned)
+    uint32_t page_size;            // page size used at creation
+    uint16_t record_header_bytes;  // sizeof(record header); validated on recovery
+    uint16_t pointer_bytes;        // sizeof(uintptr_t) == 8
+    uint32_t footer_bytes;         // total footer size
+    uint32_t trailer_bytes;        // sizeof(this struct) for THIS version — lets a reader step back
+                                   // from the identity to the start of the v1 trailer
+} emb_profile_trailer_v1_t;
+
+// Write-once static descriptor — at the start of the metadata page.
+typedef struct {
+    uint64_t created_uptime_ns;    // CLOCK_MONOTONIC_RAW at creation
+    uint64_t created_wall_ns;      // wall clock at creation (session correlation)
+    uint8_t  session_id[16];       // opaque 128-bit id supplied by the caller
+    uint64_t image_table_offset;   // reserved; always 0 in v1 (§6)
+    uint64_t image_table_bytes;    // reserved; always 0 in v1 (§6)
+} emb_profile_descriptor_t;
+
+// Live control block — the first footer page (read/write for the whole session).
+typedef struct {
+    _Atomic uint64_t write_pos;    // monotonic write position (absolute byte counter)
+    _Atomic uint64_t oldest_pos;   // position of the oldest surviving record
+    uint64_t         next_seq;     // writer-local seqlock counter (single writer)
+    _Atomic uint32_t status_flags; // Reserved. Session lifecycle is signaled via format_version
+                                   // (§5), NOT here.
+} emb_ring_control_t;
+```
+
+**`trailer_bytes` vs `sizeof`:** the trailer records its own size so a *future* build reading a v1
+file knows the on-disk v1 trailer size without hardcoding it — `sizeof` in a newer build would be the
+newer struct's size. This is what lets the trailer grow in a later version without stranding old files.
+
+## 4. Record layout (the data region)
+
+The data region is **byte-for-byte the same record layout the in-memory ring buffer uses**, so the
+same reader walks both. Each record is a fixed 16-byte header followed by `frame_count` frame
+addresses (`uintptr_t`, 8 bytes each):
+
+```c
+typedef struct {
+    uint32_t seq;           // internal seqlock value (torn-read detection); ignore when reading
+    uint16_t frame_count;   // number of frames that follow (1 … EMB_MAX_STACK_FRAMES = 1024)
+    uint8_t  thread_state;  // main-thread run state at capture — see PROFILING-THREAD-STATE.md
+    uint8_t  flags;         // packed per-sample flags (idle / swapped / truncated) — internal in v1
+    uint64_t timestamp_ns;  // CLOCK_MONOTONIC_RAW timestamp
+} emb_ring_record_header_t;  // exactly 16 bytes
+
+record_size = sizeof(header) + frame_count * sizeof(uintptr_t)
+```
+
+`write_pos` and `oldest_pos` are **absolute monotonic byte counters** (they only ever grow); the
+byte offset of a record within the data region is `pos % data_capacity`. The data region is mapped
+twice back-to-back at runtime so a record that wraps past the end is still contiguous in memory. The
+`thread_state` and `flags` bytes are documented in
+[PROFILING-THREAD-STATE.md](PROFILING-THREAD-STATE.md).
+
+## 5. `format_version` as the validity marker
+
+`format_version` in the frozen identity doubles as the file's transactional validity / tombstone
+marker. **`0` (`EMB_PROFILE_FORMAT_INVALID`) is reserved forever to mean "disregard this file".** It
+is written in two situations:
+
+- **Transiently, while the file is mid-mutation** (during create, before the real version is
+  committed; and briefly during an in-place reset). The real version is committed *last*, so a crash
+  mid-mutation leaves `0` and the file is safely ignored rather than half-read.
+- **As the clean-shutdown tombstone.** When a session is stopped cleanly and its samples have already
+  been drained live, `finalizeStorage()` writes `0`. Recovery then reports the file as *finalized*
+  (nothing to recover). The file is **never deleted by the SDK** — the host app owns retention.
+
+So on recovery:
+
+| identity state | meaning | outcome |
+|---|---|---|
+| `magic` mismatch | not one of our files | skip / not ours |
+| `format_version == 0` | finalized or mid-mutation | nothing to recover (finalized) |
+| `format_version == 1` | a v1 file | parse and recover |
+| `format_version` other | written by a newer build | unsupported (kept, not parsed) |
+
+Because the identity layout is frozen, `0` means "ignore" regardless of any future format change, and
+a newer `format_version` can always be recognized (and preserved) by an older build even when it can't
+parse the contents.
+
+## 6. Recovery
+
+Recovery runs on the launch *after* the one that wrote the file — possibly after an SDK update — off
+the hot path. The sequence:
+
+1. `open` (with `O_NOFOLLOW`) + `fstat`; reject non-regular files.
+2. Read `emb_profile_ident_t` at `EOF − 16`; validate `magic`; dispatch on `format_version` (§5).
+3. For v1, read `emb_profile_trailer_v1_t` immediately before the identity and validate it:
+   `page_size`, `record_header_bytes`, `pointer_bytes` must match this build; `data_capacity` must be
+   non-zero, page-aligned, and consistent with the real file size (`data_capacity + footer_bytes ==
+   file_size`). Any mismatch → the file is treated as corrupt and discarded.
+4. Read `write_pos` / `oldest_pos` from the control block and validate them
+   (`oldest_pos <= write_pos` and `write_pos − oldest_pos <= data_capacity`). Inconsistent → discard.
+5. Walk records from `oldest_pos` toward `write_pos`, emitting each valid record.
+
+**Torn-tail tolerance.** A crash mid-write can leave one partially written record at the head of the
+ring. The walk stops cleanly at the first record that is:
+
+- **torn** — the seqlock value is odd (the writer died mid-record), or
+- an **unflushed / zeroed** slot — `frame_count == 0`, or
+- **garbage** — `frame_count > EMB_MAX_STACK_FRAMES`, or
+- an **overrun** — the record's size exceeds the committed span (`write_pos − pos`).
+
+Everything committed before that point is recovered; the partial tail is dropped. Comparing on the
+remaining span (`write_pos − pos`, a subtraction that cannot underflow) rather than `pos + size`
+avoids an integer-overflow edge case on a crafted file and keeps every read inside the double mapping.
+
+A cheap **peek** path (`emb_profile_peek`) reads only the 16-byte identity to classify a file as
+recoverable / finalized / not-ours without walking any records — this is what
+`ProfilingEngine.recoverableSessions(in:)` uses to enumerate a directory at launch.
+
+## 7. Runtime hardening (not on disk, but part of the integrity story)
+
+The footer is irreplaceable — corrupt the identity, trailer, or descriptor and the file becomes
+unrecoverable. Two hot-path-free defenses protect it against a runaway sequential write out of the
+data region:
+
+- **A guard page.** At runtime the reservation places an unmapped `PROT_NONE` page immediately after
+  the (double-mapped) data region, before the footer. A sequential overrun traps (`SIGSEGV`/`SIGBUS`)
+  before it can reach any metadata. This costs one page of address space, no RAM and no file bytes.
+- **Write-once pages made read-only.** After the descriptor / trailer / identity are written at
+  create time, the metadata page is dropped to read-only (`mprotect(PROT_READ)`), so any stray store
+  into it faults immediately. The control page stays writable (it is updated every sample).
+
+Converting silent footer corruption into an immediate fault is a net win: the on-disk metadata stays
+intact (the file stays recoverable), every sample written before the runaway survives, and the fault
+itself is a crash the next launch recovers from.
+
+## 8. Where the files live & data protection
+
+- The **directory is provided by the caller** (`ProfilingEngine.start(directory:)`); the profiling
+  module does no path policy of its own. There is **one file per session**, named
+  `<session-id-hex>.embprof` (the 16-byte session id rendered as 32 hex characters). The active
+  session's file belongs to the current process; any *other* `.embprof` file present at launch is a
+  previous session that may be recoverable.
+- **iOS data protection:** on data-protection platforms the file is created with protection class B
+  (`NSFileProtectionCompleteUnlessOpen`), so an open file keeps accepting writes while the device is
+  locked (the SDK holds it open for the whole session). Without this, late samples would be lost when
+  the screen locks. This is not applied on macOS.
+
+## 9. Versioning & forward-compatibility
+
+Recovery can happen after an SDK update, so forward-compatibility is built in:
+
+- The frozen 16-byte identity is found independently of capacity or format growth and names
+  `format_version` **before** any version-dependent layout is parsed.
+- Everything else — trailer, descriptor, control block — is parsed by the version-specific parser
+  selected from that one field, so any of those may change layout in a future version without
+  breaking an older reader's ability to *recognize* the file and pick a parser (or to safely skip a
+  file written by a newer build).
+- `record_header_bytes`, `pointer_bytes`, `page_size`, and `data_capacity` are all validated on
+  recovery, so a file that doesn't match this build's assumptions is rejected rather than misread.
+
+## Appendix: reserved for future versions
+
+The descriptor carries `image_table_offset` / `image_table_bytes`, both **0 in v1**. They reserve
+space for an optional per-file **image table** (binary UUID + load address + path) that would let a
+recovered session be symbolicated entirely from its own file, without correlating against the live
+process's image list. v1 emits raw return addresses plus the `session_id`; symbolication of recovered
+samples is handled by the host SDK using its per-session image list. Because the format is
+tail-versioned, an image table can be added later without a breaking format change.

--- a/Sources/EmbraceProfilingSampler/PROFILING-THREAD-STATE.md
+++ b/Sources/EmbraceProfilingSampler/PROFILING-THREAD-STATE.md
@@ -1,0 +1,88 @@
+# EmbraceProfiling — per-sample thread run state
+
+Every profiling sample records the **run state of the main thread** at the moment of capture —
+running vs. blocked/waiting. This is what lets a flame graph separate genuine on-CPU hotspots from
+off-CPU (blocked or idle) stacks, which is the signal that makes the data useful for hang detection.
+
+The run state occupies the `thread_state` byte of each record header (see
+[PROFILING-DISK-FORMAT.md](PROFILING-DISK-FORMAT.md) §4); the adjacent `flags` byte carries a few
+per-sample flags.
+
+## 1. Source of the value
+
+The run state comes from Mach's `thread_info` (**not** `thread_get_state`, which returns register
+state — that is what the stack walker uses):
+
+```c
+thread_basic_info_data_t info;
+mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+kern_return_t kr = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t)&info, &count);
+// info.run_state ∈ { TH_STATE_RUNNING(1), TH_STATE_STOPPED(2), TH_STATE_WAITING(3),
+//                     TH_STATE_UNINTERRUPTIBLE(4), TH_STATE_HALTED(5) }
+```
+
+For the main thread the meaningful distinction is **RUNNING** (on-CPU work) vs. **WAITING** (blocked
+on a lock or I/O, or idle in the runloop's `mach_msg`).
+
+## 2. Captured *before* the thread is suspended
+
+The sampler captures `thread_info` in the pre-suspend window (where it already reads the stack
+bounds), **not** inside the suspended window, for two reasons:
+
+1. **It reads the genuinely-running state.** A thread we have suspended has `suspend_count ≥ 1`;
+   whether `thread_suspend` also perturbs `run_state` is an XNU internal we don't want to depend on.
+   Reading before suspend captures the running thread's state unambiguously.
+2. **`thread_info` is a `mach_msg` RPC, not a cheap trap.** It is not async-signal-safe and, as a
+   kernel round-trip, would lengthen the main-thread suspension if run inside the window. Capturing
+   it before suspend, on the sampler's own thread, keeps the suspended window microsecond-short.
+
+The trade-off is a tiny race (`thread_info` → suspend, on the order of microseconds) in which the
+thread could change state — irrelevant for a coarse RUNNING/WAITING signal that changes on
+millisecond scales.
+
+## 3. On-disk enum
+
+The stored byte mirrors the Mach `TH_STATE_*` constants exactly, so the captured `run_state` is
+stored directly with no translation:
+
+```c
+typedef enum {                                   // fits in uint8_t
+    EMB_THREAD_RUN_STATE_RUNNING         = 1,    // == TH_STATE_RUNNING
+    EMB_THREAD_RUN_STATE_STOPPED         = 2,    // == TH_STATE_STOPPED
+    EMB_THREAD_RUN_STATE_WAITING         = 3,    // == TH_STATE_WAITING
+    EMB_THREAD_RUN_STATE_UNINTERRUPTIBLE = 4,    // == TH_STATE_UNINTERRUPTIBLE
+    EMB_THREAD_RUN_STATE_HALTED          = 5,    // == TH_STATE_HALTED
+    EMB_THREAD_RUN_STATE_UNKNOWN         = 255,  // thread_info failed / not captured
+} emb_thread_run_state_t;
+```
+
+A `_Static_assert` in `emb_ring_buffer.h` locks these values to the Mach constants so a future header
+change can't silently desync them. `UNKNOWN = 255` is a value Mach never returns; it means "couldn't
+capture." If a future OS returns a `run_state` outside the known set, it is stored **raw** (still
+forward-compatible), and the Swift side maps any unrecognized value to `.unknown`.
+
+On the Swift side this surfaces as `ProfilingSample.threadState`:
+
+```swift
+public enum ThreadState: UInt8, Sendable {
+    case running = 1, stopped = 2, waiting = 3, uninterruptible = 4, halted = 5, unknown = 255
+}
+```
+
+The Swift enum and the C enum independently mirror `TH_STATE_*`; the raw values are the shared source
+of truth. (A test anchoring the Swift enum to the Mach constants keeps the two from drifting.)
+
+## 4. The `flags` byte
+
+The header's `flags` byte is **the SDK's own packed layout, not a raw copy of Mach's `info.flags`** —
+the bit positions are reassigned and one non-Mach flag (`truncated`) is added:
+
+| bit | meaning | source |
+|---|---|---|
+| 0 | idle | `TH_FLAGS_IDLE` |
+| 1 | swapped | `TH_FLAGS_SWAPPED` |
+| 2 | truncated | stack exceeded `max_frames` during the walk |
+| 3–7 | reserved (0) | — |
+
+In v1 these flags are **internal** — they are stored in the record but not surfaced in the public
+Swift API, which exposes `threadState` only.

--- a/Sources/EmbraceProfilingSampler/include/EmbraceProfilingSampler.h
+++ b/Sources/EmbraceProfilingSampler/include/EmbraceProfilingSampler.h
@@ -8,5 +8,6 @@
 #include "emb_ring_buffer.h"
 #include "emb_stack_walker.h"
 #include "emb_sampler.h"
+#include "emb_profile_store.h"
 
 #endif /* EmbraceProfilingSampler_h */

--- a/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
@@ -152,10 +152,14 @@ typedef void (*emb_profile_record_cb)(void *ctx,
 /// (frame_count == 0), garbage (frame_count > MAX), or a record overrunning committed data.
 /// Each valid record is delivered via `emit`.
 ///
+/// @param errno_out On an `EMB_PROFILE_RECOVER_IO_ERROR` result, receives the `errno` that caused it,
+///                   or 0 if the failure set none. 0 for every other result. May be NULL.
+///
 /// NOT async-safe. Intended to run off the main thread at launch.
 emb_profile_recover_status_t emb_profile_recover(const char *path,
                                                  emb_profile_record_cb emit,
-                                                 void *ctx);
+                                                 void *ctx,
+                                                 int *errno_out);
 
 /// Classification of a file from a cheap peek at its frozen identity only (no record walk).
 typedef enum {

--- a/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
@@ -1,0 +1,167 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+/// File-backed persistence for the profiling ring buffer.
+///
+/// `emb_profile_store` owns a per-session file and the memory mapping over it, and
+/// hands back an `emb_ring_buffer_t` (via `emb_ring_buffer_attach`) wired to the
+/// mapped data region + a mapped footer control block. The sampler writes into that
+/// ring buffer exactly as it does for an in-memory buffer; the kernel flushes the
+/// dirty `MAP_SHARED` pages to the file, so samples survive abrupt process death and
+/// can be recovered on the next launch.
+///
+/// See `design/PROFILING-DISK-FORMAT.md` for the on-disk format. Recovery (reading a
+/// previous session's file) lives in this unit too (added in a later step); creation
+/// and the live write path are here.
+///
+/// NONE of this is async-safe — create/destroy/recovery all run off the hot path.
+
+#ifndef emb_profile_store_h
+#define emb_profile_store_h
+
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "emb_ring_buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EMB_PROFILE_FILE_MAGIC 0x454D422D50524F46ULL  // "EMB-PROF" — version-free, also an endianness marker
+#define EMB_PROFILE_FORMAT_VER 1u                      // first real version
+// format_version == 0 is RESERVED FOREVER as "disregard this file": written transiently while a file is
+// mid-mutation (create/reset) and as the clean-shutdown / finalized tombstone. Because the identity
+// layout is frozen, version 0 means "ignore" regardless of any future format change.
+#define EMB_PROFILE_FORMAT_INVALID 0u
+
+/// Write-once static descriptor (written at create).
+typedef struct {
+    uint64_t created_uptime_ns;   // CLOCK_MONOTONIC_RAW at creation
+    uint64_t created_wall_ns;     // wall clock at creation (session correlation)
+    uint8_t  session_id[16];      // opaque 128-bit id supplied by the caller
+    uint64_t image_table_offset;  // 0 if absent (always 0 in v1)
+    uint64_t image_table_bytes;   // 0 if absent (always 0 in v1)
+} emb_profile_descriptor_t;
+
+/// FROZEN identity — the LAST bytes of the file. Same layout in every format version, forever.
+/// Discovered via fstat + read(EOF − sizeof(emb_profile_ident_t)).
+typedef struct {
+    uint64_t magic;           // EMB_PROFILE_FILE_MAGIC
+    uint64_t format_version;  // selects the parser for everything else; 0 = "disregard this file"
+} emb_profile_ident_t;
+_Static_assert(sizeof(emb_profile_ident_t) == 16, "frozen identity must stay 16 bytes, forever");
+
+/// Version-specific trailer — sits immediately before the identity struct. v1 layout.
+typedef struct {
+    uint64_t footer_offset;       // == data_capacity; where the footer begins
+    uint64_t data_capacity;       // ring data region size in bytes (page-aligned)
+    uint32_t page_size;           // page size used at creation
+    uint16_t record_header_bytes; // sizeof(emb_ring_record_header_t), validated on recovery
+    uint16_t pointer_bytes;       // sizeof(uintptr_t) == 8
+    uint32_t footer_bytes;        // total footer size
+    uint32_t trailer_bytes;       // sizeof(this struct) for THIS version
+} emb_profile_trailer_v1_t;
+
+/// Opaque store handle. Owns the fd, the address-space reservation/mapping, the mapped
+/// control block, and the attached ring buffer.
+typedef struct emb_profile_store emb_profile_store_t;
+
+/// Create a fresh file-backed store at `path` (the caller-injected directory must already
+/// exist; the file is created/truncated). On success, returns a store whose ring buffer
+/// (`emb_profile_store_buffer`) is ready for the sampler.
+///
+/// @param path          Filesystem path for this session's file.
+/// @param capacity_bytes Minimum data-region capacity; rounded up to a page boundary.
+/// @param session_id    Opaque 128-bit session id recorded in the descriptor.
+/// @param errno_out     On failure, receives `errno` (or 0 for a non-errno failure). May be NULL.
+/// @return A new store, or NULL on failure.
+emb_profile_store_t *emb_profile_store_create(const char *path,
+                                              size_t capacity_bytes,
+                                              const uint8_t session_id[16],
+                                              int *errno_out);
+
+/// The ring buffer wired to this store's mapped data region. Owned by the store; do not
+/// destroy it directly — use `emb_profile_store_destroy`.
+emb_ring_buffer_t *emb_profile_store_buffer(emb_profile_store_t *store);
+
+/// Clear the buffer for reuse within the same process (e.g. a same-capacity restart),
+/// reusing the same file. Transactional: format_version → 0, memset the data region +
+/// reset positions, format_version → 1. A crash mid-reset leaves version 0 so recovery
+/// disregards the half-cleared file. Returns false if a concurrent reader blocked the
+/// reset (the file is left intact and valid). NOT async-safe.
+bool emb_profile_store_reset(emb_profile_store_t *store);
+
+/// Mark the file cleanly finalized: write the format_version → 0 tombstone, so recovery
+/// reports nothing for it (its samples were already drained live). Does not delete the
+/// file (Embrace owns deletion). Call after the writer has stopped. NOT async-safe.
+void emb_profile_store_finalize(emb_profile_store_t *store);
+
+/// `msync(MS_ASYNC)` the mapped data + footer, so samples are durable before a possible
+/// background Jetsam kill. Cheap, non-blocking, off the hot path. NOT async-safe (call from
+/// the main/notification thread on background/terminate).
+void emb_profile_store_flush(emb_profile_store_t *store);
+
+/// Tear down the store: destroy the ring buffer wrapper, unmap the reservation, close the
+/// file. Does not delete the file (Embrace owns deletion). Safe to call with NULL.
+void emb_profile_store_destroy(emb_profile_store_t *store);
+
+// MARK: - Recovery (read-only)
+
+/// Outcome of attempting to recover a previous session's file.
+typedef enum {
+    EMB_PROFILE_RECOVER_OK = 0,        // parsed; `emit` was invoked once per recovered record
+    EMB_PROFILE_RECOVER_FINALIZED,     // cleanly finalized (format_version 0) — nothing to recover
+    EMB_PROFILE_RECOVER_NOT_OURS,      // magic mismatch — not one of our files
+    EMB_PROFILE_RECOVER_UNSUPPORTED,   // format_version this build doesn't understand
+    EMB_PROFILE_RECOVER_CORRUPT,       // trailer / control-block validation failed → discard
+    EMB_PROFILE_RECOVER_IO_ERROR,      // open / fstat / read / mmap failed
+} emb_profile_recover_status_t;
+
+/// Callback invoked once per recovered record, in chronological order.
+/// `frames` points into a temporary mapping valid only for the duration of the call —
+/// copy what you need; do not retain it.
+typedef void (*emb_profile_record_cb)(void *ctx,
+                                      uint64_t timestamp_ns,
+                                      uint8_t thread_state,
+                                      uint8_t flags,
+                                      const uintptr_t *frames,
+                                      uint32_t frame_count);
+
+/// Recover a previous session's file. **Strictly read-only** — never writes, tombstones, or
+/// deletes the file (Embrace owns deletion). Reads the frozen identity (version gate: 0 →
+/// FINALIZED, unknown → NOT_OURS/UNSUPPORTED), validates the v1 trailer and control block
+/// (discard on inconsistency), then double-maps the data region and walks records from
+/// oldest_pos to write_pos — stopping on a torn tail (odd seq), a zeroed/unflushed page
+/// (frame_count == 0), garbage (frame_count > MAX), or a record overrunning committed data.
+/// Each valid record is delivered via `emit`.
+///
+/// NOT async-safe. Intended to run off the main thread at launch.
+emb_profile_recover_status_t emb_profile_recover(const char *path,
+                                                 emb_profile_record_cb emit,
+                                                 void *ctx);
+
+/// Classification of a file from a cheap peek at its frozen identity only (no record walk).
+typedef enum {
+    EMB_PROFILE_PEEK_RECOVERABLE = 0,  // ours, format_version != 0 — has (or may have) records
+    EMB_PROFILE_PEEK_FINALIZED,        // ours, format_version 0 — cleanly stopped, nothing to recover
+    EMB_PROFILE_PEEK_NOT_OURS,         // not a regular file / magic mismatch / unreadable
+} emb_profile_peek_status_t;
+
+/// Cheaply classify a candidate file by reading ONLY the 16-byte frozen identity at EOF (open +
+/// fstat + one pread). Lets a caller enumerate a directory and decide what to recover/delete without
+/// mapping or walking any records. Read-only; never modifies the file. NOT async-safe.
+emb_profile_peek_status_t emb_profile_peek(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !TARGET_OS_WATCH */
+
+#endif /* emb_profile_store_h */

--- a/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
@@ -11,7 +11,7 @@
 /// dirty `MAP_SHARED` pages to the file, so samples survive abrupt process death and
 /// can be recovered on the next launch.
 ///
-/// See `design/PROFILING-DISK-FORMAT.md` for the on-disk format. Recovery (reading a
+/// See `PROFILING-DISK-FORMAT.md` for the on-disk format. Recovery (reading a
 /// previous session's file) lives in this unit too (added in a later step); creation
 /// and the live write path are here.
 ///
@@ -45,12 +45,14 @@ typedef struct {
     uint64_t created_uptime_ns;   // CLOCK_MONOTONIC_RAW at creation
     uint64_t created_wall_ns;     // wall clock at creation (session correlation)
     uint8_t  session_id[16];      // opaque 128-bit id supplied by the caller
-    uint64_t image_table_offset;  // 0 if absent (always 0 in v1)
-    uint64_t image_table_bytes;   // 0 if absent (always 0 in v1)
+    uint64_t image_table_offset;  // reserved for a future image table (symbolication); always 0 in v1
+    uint64_t image_table_bytes;   // reserved; always 0 in v1 (see PROFILING-DISK-FORMAT.md appendix)
 } emb_profile_descriptor_t;
 
 /// FROZEN identity — the LAST bytes of the file. Same layout in every format version, forever.
-/// Discovered via fstat + read(EOF − sizeof(emb_profile_ident_t)).
+/// Discovered via fstat + read(EOF − sizeof(emb_profile_ident_t)) — placing it at EOF (not the front)
+/// lets a reader find it without knowing the file's size or format version first, so any other field
+/// can grow or move between versions (see PROFILING-DISK-FORMAT.md §2.1).
 typedef struct {
     uint64_t magic;           // EMB_PROFILE_FILE_MAGIC
     uint64_t format_version;  // selects the parser for everything else; 0 = "disregard this file"
@@ -65,7 +67,8 @@ typedef struct {
     uint16_t record_header_bytes; // sizeof(emb_ring_record_header_t), validated on recovery
     uint16_t pointer_bytes;       // sizeof(uintptr_t) == 8
     uint32_t footer_bytes;        // total footer size
-    uint32_t trailer_bytes;       // sizeof(this struct) for THIS version
+    uint32_t trailer_bytes;       // on-disk size of THIS version's trailer, so a newer build can step
+                                  // back from the identity to it without assuming its own sizeof
 } emb_profile_trailer_v1_t;
 
 /// Opaque store handle. Owns the fd, the address-space reservation/mapping, the mapped
@@ -108,7 +111,9 @@ void emb_profile_store_finalize(emb_profile_store_t *store);
 void emb_profile_store_flush(emb_profile_store_t *store);
 
 /// Tear down the store: destroy the ring buffer wrapper, unmap the reservation, close the
-/// file. Does not delete the file (Embrace owns deletion). Safe to call with NULL.
+/// file. Does not delete the file (Embrace owns deletion), and does not itself force a sync — the
+/// kernel writes back the MAP_SHARED pages; call `emb_profile_store_flush` first if you need samples
+/// durable before an imminent abrupt exit. Safe to call with NULL.
 void emb_profile_store_destroy(emb_profile_store_t *store);
 
 // MARK: - Recovery (read-only)
@@ -150,12 +155,18 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
 typedef enum {
     EMB_PROFILE_PEEK_RECOVERABLE = 0,  // ours, format_version != 0 — has (or may have) records
     EMB_PROFILE_PEEK_FINALIZED,        // ours, format_version 0 — cleanly stopped, nothing to recover
-    EMB_PROFILE_PEEK_NOT_OURS,         // not a regular file / magic mismatch / unreadable
+    EMB_PROFILE_PEEK_NOT_OURS,         // a readable regular file whose magic doesn't match — not ours
+    EMB_PROFILE_PEEK_INDETERMINATE,    // couldn't open/stat/read (e.g. locked under data protection at
+                                       // launch, or a transient I/O error) — may be ours; retry later
 } emb_profile_peek_status_t;
 
 /// Cheaply classify a candidate file by reading ONLY the 16-byte frozen identity at EOF (open +
 /// fstat + one pread). Lets a caller enumerate a directory and decide what to recover/delete without
 /// mapping or walking any records. Read-only; never modifies the file. NOT async-safe.
+///
+/// A file that can't be opened/stat'd/read returns INDETERMINATE (not NOT_OURS): it may be one of ours
+/// that is temporarily unreadable (e.g. still locked under data protection at launch), so the caller
+/// should retry it on a later launch rather than discard it. Retries EINTR internally.
 emb_profile_peek_status_t emb_profile_peek(const char *path);
 
 #ifdef __cplusplus

--- a/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_profile_store.h
@@ -105,15 +105,21 @@ bool emb_profile_store_reset(emb_profile_store_t *store);
 /// file (Embrace owns deletion). Call after the writer has stopped. NOT async-safe.
 void emb_profile_store_finalize(emb_profile_store_t *store);
 
-/// `msync(MS_ASYNC)` the mapped data + footer, so samples are durable before a possible
-/// background Jetsam kill. Cheap, non-blocking, off the hot path. NOT async-safe (call from
-/// the main/notification thread on background/terminate).
+/// `msync(MS_ASYNC)` the mapped data + footer. Not needed to survive process death (crash, Jetsam
+/// kill) — the kernel's page cache owns the dirty `MAP_SHARED` pages independent of the process and
+/// writes them back regardless. Call this from willResignActive/didEnterBackground/willTerminate to
+/// also protect against uncontrolled terminations such as power loss / kernel panic while the app is
+/// suspended, by narrowing the window recently-captured samples sit unwritten in memory. Cheap,
+/// non-blocking, off the hot path. NOT async-safe (call from the main/notification thread on
+/// background/terminate).
 void emb_profile_store_flush(emb_profile_store_t *store);
 
 /// Tear down the store: destroy the ring buffer wrapper, unmap the reservation, close the
 /// file. Does not delete the file (Embrace owns deletion), and does not itself force a sync — the
-/// kernel writes back the MAP_SHARED pages; call `emb_profile_store_flush` first if you need samples
-/// durable before an imminent abrupt exit. Safe to call with NULL.
+/// kernel writes back the MAP_SHARED pages regardless of process death. Call `emb_profile_store_flush`
+/// from willResignActive/didEnterBackground/willTerminate beforehand to also protect against
+/// uncontrolled terminations such as power loss / kernel panic while the app is suspended. Safe to
+/// call with NULL.
 void emb_profile_store_destroy(emb_profile_store_t *store);
 
 // MARK: - Recovery (read-only)

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -34,6 +34,7 @@
 #if !TARGET_OS_WATCH
 
 #include <mach/kern_return.h>
+#include <mach/thread_info.h>
 #include <stdbool.h>
 #include <stdatomic.h>
 #include <stddef.h>
@@ -60,18 +61,62 @@ typedef enum {
 extern "C" {
 #endif
 
+/// Control block holding the writer/reader positions. Relocated out of
+/// emb_ring_buffer_t so it can be backed either by a small anonymous allocation
+/// (in-memory buffers) or by a file-backed mapped footer page (persistent buffers,
+/// PROFILING-DISK-FORMAT.md §3.1) — the same struct, only the backing differs.
+typedef struct {
+    _Atomic uint64_t write_pos;  // Monotonically increasing write position.
+    _Atomic uint64_t oldest_pos; // Position of the oldest surviving record.
+    uint64_t next_seq;           // Writer-local seqlock counter (single-writer).
+    _Atomic uint32_t status_flags; // Reserved (file-backed lifecycle is signaled via the footer
+                                 // format_version, not here — PROFILING-DISK-FORMAT.md §8).
+} emb_ring_control_t;
+
 typedef struct {
     uint8_t *data;               // Double-mapped virtual region (2 × capacity).
     size_t capacity;             // Usable buffer size in bytes (page-aligned).
-    uint64_t next_seq;           // Writer-local seqlock counter (single-writer).
-    _Atomic uint64_t write_pos;  // Monotonically increasing write position.
-    _Atomic uint64_t oldest_pos; // Position of the oldest surviving record.
+    emb_ring_control_t *control; // write_pos / oldest_pos / next_seq (anon- or file-backed).
+    bool owns_resources;         // true: this buffer owns `data` (vm) and `control` (heap) and frees
+                                 // them on destroy. false: a file-backed store owns the mapping.
     _Atomic uint32_t active_readers; // Number of concurrent read_range calls (for reset safety).
     _Atomic bool resetting;      // True while reset is in progress.
                                  // Uses Dekker-style mutual exclusion with active_readers:
                                  // both sides use seq_cst to prevent ARM64 store-buffer
                                  // reordering. See emb_ring_buffer_reset and read_range.
 } emb_ring_buffer_t;
+
+/// Hard upper limit on stack frames per sample. Defined here (not in emb_sampler.h)
+/// because the ring write path validates `frame_count` against it; emb_sampler.h
+/// includes this header and consumes the value from here.
+#define EMB_MAX_STACK_FRAMES 1024
+
+/// Main-thread run state captured per sample (see THREAD-STATE.md). Values mirror
+/// the Mach `TH_STATE_*` constants so the stored byte equals
+/// `thread_basic_info.run_state`. 255 = "couldn't capture" — Mach never returns it.
+typedef enum {
+    EMB_THREAD_RUN_STATE_RUNNING         = 1,   // == TH_STATE_RUNNING
+    EMB_THREAD_RUN_STATE_STOPPED         = 2,   // == TH_STATE_STOPPED
+    EMB_THREAD_RUN_STATE_WAITING         = 3,   // == TH_STATE_WAITING
+    EMB_THREAD_RUN_STATE_UNINTERRUPTIBLE = 4,   // == TH_STATE_UNINTERRUPTIBLE
+    EMB_THREAD_RUN_STATE_HALTED          = 5,   // == TH_STATE_HALTED
+    EMB_THREAD_RUN_STATE_UNKNOWN         = 255,  // thread_info failed / not captured
+} emb_thread_run_state_t;
+_Static_assert(EMB_THREAD_RUN_STATE_RUNNING == TH_STATE_RUNNING
+            && EMB_THREAD_RUN_STATE_STOPPED == TH_STATE_STOPPED
+            && EMB_THREAD_RUN_STATE_WAITING == TH_STATE_WAITING
+            && EMB_THREAD_RUN_STATE_UNINTERRUPTIBLE == TH_STATE_UNINTERRUPTIBLE
+            && EMB_THREAD_RUN_STATE_HALTED == TH_STATE_HALTED,
+            "emb_thread_run_state_t must mirror TH_STATE_*");
+
+/// Per-sample flag bits packed into the record header's `flags` byte. This is OUR
+/// own layout, NOT raw `thread_basic_info.flags`: idle/swapped are remapped to
+/// these bit positions and `truncated` is not a Mach flag.
+enum {
+    EMB_RECORD_FLAG_IDLE      = 1u << 0,  // thread is an idle thread   (from TH_FLAGS_IDLE)
+    EMB_RECORD_FLAG_SWAPPED   = 1u << 1,  // thread is swapped out       (from TH_FLAGS_SWAPPED)
+    EMB_RECORD_FLAG_TRUNCATED = 1u << 2,  // stack exceeded max_frames
+};
 
 /// Public facing view of the record header stored in the ring buffer.
 /// We do this to simplify reading the records. It's expected that the caller would
@@ -84,9 +129,11 @@ typedef struct {
 /// The `seq` field is an internal seqlock value used for torn-read detection,
 /// and callers should ignore it.
 typedef struct {
-    uint32_t seq;          // Internal seqlock value (ignore).
-    uint32_t frame_count;  // Number of frames following this header.
-    uint64_t timestamp_ns; // Monotonic timestamp (nanoseconds).
+    uint32_t seq;           // Internal seqlock value (ignore).
+    uint16_t frame_count;   // Number of frames following this header (1..EMB_MAX_STACK_FRAMES).
+    uint8_t  thread_state;  // emb_thread_run_state_t at capture time.
+    uint8_t  flags;         // EMB_RECORD_FLAG_* bits (our packed layout).
+    uint64_t timestamp_ns;  // Monotonic timestamp (nanoseconds).
 } emb_ring_record_header_t;
 
 // The record layout assumes 64-bit pointers (uintptr_t == 8 bytes).
@@ -94,6 +141,11 @@ typedef struct {
 // Catch any hypothetical 32-bit platform at compile time.
 _Static_assert(sizeof(uintptr_t) == 8,
                "Ring buffer record layout requires 64-bit pointers");
+// The header must stay exactly 16 bytes: seq(4) + frame_count(2) + thread_state(1)
+// + flags(1) + timestamp_ns(8). The on-disk format (PROFILING-DISK-FORMAT.md §3.2)
+// mirrors this byte-for-byte and the trailer records sizeof() for recovery.
+_Static_assert(sizeof(emb_ring_record_header_t) == 16,
+               "Ring buffer record header must stay 16 bytes");
 
 /// Compute the total byte size of a record with the given frame count.
 static inline size_t emb_ring_record_size(uint32_t frame_count) {
@@ -116,6 +168,25 @@ typedef struct {
 /// @param kr_out  On failure, receives the kern_return_t that caused the error. May be NULL.
 /// @return A newly allocated buffer, or NULL on failure.
 emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes, kern_return_t *kr_out);
+
+/// Create a ring buffer over caller-provided, externally-owned backing memory.
+///
+/// Used by `emb_profile_store` for file-backed buffers: the store builds the
+/// double-mapped file region and the (mapped) control block, then attaches a ring
+/// buffer over them. The returned buffer has `owns_resources == false`, so
+/// `emb_ring_buffer_destroy` frees only the wrapper — never `data` or `control`
+/// (the store owns and unmaps those).
+///
+/// This function does NOT modify `*control` — the caller sets the positions (0 for
+/// a freshly truncated file; the persisted values for recovery).
+///
+/// This function is NOT async-safe.
+///
+/// @param data     Double-mapped region of 2×capacity bytes (lower half + aliased upper half).
+/// @param capacity Page-aligned usable capacity in bytes (the data region size).
+/// @param control  Caller-owned control block (anon or mapped).
+/// @return A newly allocated buffer wrapper, or NULL on bad args / allocation failure.
+emb_ring_buffer_t *emb_ring_buffer_attach(uint8_t *data, size_t capacity, emb_ring_control_t *control);
 
 /// Destroy a ring buffer and release all VM and heap resources.
 ///
@@ -157,15 +228,20 @@ size_t emb_ring_buffer_capacity(const emb_ring_buffer_t *buf);
 /// @param buf The ring buffer.
 /// @param timestamp_ns Monotonic timestamp (nanoseconds).
 /// @param frames Array of frame addresses to copy.
-/// @param frame_count Number of frames in the array. Must not exceed UINT32_MAX.
-/// @return EMB_RING_WRITE_OK on success; EMB_RING_WRITE_BAD_ARGS if buf or frames is NULL or
-///         frame_count exceeds UINT32_MAX; EMB_RING_WRITE_RECORD_TOO_LARGE if the record does
-///         not fit in the buffer; EMB_RING_WRITE_CORRUPTION_DETECTED if a corrupted header was
-///         found during eviction.
+/// @param frame_count Number of frames in the array. Stored as uint16, so must not exceed
+///        UINT16_MAX. (The sampler, sole writer of persisted buffers, writes 1..EMB_MAX_STACK_FRAMES.)
+/// @param thread_state emb_thread_run_state_t for the sampled thread at capture time.
+/// @param flags EMB_RECORD_FLAG_* bits for this sample.
+/// @return EMB_RING_WRITE_OK on success; EMB_RING_WRITE_BAD_ARGS if buf is NULL, frames is NULL with
+///         a non-zero frame_count, or frame_count exceeds UINT16_MAX; EMB_RING_WRITE_RECORD_TOO_LARGE
+///         if the record does not fit in the buffer; EMB_RING_WRITE_CORRUPTION_DETECTED if a corrupted
+///         header was found during eviction.
 emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
                                                uint64_t timestamp_ns,
                                                const uintptr_t *frames,
-                                               size_t frame_count);
+                                               size_t frame_count,
+                                               uint8_t thread_state,
+                                               uint8_t flags);
 
 /// Read records from the ring buffer within a time range.
 ///

--- a/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_ring_buffer.h
@@ -64,13 +64,13 @@ extern "C" {
 /// Control block holding the writer/reader positions. Relocated out of
 /// emb_ring_buffer_t so it can be backed either by a small anonymous allocation
 /// (in-memory buffers) or by a file-backed mapped footer page (persistent buffers,
-/// PROFILING-DISK-FORMAT.md §3.1) — the same struct, only the backing differs.
+/// PROFILING-DISK-FORMAT.md §3) — the same struct, only the backing differs.
 typedef struct {
     _Atomic uint64_t write_pos;  // Monotonically increasing write position.
     _Atomic uint64_t oldest_pos; // Position of the oldest surviving record.
     uint64_t next_seq;           // Writer-local seqlock counter (single-writer).
     _Atomic uint32_t status_flags; // Reserved (file-backed lifecycle is signaled via the footer
-                                 // format_version, not here — PROFILING-DISK-FORMAT.md §8).
+                                 // format_version, not here — PROFILING-DISK-FORMAT.md §5).
 } emb_ring_control_t;
 
 typedef struct {
@@ -91,7 +91,7 @@ typedef struct {
 /// includes this header and consumes the value from here.
 #define EMB_MAX_STACK_FRAMES 1024
 
-/// Main-thread run state captured per sample (see THREAD-STATE.md). Values mirror
+/// Main-thread run state captured per sample (see PROFILING-THREAD-STATE.md). Values mirror
 /// the Mach `TH_STATE_*` constants so the stored byte equals
 /// `thread_basic_info.run_state`. 255 = "couldn't capture" — Mach never returns it.
 typedef enum {
@@ -142,7 +142,7 @@ typedef struct {
 _Static_assert(sizeof(uintptr_t) == 8,
                "Ring buffer record layout requires 64-bit pointers");
 // The header must stay exactly 16 bytes: seq(4) + frame_count(2) + thread_state(1)
-// + flags(1) + timestamp_ns(8). The on-disk format (PROFILING-DISK-FORMAT.md §3.2)
+// + flags(1) + timestamp_ns(8). The on-disk format (PROFILING-DISK-FORMAT.md §4)
 // mirrors this byte-for-byte and the trailer records sizeof() for recovery.
 _Static_assert(sizeof(emb_ring_record_header_t) == 16,
                "Ring buffer record header must stay 16 bytes");

--- a/Sources/EmbraceProfilingSampler/include/emb_sampler.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_sampler.h
@@ -59,9 +59,6 @@
 extern "C" {
 #endif
 
-// EMB_MAX_STACK_FRAMES is defined in emb_ring_buffer.h (included above) — the ring
-// write path validates against it, so it lives at that layer and is consumed here.
-
 /// Sampler lifecycle states.
 ///
 /// Transitions:

--- a/Sources/EmbraceProfilingSampler/include/emb_sampler.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_sampler.h
@@ -59,8 +59,8 @@
 extern "C" {
 #endif
 
-/// Hard upper limit on stack frames per sample.
-#define EMB_MAX_STACK_FRAMES 1024
+// EMB_MAX_STACK_FRAMES is defined in emb_ring_buffer.h (included above) — the ring
+// write path validates against it, so it lives at that layer and is consumed here.
 
 /// Sampler lifecycle states.
 ///

--- a/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
+++ b/Sources/EmbraceProfilingSampler/include/emb_stack_walker.h
@@ -56,13 +56,17 @@ extern "C" {
 /// @param frames_out   Output buffer for frame addresses.
 /// @param max_frames   Capacity of frames_out.
 /// @param count_out    On return, the number of frames captured.
+/// @param is_truncated Optional (may be NULL). On return, true if the walk stopped
+///                     because `max_frames` was reached while the chain still had
+///                     at least one more frame.
 /// @return true on success, false on failure.
 bool emb_stack_walk(thread_t thread,
                     const void *stack_bottom,
                     const void *stack_top,
                     uintptr_t *frames_out,
                     size_t max_frames,
-                    size_t *count_out);
+                    size_t *count_out,
+                    bool *is_truncated);
 
 #ifdef __cplusplus
 }

--- a/Sources/EmbraceProfilingSampler/source/emb_profile_store.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_profile_store.c
@@ -1,0 +1,350 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#include "emb_profile_store.h"
+
+#if !TARGET_OS_WATCH
+
+#include <errno.h>
+#include <fcntl.h>
+#include <mach/mach.h>     // vm_page_size
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+// Data-protection Class B == NSFileProtectionCompleteUnlessOpen. The protection-class enum constants
+// (PROTECTION_CLASS_*) are NOT exported by the public SDK headers — only F_SETPROTECTIONCLASS is — so
+// we use the documented integer value directly.
+#define EMB_PROTECTION_CLASS_B 2
+
+struct emb_profile_store {
+    int fd;
+    void *base;               // base of the address-space reservation
+    size_t reserve_size;      // total reserved bytes (for munmap)
+    size_t data_capacity;     // page-aligned data region size
+    size_t footer_bytes;      // page-aligned footer size
+    size_t page;              // vm page size used at creation
+    void *footer;             // start of the mapped footer ([control page][metadata page]); for flush
+    void *meta_page;          // the write-once metadata page (mprotect-toggled for version writes)
+    emb_profile_ident_t *ident; // frozen identity within the metadata page
+    emb_ring_buffer_t *ring;  // attached ring buffer (owns_resources == false)
+};
+
+/// Write `version` into the frozen identity, briefly toggling the write-once metadata
+/// page to RW. The version field is the file's transactional validity/tombstone marker
+/// (PROFILING-DISK-FORMAT.md §4.2): 0 = "disregard"; a real version = recoverable.
+static void store_set_version(emb_profile_store_t *store, uint64_t version)
+{
+    // Toggle the write-once metadata page to RW just for this write. If the unprotect fails, the page
+    // is still read-only — writing would SIGBUS and crash the host app — so bail and leave the current
+    // version intact. Worst case the file keeps version 1 and is re-reported as a crash next launch
+    // (a harmless false positive), never a fault.
+    if (mprotect(store->meta_page, store->page, PROT_READ | PROT_WRITE) != 0) { return; }
+    store->ident->format_version = version;
+    (void)mprotect(store->meta_page, store->page, PROT_READ);  // best-effort re-protect
+}
+
+static size_t round_up_to_page(size_t n, size_t page)
+{
+    return (n + page - 1) & ~(page - 1);
+}
+
+emb_profile_store_t *emb_profile_store_create(const char *path,
+                                              size_t capacity_bytes,
+                                              const uint8_t session_id[16],
+                                              int *errno_out)
+{
+    int dummy_errno = 0;
+    if (errno_out == NULL) { errno_out = &dummy_errno; }
+    *errno_out = 0;
+
+    if (path == NULL || capacity_bytes == 0) {
+        *errno_out = EINVAL;
+        return NULL;
+    }
+
+    const size_t page = (size_t)vm_page_size;
+    const size_t data_capacity = round_up_to_page(capacity_bytes, page);
+    // Footer = one RW control-block page + one write-once metadata page.
+    const size_t footer_bytes = 2 * page;
+    const size_t guard_bytes = page;
+    const off_t  file_size = (off_t)(data_capacity + footer_bytes);
+    const size_t reserve_size = 2 * data_capacity + guard_bytes + footer_bytes;
+
+    // --- open + size the file ---
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) { *errno_out = errno; return NULL; }
+
+#if !TARGET_OS_OSX
+    // Class B = NSFileProtectionCompleteUnlessOpen: an open file keeps accepting writes while the
+    // device is locked (we hold it open for the whole session). Best-effort, non-fatal. Applied on
+    // every data-protection platform (iOS/iPadOS/tvOS/visionOS); excluded only on macOS, where
+    // F_SETPROTECTIONCLASS is meaningless and the host C-layer tests run.
+    (void)fcntl(fd, F_SETPROTECTIONCLASS, EMB_PROTECTION_CLASS_B);
+#endif
+
+    if (ftruncate(fd, file_size) != 0) { *errno_out = errno; close(fd); return NULL; }
+
+    // --- reserve address space, then place the double-mapped data + guard + footer ---
+    void *base = mmap(NULL, reserve_size, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (base == MAP_FAILED) { *errno_out = errno; close(fd); return NULL; }
+
+    uint8_t *b = (uint8_t *)base;
+    // Lower half + aliased upper half: both MAP_SHARED over file offset 0, so a record that
+    // wraps past the end is written through the alias into the single file region.
+    if (mmap(b, data_capacity, PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) { goto fail_mmap; }
+    if (mmap(b + data_capacity, data_capacity, PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) { goto fail_mmap; }
+    // Guard page at b + 2*data_capacity stays PROT_NONE (never mapped over) — §4.1 Layer 1.
+    uint8_t *footer = b + 2 * data_capacity + guard_bytes;
+    if (mmap(footer, footer_bytes, PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_FIXED, fd, (off_t)data_capacity) == MAP_FAILED) { goto fail_mmap; }
+
+    // --- footer layout: [control page][write-once metadata page] ---
+    // Control block at the start of the footer (its own RW page); zero from ftruncate, so the
+    // fresh session's write_pos/oldest_pos/next_seq are all 0.
+    emb_ring_control_t *control = (emb_ring_control_t *)footer;
+
+    // Descriptor at the start of the metadata page; identity at the very end of the file;
+    // trailer immediately before identity.
+    uint8_t *meta = footer + page;
+    emb_profile_descriptor_t *desc = (emb_profile_descriptor_t *)meta;
+    emb_profile_ident_t *ident =
+        (emb_profile_ident_t *)(footer + footer_bytes - sizeof(emb_profile_ident_t));
+    emb_profile_trailer_v1_t *trailer =
+        (emb_profile_trailer_v1_t *)((uint8_t *)ident - sizeof(emb_profile_trailer_v1_t));
+
+    // --- write the write-once metadata ---
+    desc->created_uptime_ns = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
+    desc->created_wall_ns   = clock_gettime_nsec_np(CLOCK_REALTIME);
+    if (session_id != NULL) { memcpy(desc->session_id, session_id, 16); }
+    else                    { memset(desc->session_id, 0, 16); }
+    desc->image_table_offset = 0;  // absent in v1
+    desc->image_table_bytes  = 0;
+
+    trailer->footer_offset       = data_capacity;
+    trailer->data_capacity       = data_capacity;
+    trailer->page_size           = (uint32_t)page;
+    trailer->record_header_bytes = (uint16_t)sizeof(emb_ring_record_header_t);
+    trailer->pointer_bytes       = (uint16_t)sizeof(uintptr_t);
+    trailer->footer_bytes        = (uint32_t)footer_bytes;
+    trailer->trailer_bytes       = (uint32_t)sizeof(emb_profile_trailer_v1_t);
+
+    ident->magic = EMB_PROFILE_FILE_MAGIC;
+    // Commit LAST: a crash before this leaves format_version == 0 → recovery disregards the file (§4.2).
+    ident->format_version = EMB_PROFILE_FORMAT_VER;
+
+    // --- harden: drop the write-once metadata page to read-only (control page stays RW) ---
+    // Best-effort: the store is fully functional whether or not this succeeds (write-once protection is
+    // defense-in-depth). Failing it here would discard a working store AND leave an already-committed
+    // file on disk, so we don't treat it as fatal.
+    (void)mprotect(meta, page, PROT_READ);
+
+    // --- attach a ring buffer over the data region + mapped control block ---
+    emb_ring_buffer_t *ring = emb_ring_buffer_attach(b, data_capacity, control);
+    if (ring == NULL) { *errno_out = ENOMEM; goto fail_mmap; }
+
+    emb_profile_store_t *store = calloc(1, sizeof(*store));
+    if (store == NULL) { *errno_out = ENOMEM; emb_ring_buffer_destroy(ring); goto fail_mmap; }
+    store->fd            = fd;
+    store->base          = base;
+    store->reserve_size  = reserve_size;
+    store->data_capacity = data_capacity;
+    store->footer_bytes  = footer_bytes;
+    store->page          = page;
+    store->footer        = footer;
+    store->meta_page     = meta;
+    store->ident         = ident;
+    store->ring          = ring;
+    return store;
+
+fail_mmap:
+    if (*errno_out == 0) { *errno_out = errno; }
+    munmap(base, reserve_size);
+    close(fd);
+    return NULL;
+}
+
+emb_ring_buffer_t *emb_profile_store_buffer(emb_profile_store_t *store)
+{
+    return store ? store->ring : NULL;
+}
+
+bool emb_profile_store_reset(emb_profile_store_t *store)
+{
+    if (store == NULL) { return false; }
+    // Transactional reset (PROFILING-DISK-FORMAT.md §4.2 / audit B3): bracket the mutation with the
+    // version marker so a crash mid-reset leaves format_version == 0 → recovery disregards a half-cleared
+    // file. The file length never changes within a process run, so we reuse the same mapping/file.
+    store_set_version(store, EMB_PROFILE_FORMAT_INVALID);
+    bool ok = emb_ring_buffer_reset(store->ring);  // memset data + reset positions (reader-safe)
+    store_set_version(store, EMB_PROFILE_FORMAT_VER);  // consistent again (also restores on reader-blocked reset)
+    return ok;
+}
+
+void emb_profile_store_finalize(emb_profile_store_t *store)
+{
+    if (store == NULL) { return; }
+    // Clean-stop tombstone (audit B2): version → 0 marks the file "finalized" so recovery reports
+    // nothing for it (its samples were already drained live). We never delete — Embrace owns deletion.
+    store_set_version(store, EMB_PROFILE_FORMAT_INVALID);
+}
+
+void emb_profile_store_flush(emb_profile_store_t *store)
+{
+    if (store == NULL) { return; }
+    // Async flush of dirty pages to the file ahead of a possible background Jetsam kill. The lower data
+    // half covers the file data region (the upper half aliases the same file pages); the footer holds the
+    // control block + metadata. MS_ASYNC: schedule writeback, don't block.
+    msync(store->base, store->data_capacity, MS_ASYNC);
+    msync(store->footer, store->footer_bytes, MS_ASYNC);  // exact mapped footer base (no guard-size coupling)
+}
+
+void emb_profile_store_destroy(emb_profile_store_t *store)
+{
+    if (store == NULL) { return; }
+    // The ring buffer was attached (owns_resources == false), so this frees only the wrapper —
+    // never the mapping or the control block, which the store owns and unmaps below.
+    if (store->ring != NULL) { emb_ring_buffer_destroy(store->ring); }
+    if (store->base != NULL) { munmap(store->base, store->reserve_size); }
+    if (store->fd >= 0)      { close(store->fd); }
+    free(store);
+}
+
+// MARK: - Recovery (read-only)
+
+static bool pread_exact(int fd, void *buf, size_t n, off_t off)
+{
+    return pread(fd, buf, n, off) == (ssize_t)n;
+}
+
+emb_profile_recover_status_t emb_profile_recover(const char *path,
+                                                 emb_profile_record_cb emit,
+                                                 void *ctx)
+{
+    if (path == NULL) { return EMB_PROFILE_RECOVER_IO_ERROR; }
+
+    // O_NOFOLLOW: don't traverse a symlink left in the recovery directory (hardening for untrusted input).
+    int fd = open(path, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) { return EMB_PROFILE_RECOVER_IO_ERROR; }
+
+    emb_profile_recover_status_t status = EMB_PROFILE_RECOVER_CORRUPT;
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) { status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
+    if (!S_ISREG(st.st_mode)) { status = EMB_PROFILE_RECOVER_NOT_OURS; goto done; }  // dirs/devices/etc.
+    const off_t file_size = st.st_size;
+    if (file_size < (off_t)(sizeof(emb_profile_ident_t) + sizeof(emb_profile_trailer_v1_t))) {
+        goto done;  // too small to be valid → CORRUPT
+    }
+
+    // --- frozen identity at EOF − 16: magic + version gate ---
+    emb_profile_ident_t ident;
+    if (!pread_exact(fd, &ident, sizeof(ident), file_size - (off_t)sizeof(ident))) {
+        status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
+    }
+    if (ident.magic != EMB_PROFILE_FILE_MAGIC) { status = EMB_PROFILE_RECOVER_NOT_OURS; goto done; }
+    if (ident.format_version == EMB_PROFILE_FORMAT_INVALID) { status = EMB_PROFILE_RECOVER_FINALIZED; goto done; }
+    if (ident.format_version != EMB_PROFILE_FORMAT_VER) { status = EMB_PROFILE_RECOVER_UNSUPPORTED; goto done; }
+
+    // --- v1 trailer (immediately before the identity), validated ---
+    emb_profile_trailer_v1_t tr;
+    const off_t trailer_off = file_size - (off_t)sizeof(ident) - (off_t)sizeof(tr);
+    if (!pread_exact(fd, &tr, sizeof(tr), trailer_off)) { status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
+    if (tr.page_size != (uint32_t)vm_page_size ||
+        tr.record_header_bytes != (uint16_t)sizeof(emb_ring_record_header_t) ||
+        tr.pointer_bytes != (uint16_t)sizeof(uintptr_t) ||
+        tr.data_capacity == 0 ||
+        (tr.data_capacity % (uint64_t)vm_page_size) != 0 ||        // must be page-aligned
+        tr.data_capacity > (uint64_t)file_size ||                  // can't exceed the real file (anti-overflow)
+        tr.footer_bytes < 2 * (uint64_t)vm_page_size ||            // at least control + metadata page
+        tr.footer_offset != tr.data_capacity ||
+        (off_t)(tr.data_capacity + tr.footer_bytes) != file_size) {
+        goto done;  // mismatch → CORRUPT (page-size / record-size / endian / out-of-range rejected here)
+    }
+    const size_t data_capacity = (size_t)tr.data_capacity;
+
+    // --- control block (trusted but validated; option B): write_pos@0, oldest_pos@8 ---
+    uint64_t write_pos = 0, oldest_pos = 0;
+    if (!pread_exact(fd, &write_pos, sizeof(write_pos), (off_t)data_capacity) ||
+        !pread_exact(fd, &oldest_pos, sizeof(oldest_pos), (off_t)data_capacity + (off_t)sizeof(uint64_t))) {
+        status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
+    }
+    if (oldest_pos > write_pos || (write_pos - oldest_pos) > data_capacity) {
+        goto done;  // inconsistent positions → discard (CORRUPT)
+    }
+    if (write_pos == oldest_pos) { status = EMB_PROFILE_RECOVER_OK; goto done; }  // empty — nothing to emit
+
+    // --- double-map the data region (read-only) so wrapped records are contiguous ---
+    const size_t map_reserve = 2 * data_capacity;
+    void *base = mmap(NULL, map_reserve, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (base == MAP_FAILED) { status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
+    uint8_t *b = (uint8_t *)base;
+    if (mmap(b, data_capacity, PROT_READ, MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED ||
+        mmap(b + data_capacity, data_capacity, PROT_READ, MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) {
+        munmap(base, map_reserve);
+        status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
+    }
+
+    // --- walk records oldest_pos → write_pos, torn-tail tolerant ---
+    // write_pos/oldest_pos are absolute monotonic byte counters (indexed via % data_capacity), so over
+    // a long session write_pos grows large — we must NOT cap it. Loop invariant: oldest_pos <= pos <=
+    // write_pos and (write_pos - oldest_pos) <= data_capacity. We therefore compare on the remaining
+    // span `write_pos - pos` (subtraction, never underflows) instead of `pos + size` — the latter can
+    // overflow uint64 on a crafted file whose write_pos sits within one record of UINT64_MAX, which
+    // would defeat the overrun guard and read past the 2*data_capacity mapping. With the subtraction
+    // form, rsize <= write_pos - pos <= data_capacity, so (pos % data_capacity) + rsize <= 2*cap-1,
+    // always inside the double map.
+    const size_t hdr_size = sizeof(emb_ring_record_header_t);
+    uint64_t pos = oldest_pos;
+    while (write_pos - pos >= hdr_size) {
+        const emb_ring_record_header_t *h =
+            (const emb_ring_record_header_t *)(b + (pos % data_capacity));
+        if (h->seq & 1u) { break; }                            // odd seq = writer died mid-record (torn)
+        if (h->frame_count == 0) { break; }                    // zeroed/unflushed page — not a real record (B1)
+        if (h->frame_count > EMB_MAX_STACK_FRAMES) { break; }  // garbage
+        const size_t rsize = hdr_size + (size_t)h->frame_count * sizeof(uintptr_t);
+        if (rsize > write_pos - pos) { break; }                // record overruns committed data
+        if (emit != NULL) {
+            const uintptr_t *frames = (const uintptr_t *)((const uint8_t *)h + hdr_size);
+            emit(ctx, h->timestamp_ns, h->thread_state, h->flags, frames, h->frame_count);
+        }
+        pos += rsize;
+    }
+
+    munmap(base, map_reserve);
+    status = EMB_PROFILE_RECOVER_OK;
+
+done:
+    close(fd);
+    return status;
+}
+
+emb_profile_peek_status_t emb_profile_peek(const char *path)
+{
+    if (path == NULL) { return EMB_PROFILE_PEEK_NOT_OURS; }
+
+    int fd = open(path, O_RDONLY | O_NOFOLLOW);
+    if (fd < 0) { return EMB_PROFILE_PEEK_NOT_OURS; }
+
+    emb_profile_peek_status_t result = EMB_PROFILE_PEEK_NOT_OURS;
+    struct stat st;
+    emb_profile_ident_t ident;
+    if (fstat(fd, &st) == 0 && S_ISREG(st.st_mode) &&
+        st.st_size >= (off_t)sizeof(ident) &&
+        pread_exact(fd, &ident, sizeof(ident), st.st_size - (off_t)sizeof(ident)) &&
+        ident.magic == EMB_PROFILE_FILE_MAGIC) {
+        result = (ident.format_version == EMB_PROFILE_FORMAT_INVALID)
+            ? EMB_PROFILE_PEEK_FINALIZED
+            : EMB_PROFILE_PEEK_RECOVERABLE;
+    }
+    close(fd);
+    return result;
+}
+
+#endif /* !TARGET_OS_WATCH */

--- a/Sources/EmbraceProfilingSampler/source/emb_profile_store.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_profile_store.c
@@ -207,6 +207,13 @@ void emb_profile_store_flush(emb_profile_store_t *store)
     // Async flush of dirty pages to the file ahead of a possible background Jetsam kill. The lower data
     // half covers the file data region (the upper half aliases the same file pages); the footer holds the
     // control block + metadata. MS_ASYNC: schedule writeback, don't block.
+    //
+    // The order of these two calls does not matter. MS_ASYNC only schedules writeback — it gives no
+    // ordering or completion guarantee, least of all across two separate calls — so it can't enforce
+    // "data durable before footer durable" regardless of which we issue first. Correctness doesn't need
+    // it to: recovery tolerates a footer that's ahead of its data. If the footer commits a record whose
+    // data page never reached disk, that page is still ftruncate zero-fill, so the record walk sees
+    // frame_count == 0 and stops cleanly at the torn tail (see emb_profile_recover).
     msync(store->base, store->data_capacity, MS_ASYNC);
     msync(store->footer, store->footer_bytes, MS_ASYNC);  // exact mapped footer base (no guard-size coupling)
 }
@@ -235,7 +242,14 @@ static int recover_open(const char *path)
 
 // Read exactly `n` bytes at `off`. Loops over partial reads and retries EINTR — a signal during the
 // launch-time recovery read must not fail an otherwise-valid file. Returns false on a short read
-// (EOF before `n`) or a real I/O error.
+// (EOF before `n`) or a real I/O error; on false, `errno` always describes the failure — the pread
+// error, or 0 for EOF, which sets no errno of its own.
+//
+// Callers don't distinguish EOF from an I/O error: every offset here is validated in-bounds against
+// the fstat'd file_size before the read, and a file's length is fixed at create (ftruncate) and never
+// changes afterwards — recovery only ever reads files whose writer is already dead. So a short read
+// isn't reachable, and a genuinely truncated file is rejected earlier (it loses the tail where the
+// identity lives) as NOT_OURS/CORRUPT, never as an I/O error.
 static bool pread_exact(int fd, void *buf, size_t n, off_t off)
 {
     uint8_t *p = (uint8_t *)buf;
@@ -244,26 +258,32 @@ static bool pread_exact(int fd, void *buf, size_t n, off_t off)
         ssize_t r = pread(fd, p + got, n - got, off + (off_t)got);
         if (r > 0) { got += (size_t)r; continue; }
         if (r < 0 && errno == EINTR) { continue; }
-        return false;  // r == 0 (short read / EOF) or a real error
+        if (r == 0) { errno = 0; }  // EOF sets no errno — never leave a stale one for the caller
+        return false;
     }
     return true;
 }
 
 emb_profile_recover_status_t emb_profile_recover(const char *path,
                                                  emb_profile_record_cb emit,
-                                                 void *ctx)
+                                                 void *ctx,
+                                                 int *errno_out)
 {
-    if (path == NULL) { return EMB_PROFILE_RECOVER_IO_ERROR; }
+    int dummy_errno = 0;
+    if (errno_out == NULL) { errno_out = &dummy_errno; }
+    *errno_out = 0;
+
+    if (path == NULL) { *errno_out = EINVAL; return EMB_PROFILE_RECOVER_IO_ERROR; }
 
     // O_NOFOLLOW: don't traverse a symlink left in the recovery directory (hardening for untrusted
     // input). recover_open retries EINTR so a signal during the read doesn't spuriously fail.
     int fd = recover_open(path);
-    if (fd < 0) { return EMB_PROFILE_RECOVER_IO_ERROR; }
+    if (fd < 0) { *errno_out = errno; return EMB_PROFILE_RECOVER_IO_ERROR; }
 
     emb_profile_recover_status_t status = EMB_PROFILE_RECOVER_CORRUPT;
 
     struct stat st;
-    if (fstat(fd, &st) != 0) { status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
+    if (fstat(fd, &st) != 0) { *errno_out = errno; status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
     if (!S_ISREG(st.st_mode)) { status = EMB_PROFILE_RECOVER_NOT_OURS; goto done; }  // dirs/devices/etc.
     const off_t file_size = st.st_size;
     if (file_size < (off_t)(sizeof(emb_profile_ident_t) + sizeof(emb_profile_trailer_v1_t))) {
@@ -273,7 +293,7 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
     // --- frozen identity at EOF − 16: magic + version gate ---
     emb_profile_ident_t ident;
     if (!pread_exact(fd, &ident, sizeof(ident), file_size - (off_t)sizeof(ident))) {
-        status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
+        *errno_out = errno; status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
     }
     if (ident.magic != EMB_PROFILE_FILE_MAGIC) { status = EMB_PROFILE_RECOVER_NOT_OURS; goto done; }
     if (ident.format_version == EMB_PROFILE_FORMAT_INVALID) { status = EMB_PROFILE_RECOVER_FINALIZED; goto done; }
@@ -282,7 +302,9 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
     // --- v1 trailer (immediately before the identity), validated ---
     emb_profile_trailer_v1_t tr;
     const off_t trailer_off = file_size - (off_t)sizeof(ident) - (off_t)sizeof(tr);
-    if (!pread_exact(fd, &tr, sizeof(tr), trailer_off)) { status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
+    if (!pread_exact(fd, &tr, sizeof(tr), trailer_off)) {
+        *errno_out = errno; status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
+    }
     if (tr.page_size != (uint32_t)vm_page_size ||
         tr.record_header_bytes != (uint16_t)sizeof(emb_ring_record_header_t) ||
         tr.pointer_bytes != (uint16_t)sizeof(uintptr_t) ||
@@ -300,7 +322,7 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
     uint64_t write_pos = 0, oldest_pos = 0;
     if (!pread_exact(fd, &write_pos, sizeof(write_pos), (off_t)data_capacity) ||
         !pread_exact(fd, &oldest_pos, sizeof(oldest_pos), (off_t)data_capacity + (off_t)sizeof(uint64_t))) {
-        status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
+        *errno_out = errno; status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
     }
     if (oldest_pos > write_pos || (write_pos - oldest_pos) > data_capacity) {
         goto done;  // inconsistent positions → discard (CORRUPT)
@@ -310,10 +332,11 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
     // --- double-map the data region (read-only) so wrapped records are contiguous ---
     const size_t map_reserve = 2 * data_capacity;
     void *base = mmap(NULL, map_reserve, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
-    if (base == MAP_FAILED) { status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
+    if (base == MAP_FAILED) { *errno_out = errno; status = EMB_PROFILE_RECOVER_IO_ERROR; goto done; }
     uint8_t *b = (uint8_t *)base;
     if (mmap(b, data_capacity, PROT_READ, MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED ||
         mmap(b + data_capacity, data_capacity, PROT_READ, MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) {
+        *errno_out = errno;
         munmap(base, map_reserve);
         status = EMB_PROFILE_RECOVER_IO_ERROR; goto done;
     }
@@ -327,6 +350,14 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
     // would defeat the overrun guard and read past the 2*data_capacity mapping. With the subtraction
     // form, rsize <= write_pos - pos <= data_capacity, so (pos % data_capacity) + rsize <= 2*cap-1,
     // always inside the double map.
+    // Each break below is a `break`, never a `continue`: the thing that's untrustworthy in every case
+    // is the record's own frame_count/seq, which is exactly what we'd need to compute rsize and find
+    // where the next record begins. With no trustworthy stride there is no safe way to skip forward —
+    // guessing one would emit misaligned frame pointers to the callback, which is worse than stopping.
+    // This is torn-tail tolerance (a crash-interrupted final write), not mid-stream resync: corruption
+    // before the true tail drops everything after it. Records emitted before the break are valid, so
+    // reaching the bottom with EMB_PROFILE_RECOVER_OK is the intended partial-recovery contract (the
+    // empty write_pos == oldest_pos case above returns OK with zero records for the same reason).
     const size_t hdr_size = sizeof(emb_ring_record_header_t);
     uint64_t pos = oldest_pos;
     while (write_pos - pos >= hdr_size) {

--- a/Sources/EmbraceProfilingSampler/source/emb_profile_store.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_profile_store.c
@@ -16,9 +16,11 @@
 #include <time.h>
 #include <unistd.h>
 
-// Data-protection Class B == NSFileProtectionCompleteUnlessOpen. The protection-class enum constants
-// (PROTECTION_CLASS_*) are NOT exported by the public SDK headers — only F_SETPROTECTIONCLASS is — so
-// we use the documented integer value directly.
+// Data-protection Class B == NSFileProtectionCompleteUnlessOpen. It is the only class we use: it keeps
+// an already-open file writable while the device is locked, which is exactly this file's lifetime (we
+// hold it open for the whole session). The protection-class enum constants (PROTECTION_CLASS_*) are NOT
+// exported by the public SDK headers — only F_SETPROTECTIONCLASS is — so we use the documented integer
+// value directly. No other class is defined here because none is needed.
 #define EMB_PROTECTION_CLASS_B 2
 
 struct emb_profile_store {
@@ -36,13 +38,14 @@ struct emb_profile_store {
 
 /// Write `version` into the frozen identity, briefly toggling the write-once metadata
 /// page to RW. The version field is the file's transactional validity/tombstone marker
-/// (PROFILING-DISK-FORMAT.md §4.2): 0 = "disregard"; a real version = recoverable.
+/// (PROFILING-DISK-FORMAT.md §5): 0 = "disregard"; a real version = recoverable.
 static void store_set_version(emb_profile_store_t *store, uint64_t version)
 {
-    // Toggle the write-once metadata page to RW just for this write. If the unprotect fails, the page
+    // Toggle the write-once metadata page to RW just for this write. mprotect on our own mapped page is
+    // not expected to fail in practice — this is purely defensive. If the unprotect does fail the page
     // is still read-only — writing would SIGBUS and crash the host app — so bail and leave the current
-    // version intact. Worst case the file keeps version 1 and is re-reported as a crash next launch
-    // (a harmless false positive), never a fault.
+    // version intact. Worst case the file keeps version 1 and is re-reported as a crash next launch (a
+    // harmless false positive: recovery finds a valid file with no torn tail), never a fault.
     if (mprotect(store->meta_page, store->page, PROT_READ | PROT_WRITE) != 0) { return; }
     store->ident->format_version = version;
     (void)mprotect(store->meta_page, store->page, PROT_READ);  // best-effort re-protect
@@ -76,7 +79,9 @@ emb_profile_store_t *emb_profile_store_create(const char *path,
     const size_t reserve_size = 2 * data_capacity + guard_bytes + footer_bytes;
 
     // --- open + size the file ---
-    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    // O_NOFOLLOW: the directory is caller-provided, so refuse to follow a symlink at the final
+    // path component and truncate an unexpected file (matches the symlink hardening in recovery).
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
     if (fd < 0) { *errno_out = errno; return NULL; }
 
 #if !TARGET_OS_OSX
@@ -97,13 +102,13 @@ emb_profile_store_t *emb_profile_store_create(const char *path,
     // Lower half + aliased upper half: both MAP_SHARED over file offset 0, so a record that
     // wraps past the end is written through the alias into the single file region.
     if (mmap(b, data_capacity, PROT_READ | PROT_WRITE,
-             MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) { goto fail_mmap; }
+             MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) { goto fail; }
     if (mmap(b + data_capacity, data_capacity, PROT_READ | PROT_WRITE,
-             MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) { goto fail_mmap; }
-    // Guard page at b + 2*data_capacity stays PROT_NONE (never mapped over) — §4.1 Layer 1.
+             MAP_SHARED | MAP_FIXED, fd, 0) == MAP_FAILED) { goto fail; }
+    // Guard page at b + 2*data_capacity stays PROT_NONE (never mapped over) — §7 (guard page).
     uint8_t *footer = b + 2 * data_capacity + guard_bytes;
     if (mmap(footer, footer_bytes, PROT_READ | PROT_WRITE,
-             MAP_SHARED | MAP_FIXED, fd, (off_t)data_capacity) == MAP_FAILED) { goto fail_mmap; }
+             MAP_SHARED | MAP_FIXED, fd, (off_t)data_capacity) == MAP_FAILED) { goto fail; }
 
     // --- footer layout: [control page][write-once metadata page] ---
     // Control block at the start of the footer (its own RW page); zero from ftruncate, so the
@@ -136,7 +141,7 @@ emb_profile_store_t *emb_profile_store_create(const char *path,
     trailer->trailer_bytes       = (uint32_t)sizeof(emb_profile_trailer_v1_t);
 
     ident->magic = EMB_PROFILE_FILE_MAGIC;
-    // Commit LAST: a crash before this leaves format_version == 0 → recovery disregards the file (§4.2).
+    // Commit LAST: a crash before this leaves format_version == 0 → recovery disregards the file (§5).
     ident->format_version = EMB_PROFILE_FORMAT_VER;
 
     // --- harden: drop the write-once metadata page to read-only (control page stays RW) ---
@@ -147,10 +152,10 @@ emb_profile_store_t *emb_profile_store_create(const char *path,
 
     // --- attach a ring buffer over the data region + mapped control block ---
     emb_ring_buffer_t *ring = emb_ring_buffer_attach(b, data_capacity, control);
-    if (ring == NULL) { *errno_out = ENOMEM; goto fail_mmap; }
+    if (ring == NULL) { *errno_out = ENOMEM; goto fail; }
 
     emb_profile_store_t *store = calloc(1, sizeof(*store));
-    if (store == NULL) { *errno_out = ENOMEM; emb_ring_buffer_destroy(ring); goto fail_mmap; }
+    if (store == NULL) { *errno_out = ENOMEM; emb_ring_buffer_destroy(ring); goto fail; }
     store->fd            = fd;
     store->base          = base;
     store->reserve_size  = reserve_size;
@@ -163,7 +168,7 @@ emb_profile_store_t *emb_profile_store_create(const char *path,
     store->ring          = ring;
     return store;
 
-fail_mmap:
+fail:
     if (*errno_out == 0) { *errno_out = errno; }
     munmap(base, reserve_size);
     close(fd);
@@ -178,7 +183,7 @@ emb_ring_buffer_t *emb_profile_store_buffer(emb_profile_store_t *store)
 bool emb_profile_store_reset(emb_profile_store_t *store)
 {
     if (store == NULL) { return false; }
-    // Transactional reset (PROFILING-DISK-FORMAT.md §4.2 / audit B3): bracket the mutation with the
+    // Transactional reset (PROFILING-DISK-FORMAT.md §5): bracket the mutation with the
     // version marker so a crash mid-reset leaves format_version == 0 → recovery disregards a half-cleared
     // file. The file length never changes within a process run, so we reuse the same mapping/file.
     store_set_version(store, EMB_PROFILE_FORMAT_INVALID);
@@ -190,8 +195,9 @@ bool emb_profile_store_reset(emb_profile_store_t *store)
 void emb_profile_store_finalize(emb_profile_store_t *store)
 {
     if (store == NULL) { return; }
-    // Clean-stop tombstone (audit B2): version → 0 marks the file "finalized" so recovery reports
-    // nothing for it (its samples were already drained live). We never delete — Embrace owns deletion.
+    // Clean-stop tombstone (PROFILING-DISK-FORMAT.md §5): version → 0 marks the file "finalized" so
+    // recovery reports nothing for it (its samples were already retrieved via the live
+    // retrieveSamples path before the clean stop). We never delete — Embrace owns deletion.
     store_set_version(store, EMB_PROFILE_FORMAT_INVALID);
 }
 
@@ -218,9 +224,29 @@ void emb_profile_store_destroy(emb_profile_store_t *store)
 
 // MARK: - Recovery (read-only)
 
+// Open a candidate file read-only without following symlinks, retrying on EINTR so a signal landing
+// during launch-time recovery doesn't spuriously fail the open.
+static int recover_open(const char *path)
+{
+    int fd;
+    do { fd = open(path, O_RDONLY | O_NOFOLLOW); } while (fd < 0 && errno == EINTR);
+    return fd;
+}
+
+// Read exactly `n` bytes at `off`. Loops over partial reads and retries EINTR — a signal during the
+// launch-time recovery read must not fail an otherwise-valid file. Returns false on a short read
+// (EOF before `n`) or a real I/O error.
 static bool pread_exact(int fd, void *buf, size_t n, off_t off)
 {
-    return pread(fd, buf, n, off) == (ssize_t)n;
+    uint8_t *p = (uint8_t *)buf;
+    size_t got = 0;
+    while (got < n) {
+        ssize_t r = pread(fd, p + got, n - got, off + (off_t)got);
+        if (r > 0) { got += (size_t)r; continue; }
+        if (r < 0 && errno == EINTR) { continue; }
+        return false;  // r == 0 (short read / EOF) or a real error
+    }
+    return true;
 }
 
 emb_profile_recover_status_t emb_profile_recover(const char *path,
@@ -229,8 +255,9 @@ emb_profile_recover_status_t emb_profile_recover(const char *path,
 {
     if (path == NULL) { return EMB_PROFILE_RECOVER_IO_ERROR; }
 
-    // O_NOFOLLOW: don't traverse a symlink left in the recovery directory (hardening for untrusted input).
-    int fd = open(path, O_RDONLY | O_NOFOLLOW);
+    // O_NOFOLLOW: don't traverse a symlink left in the recovery directory (hardening for untrusted
+    // input). recover_open retries EINTR so a signal during the read doesn't spuriously fail.
+    int fd = recover_open(path);
     if (fd < 0) { return EMB_PROFILE_RECOVER_IO_ERROR; }
 
     emb_profile_recover_status_t status = EMB_PROFILE_RECOVER_CORRUPT;
@@ -329,16 +356,25 @@ emb_profile_peek_status_t emb_profile_peek(const char *path)
 {
     if (path == NULL) { return EMB_PROFILE_PEEK_NOT_OURS; }
 
-    int fd = open(path, O_RDONLY | O_NOFOLLOW);
-    if (fd < 0) { return EMB_PROFILE_PEEK_NOT_OURS; }
+    // A file we can't open/stat/read may still be one of ours — it could be locked under data
+    // protection (Class B) at launch, or hit a transient EINTR/EIO — so those map to INDETERMINATE,
+    // NOT to NOT_OURS, so the caller doesn't permanently write it off. Only a readable regular file
+    // whose magic doesn't match is definitively NOT_OURS.
+    int fd = recover_open(path);
+    if (fd < 0) { return EMB_PROFILE_PEEK_INDETERMINATE; }
 
-    emb_profile_peek_status_t result = EMB_PROFILE_PEEK_NOT_OURS;
+    emb_profile_peek_status_t result;
     struct stat st;
     emb_profile_ident_t ident;
-    if (fstat(fd, &st) == 0 && S_ISREG(st.st_mode) &&
-        st.st_size >= (off_t)sizeof(ident) &&
-        pread_exact(fd, &ident, sizeof(ident), st.st_size - (off_t)sizeof(ident)) &&
-        ident.magic == EMB_PROFILE_FILE_MAGIC) {
+    if (fstat(fd, &st) != 0) {
+        result = EMB_PROFILE_PEEK_INDETERMINATE;                       // couldn't stat
+    } else if (!S_ISREG(st.st_mode) || st.st_size < (off_t)sizeof(ident)) {
+        result = EMB_PROFILE_PEEK_NOT_OURS;                           // not a regular file / too small
+    } else if (!pread_exact(fd, &ident, sizeof(ident), st.st_size - (off_t)sizeof(ident))) {
+        result = EMB_PROFILE_PEEK_INDETERMINATE;                       // couldn't read the identity
+    } else if (ident.magic != EMB_PROFILE_FILE_MAGIC) {
+        result = EMB_PROFILE_PEEK_NOT_OURS;                           // read it — magic mismatch
+    } else {
         result = (ident.format_version == EMB_PROFILE_FORMAT_INVALID)
             ? EMB_PROFILE_PEEK_FINALIZED
             : EMB_PROFILE_PEEK_RECOVERABLE;

--- a/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_ring_buffer.c
@@ -32,7 +32,9 @@ typedef vm_size_t emb_vm_size_t;
 // Layout-compatible with the public emb_ring_record_header_t.
 typedef struct {
     _Atomic uint32_t seq;
-    uint32_t frame_count;
+    uint16_t frame_count;
+    uint8_t  thread_state;
+    uint8_t  flags;
     uint64_t timestamp_ns;
 } emb_ring_write_header_t;
 
@@ -44,6 +46,10 @@ _Static_assert(offsetof(emb_ring_write_header_t, seq) == offsetof(emb_ring_recor
                "seq offset mismatch");
 _Static_assert(offsetof(emb_ring_write_header_t, frame_count) == offsetof(emb_ring_record_header_t, frame_count),
                "frame_count offset mismatch");
+_Static_assert(offsetof(emb_ring_write_header_t, thread_state) == offsetof(emb_ring_record_header_t, thread_state),
+               "thread_state offset mismatch");
+_Static_assert(offsetof(emb_ring_write_header_t, flags) == offsetof(emb_ring_record_header_t, flags),
+               "flags offset mismatch");
 _Static_assert(offsetof(emb_ring_write_header_t, timestamp_ns) == offsetof(emb_ring_record_header_t, timestamp_ns),
                "timestamp_ns offset mismatch");
 
@@ -131,11 +137,23 @@ emb_ring_buffer_t *emb_ring_buffer_create(size_t capacity_bytes, kern_return_t *
         goto fail;
     }
 
-    buf->data       = (uint8_t *)region;
-    buf->capacity   = capacity;
-    buf->next_seq   = 0;
-    atomic_store_explicit(&buf->write_pos,  0, memory_order_relaxed);
-    atomic_store_explicit(&buf->oldest_pos, 0, memory_order_relaxed);
+    // In-memory buffers own a heap-allocated control block. (File-backed buffers
+    // attach a mapped footer control block instead — emb_profile_store, Step 3.)
+    emb_ring_control_t *control = calloc(1, sizeof(*control));
+    if (control == NULL) {
+        free(buf);
+        *kr_out = KERN_RESOURCE_SHORTAGE;
+        goto fail;
+    }
+
+    buf->data           = (uint8_t *)region;
+    buf->capacity       = capacity;
+    buf->control        = control;
+    buf->owns_resources = true;
+    buf->control->next_seq   = 0;
+    atomic_store_explicit(&buf->control->write_pos,    0, memory_order_relaxed);
+    atomic_store_explicit(&buf->control->oldest_pos,   0, memory_order_relaxed);
+    atomic_store_explicit(&buf->control->status_flags, 0, memory_order_relaxed);
     atomic_store_explicit(&buf->active_readers, 0, memory_order_relaxed);
     atomic_store_explicit(&buf->resetting, false, memory_order_relaxed);
 
@@ -159,16 +177,41 @@ fail:
     return NULL;
 }
 
+emb_ring_buffer_t *emb_ring_buffer_attach(uint8_t *data, size_t capacity, emb_ring_control_t *control)
+{
+    if (data == NULL || control == NULL || capacity == 0) {
+        return NULL;
+    }
+    emb_ring_buffer_t *buf = calloc(1, sizeof(*buf));
+    if (buf == NULL) {
+        return NULL;
+    }
+    buf->data           = data;
+    buf->capacity       = capacity;
+    buf->control        = control;          // caller-owned (mapped footer or anon)
+    buf->owns_resources = false;            // store owns data + control; destroy frees only the wrapper
+    atomic_store_explicit(&buf->active_readers, 0, memory_order_relaxed);
+    atomic_store_explicit(&buf->resetting, false, memory_order_relaxed);
+    // Deliberately does NOT touch *control — the caller sets the positions.
+    return buf;
+}
+
 void emb_ring_buffer_destroy(emb_ring_buffer_t *buf)
 {
     if (buf == NULL) {
         return;
     }
-    // Deallocate the full 2 × capacity virtual region (both the original
-    // allocation and the remap share the same address range).
-    emb_vm_deallocate(mach_task_self(),
-                      (emb_vm_address_t)buf->data,
-                      (emb_vm_size_t)buf->capacity * 2);
+    // For in-memory buffers we own the VM region and the heap control block.
+    // For file-backed buffers (owns_resources == false) the store owns the mapping
+    // and the mapped control block, so we must not free them here.
+    if (buf->owns_resources) {
+        // Deallocate the full 2 × capacity virtual region (both the original
+        // allocation and the remap share the same address range).
+        emb_vm_deallocate(mach_task_self(),
+                          (emb_vm_address_t)buf->data,
+                          (emb_vm_size_t)buf->capacity * 2);
+        free(buf->control);
+    }
     free(buf);
 }
 
@@ -189,9 +232,9 @@ bool emb_ring_buffer_reset(emb_ring_buffer_t *buf)
     }
 
     memset(buf->data, 0, buf->capacity);
-    buf->next_seq = 0;
-    atomic_store_explicit(&buf->write_pos, 0, memory_order_release);
-    atomic_store_explicit(&buf->oldest_pos, 0, memory_order_release);
+    buf->control->next_seq = 0;
+    atomic_store_explicit(&buf->control->write_pos, 0, memory_order_release);
+    atomic_store_explicit(&buf->control->oldest_pos, 0, memory_order_release);
 
     atomic_store_explicit(&buf->resetting, false, memory_order_seq_cst);
     return true;
@@ -208,14 +251,21 @@ size_t emb_ring_buffer_capacity(const emb_ring_buffer_t *buf)
 emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
                                                uint64_t timestamp_ns,
                                                const uintptr_t *frames,
-                                               size_t frame_count)
+                                               size_t frame_count,
+                                               uint8_t thread_state,
+                                               uint8_t flags)
 {
     if (buf == NULL || (frames == NULL && frame_count > 0)) {
         return EMB_RING_WRITE_BAD_ARGS;
     }
 
-    // The header stores frame_count as uint32_t.
-    if (frame_count > UINT32_MAX) {
+    // frame_count is stored as uint16 in the record header (16-byte layout), so reject
+    // anything that would truncate. The recovery scanner's invariants (no committed
+    // record has frame_count == 0 or > EMB_MAX_STACK_FRAMES) are guaranteed at the
+    // *sampler* — the sole writer of persisted/file-backed buffers, which only writes
+    // when frame_count > 0 and clamps max_frames <= EMB_MAX_STACK_FRAMES. This generic
+    // ring buffer stays general-purpose (0-frame records remain valid for in-memory use).
+    if (frame_count > UINT16_MAX) {
         return EMB_RING_WRITE_BAD_ARGS;
     }
 
@@ -228,10 +278,10 @@ emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
     }
 
     // Current write position (monotonically increasing byte offset).
-    uint64_t write_pos = atomic_load_explicit(&buf->write_pos, memory_order_relaxed);
+    uint64_t write_pos = atomic_load_explicit(&buf->control->write_pos, memory_order_relaxed);
     // relaxed: the writer is the only thread that advances oldest_pos, so no
     // synchronisation is needed here — we only need our own prior stores.
-    uint64_t oldest_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_relaxed);
+    uint64_t oldest_pos = atomic_load_explicit(&buf->control->oldest_pos, memory_order_relaxed);
 
     // Evict old records that would be overlapped by this write.
     // The loop condition: oldest_pos + capacity < write_pos + record_size
@@ -250,7 +300,7 @@ emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
         // On corruption, evict everything to prevent cascading garbage reads.
         if (old_record_size > buf->capacity) {
             oldest_pos = write_pos;
-            atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
+            atomic_store_explicit(&buf->control->oldest_pos, oldest_pos, memory_order_release);
             corruption_detected = true;
             break;
         }
@@ -259,7 +309,7 @@ emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
         oldest_pos += old_record_size;
 
         // Publish the new oldest_pos.
-        atomic_store_explicit(&buf->oldest_pos, oldest_pos, memory_order_release);
+        atomic_store_explicit(&buf->control->oldest_pos, oldest_pos, memory_order_release);
     }
 
     if (corruption_detected) {
@@ -299,24 +349,26 @@ emb_ring_write_status_t emb_ring_buffer_write(emb_ring_buffer_t *buf,
     // Set seq to odd (writing). Release ordering ensures this store is visible
     // to readers before any subsequent data writes, which is necessary for
     // correct seqlock protocol on weakly-ordered architectures (ARM64).
-    atomic_store_explicit(&header->seq, (uint32_t)(buf->next_seq | 1), memory_order_release);
+    atomic_store_explicit(&header->seq, (uint32_t)(buf->control->next_seq | 1), memory_order_release);
 
     // Copy frame data into the buffer.
     uintptr_t *dest_frames = (uintptr_t *)(header + 1);
     memcpy(dest_frames, frames, frame_count * sizeof(*dest_frames));
 
-    // Write the header fields (frame_count and timestamp).
-    header->frame_count = (uint32_t)frame_count;
+    // Write the header fields (frame_count, thread_state, flags, timestamp).
+    header->frame_count = (uint16_t)frame_count;
+    header->thread_state = thread_state;
+    header->flags = flags;
     header->timestamp_ns = timestamp_ns;
 
     // Seal the seqlock (transition to even = stable).
-    atomic_store_explicit(&header->seq, (uint32_t)buf->next_seq, memory_order_release);
+    atomic_store_explicit(&header->seq, (uint32_t)buf->control->next_seq, memory_order_release);
 
     // Advance write_pos by the actual record size.
-    atomic_store_explicit(&buf->write_pos, write_pos + record_size(frame_count), memory_order_release);
+    atomic_store_explicit(&buf->control->write_pos, write_pos + record_size(frame_count), memory_order_release);
 
     // Increment the seqlock counter for the next write.
-    buf->next_seq += 2;
+    buf->control->next_seq += 2;
 
     return EMB_RING_WRITE_OK;
 }
@@ -331,6 +383,8 @@ static inline emb_ring_record_header_t read_live_header(emb_ring_buffer_t *buf,
     emb_ring_record_header_t hdr;
     hdr.seq          = atomic_load_explicit(&whdr->seq, memory_order_acquire);
     hdr.frame_count  = whdr->frame_count;
+    hdr.thread_state = whdr->thread_state;
+    hdr.flags        = whdr->flags;
     hdr.timestamp_ns = whdr->timestamp_ns;
     return hdr;
 }
@@ -362,8 +416,8 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
     }
 
     // Snapshot the occupied region boundaries.
-    uint64_t oldest_pos = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
-    const uint64_t write_pos = atomic_load_explicit(&buf->write_pos, memory_order_acquire);
+    uint64_t oldest_pos = atomic_load_explicit(&buf->control->oldest_pos, memory_order_acquire);
+    const uint64_t write_pos = atomic_load_explicit(&buf->control->write_pos, memory_order_acquire);
 
     if (oldest_pos >= write_pos) {
         atomic_fetch_sub_explicit(&buf->active_readers, 1, memory_order_release);
@@ -412,7 +466,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
     // Skip records before start_ns.
     while (scan_pos + header_size <= write_pos) {
         // Check if the writer evicted past our position.
-        uint64_t current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        uint64_t current_oldest = atomic_load_explicit(&buf->control->oldest_pos, memory_order_acquire);
         if (current_oldest > scan_pos) {
             scan_pos = current_oldest;
             continue;
@@ -423,7 +477,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
         // Re-check oldest_pos after reading. The seq_cst fence in the writer
         // guarantees that if oldest_pos hasn't advanced past us, the data at
         // our position has not been overwritten.
-        current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        current_oldest = atomic_load_explicit(&buf->control->oldest_pos, memory_order_acquire);
         if (current_oldest > scan_pos) {
             scan_pos = current_oldest;
             continue;
@@ -443,7 +497,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
     // Find end of matching range, counting records as we go.
     size_t scan_record_count = 0;
     while (scan_pos + header_size <= write_pos) {
-        uint64_t current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        uint64_t current_oldest = atomic_load_explicit(&buf->control->oldest_pos, memory_order_acquire);
         if (current_oldest > scan_pos) {
             // Record evicted. Restart from new oldest position.
             copy_start = current_oldest;
@@ -454,7 +508,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
 
         emb_ring_record_header_t hdr = read_live_header(buf, scan_pos);
 
-        current_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+        current_oldest = atomic_load_explicit(&buf->control->oldest_pos, memory_order_acquire);
         if (current_oldest > scan_pos) {
             // Record evicted. Restart from new oldest position.
             copy_start = current_oldest;
@@ -500,7 +554,7 @@ emb_ring_read_result_t emb_ring_buffer_read_range(emb_ring_buffer_t *buf,
     // checks.
     // ========================================================================
 
-    uint64_t post_oldest = atomic_load_explicit(&buf->oldest_pos, memory_order_acquire);
+    uint64_t post_oldest = atomic_load_explicit(&buf->control->oldest_pos, memory_order_acquire);
 
     // Fast path: no eviction reached our copy range, so all records intact.
     if (post_oldest <= copy_start) {

--- a/Sources/EmbraceProfilingSampler/source/emb_sampler.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_sampler.c
@@ -218,7 +218,8 @@ static void *sampler_thread_func(void *arg) {
             void *stack_top = pthread_get_stackaddr_np(g_main_pthread_cached);
             void *stack_bottom = (uint8_t *)stack_top - stack_size;
 
-            // Capture the main thread's run state BEFORE suspending it (THREAD-STATE.md §3):
+            // Capture the main thread's run state BEFORE suspending it
+            // (PROFILING-THREAD-STATE.md §2):
             // thread_info is a mach_msg RPC, not async-signal-safe, so it must not run inside the
             // suspend window. Held in locals consumed by the post-resume write below.
             uint8_t thread_state = EMB_THREAD_RUN_STATE_UNKNOWN;

--- a/Sources/EmbraceProfilingSampler/source/emb_sampler.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_sampler.c
@@ -218,6 +218,23 @@ static void *sampler_thread_func(void *arg) {
             void *stack_top = pthread_get_stackaddr_np(g_main_pthread_cached);
             void *stack_bottom = (uint8_t *)stack_top - stack_size;
 
+            // Capture the main thread's run state BEFORE suspending it (THREAD-STATE.md §3):
+            // thread_info is a mach_msg RPC, not async-signal-safe, so it must not run inside the
+            // suspend window. Held in locals consumed by the post-resume write below.
+            uint8_t thread_state = EMB_THREAD_RUN_STATE_UNKNOWN;
+            uint8_t record_flags = 0;
+            {
+                thread_basic_info_data_t info;
+                mach_msg_type_number_t info_count = THREAD_BASIC_INFO_COUNT;
+                if (thread_info(g_main_thread, THREAD_BASIC_INFO,
+                                (thread_info_t)&info, &info_count) == KERN_SUCCESS) {
+                    thread_state = (uint8_t)info.run_state;  // values mirror TH_STATE_*
+                    // Remap Mach flags into our own packed layout (NOT a raw copy of info.flags).
+                    if (info.flags & TH_FLAGS_IDLE)    { record_flags |= EMB_RECORD_FLAG_IDLE; }
+                    if (info.flags & TH_FLAGS_SWAPPED) { record_flags |= EMB_RECORD_FLAG_SWAPPED; }
+                }
+            }
+
             if (thread_suspend(g_main_thread) != KERN_SUCCESS) {
                 // The Mach port is dead/invalid (thread terminated or port recycled).
                 // We go directly to FAULTED, bypassing the normal STOPPING→ZOMBIE→
@@ -238,20 +255,30 @@ static void *sampler_thread_func(void *arg) {
             uint64_t timestamp_ns = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW);
 
             size_t frame_count = 0;
+            bool stack_truncated = false;
             emb_stack_walk(g_main_thread,
                            stack_bottom,
                            stack_top,
                            g_stack_frames,
                            g_config.max_frames,
-                           &frame_count);
+                           &frame_count,
+                           &stack_truncated);
 
             if (frame_count < g_config.min_frames && fallback_walker != NULL) {
-                bool is_truncated = false;
+                bool fb_truncated = false;
                 int result = fallback_walker(g_main_thread,
                                              g_stack_frames,
                                              (int)g_config.max_frames,
-                                             &is_truncated);
-                frame_count = result < 0 ? 0 : (size_t)result;
+                                             &fb_truncated);
+                if (result < 0) {
+                    frame_count = 0;
+                } else {
+                    frame_count = (size_t)result;
+                    // Defense-in-depth: a misbehaving fallback could over-report; clamp to the buffer
+                    // capacity we handed it so the subsequent write never reads past g_stack_frames.
+                    if (frame_count > g_config.max_frames) { frame_count = g_config.max_frames; }
+                    stack_truncated = fb_truncated;
+                }
             }
 
             if (thread_resume(g_main_thread) != KERN_SUCCESS) {
@@ -272,8 +299,11 @@ static void *sampler_thread_func(void *arg) {
             // validates that max_frames fits within the buffer capacity. A failure
             // here indicates a logic error (e.g. buffer was destroyed externally).
             if (frame_count > 0) {
+                uint8_t flags = record_flags;
+                if (stack_truncated) { flags |= EMB_RECORD_FLAG_TRUNCATED; }
                 emb_ring_write_status_t ws =
-                    emb_ring_buffer_write(g_buffer, timestamp_ns, g_stack_frames, frame_count);
+                    emb_ring_buffer_write(g_buffer, timestamp_ns, g_stack_frames, frame_count,
+                                          thread_state, flags);
                 if (ws == EMB_RING_WRITE_CORRUPTION_DETECTED) {
                     sampler_fault("ring buffer corruption detected");
                     return NULL;

--- a/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
@@ -29,7 +29,8 @@ bool emb_stack_walk(thread_t thread,
                     const void *stack_top,
                     uintptr_t *frames_out,
                     size_t max_frames,
-                    size_t *count_out)
+                    size_t *count_out,
+                    bool *is_truncated)
 {
     if (frames_out == NULL || count_out == NULL || max_frames == 0
         || stack_bottom == NULL || stack_top == NULL
@@ -37,6 +38,9 @@ bool emb_stack_walk(thread_t thread,
         return false;
     }
     *count_out = 0;
+    if (is_truncated != NULL) {
+        *is_truncated = false;
+    }
 
     emb_thread_state_t state;
     mach_msg_type_number_t state_count = EMB_THREAD_STATE_COUNT;
@@ -61,12 +65,20 @@ bool emb_stack_walk(thread_t thread,
     // Frame pointers must be aligned to sizeof(void *) * 2 bytes
     // (16 bytes on the supported 64-bit architectures).
     const uintptr_t fp_align_mask = sizeof(void *) * 2 - 1;
-    while (count < max_frames && fp >= stack_bottom && fp < stack_top
+    while (fp >= stack_bottom && fp < stack_top
            && ((uintptr_t)fp & fp_align_mask) == 0) {
         void **record = (void **)fp;
-        void *next_fp = record[0];
         void *ret_addr = ptrauth_strip(record[1], ptrauth_key_return_address);
 
+        // Buffer full: if the chain still holds a real frame, we are truncating.
+        if (count == max_frames) {
+            if (ret_addr != NULL && is_truncated != NULL) {
+                *is_truncated = true;
+            }
+            break;
+        }
+
+        void *next_fp = record[0];
         if (ret_addr == NULL) {
             break;
         }

--- a/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
+++ b/Sources/EmbraceProfilingSampler/source/emb_stack_walker.c
@@ -64,8 +64,13 @@ bool emb_stack_walk(thread_t thread,
     // Each frame record is: [saved_fp, return_address]
     // Frame pointers must be aligned to sizeof(void *) * 2 bytes
     // (16 bytes on the supported 64-bit architectures).
-    const uintptr_t fp_align_mask = sizeof(void *) * 2 - 1;
-    while (fp >= stack_bottom && fp < stack_top
+    // We dereference both words of the record, so the whole record — not just fp — must lie
+    // within the stack; a bare `fp < stack_top` check would let record[1] read up to one word
+    // past stack_top.
+    const size_t record_bytes = sizeof(void *) * 2;
+    const uintptr_t fp_align_mask = record_bytes - 1;
+    while (fp >= stack_bottom
+           && (uintptr_t)fp <= (uintptr_t)stack_top - record_bytes
            && ((uintptr_t)fp & fp_align_mask) == 0) {
         void **record = (void **)fp;
         void *ret_addr = ptrauth_strip(record[1], ptrauth_key_return_address);

--- a/Tests/EmbraceProfilingSamplerTests/ProfileRecoveryTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/ProfileRecoveryTests.swift
@@ -107,6 +107,48 @@
             XCTAssertEqual(status, EMB_PROFILE_RECOVER_IO_ERROR)
         }
 
+        // MARK: - Peek (cheap identity-only classification)
+
+        func test_peek_crashedSession_returnsRecoverable() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else { return XCTFail() }
+            ringWrite(emb_profile_store_buffer(store), 100, [0x11], 1, 1, 0)
+            emb_profile_store_destroy(store)  // crash-like: version stays 1
+
+            XCTAssertEqual(emb_profile_peek(path), EMB_PROFILE_PEEK_RECOVERABLE)
+        }
+
+        func test_peek_finalizedSession_returnsFinalized() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else { return XCTFail() }
+            emb_profile_store_finalize(store)  // clean stop → version 0
+            emb_profile_store_destroy(store)
+
+            XCTAssertEqual(emb_profile_peek(path), EMB_PROFILE_PEEK_FINALIZED)
+        }
+
+        /// A readable regular file whose magic doesn't match is *definitively* not ours.
+        func test_peek_notOurFile_returnsNotOurs() throws {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+            try Data(count: 64 * 1024).write(to: URL(fileURLWithPath: path))
+
+            XCTAssertEqual(emb_profile_peek(path), EMB_PROFILE_PEEK_NOT_OURS)
+        }
+
+        /// A file we can't even open is INDETERMINATE, not NOT_OURS: it may be one of ours that is
+        /// temporarily unreadable (e.g. locked under data protection at launch), so the caller must be
+        /// able to tell "couldn't determine" apart from "confirmed not ours" and retry later.
+        func test_peek_unreadableFile_returnsIndeterminate() {
+            XCTAssertEqual(emb_profile_peek(tempPath() + "-nope"), EMB_PROFILE_PEEK_INDETERMINATE)
+        }
+
         // MARK: - Step 7: adversarial hardening
 
         /// Recovery must read writer dirty pages that were NEVER explicitly flushed (no msync, no

--- a/Tests/EmbraceProfilingSamplerTests/ProfileRecoveryTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/ProfileRecoveryTests.swift
@@ -32,9 +32,16 @@
         }
 
         private func recoverAll(_ path: String) -> (emb_profile_recover_status_t, [RecoverSink.Rec]) {
+            let (status, recs, _) = recoverAllWithErrno(path)
+            return (status, recs)
+        }
+
+        private func recoverAllWithErrno(_ path: String) -> (emb_profile_recover_status_t, [RecoverSink.Rec], Int32) {
             let sink = RecoverSink()
-            let status = emb_profile_recover(path, recoverCallback, Unmanaged.passUnretained(sink).toOpaque())
-            return (status, sink.records)
+            var errnoOut: Int32 = 0
+            let status = emb_profile_recover(
+                path, recoverCallback, Unmanaged.passUnretained(sink).toOpaque(), &errnoOut)
+            return (status, sink.records, errnoOut)
         }
 
         /// A store created + written + destroyed (but NOT finalized) is exactly a "crashed session"
@@ -105,6 +112,14 @@
         func test_recover_missingFile_returnsIOError() {
             let (status, _) = recoverAll(tempPath() + "-nope")
             XCTAssertEqual(status, EMB_PROFILE_RECOVER_IO_ERROR)
+        }
+
+        /// The IO_ERROR path must thread the real `errno` back out — that's what lets a caller (or a
+        /// human debugging a bug report) tell ENOENT from EACCES from EIO instead of a flat "I/O error".
+        func test_recover_missingFile_threadsErrnoOut() {
+            let (status, _, errnoOut) = recoverAllWithErrno(tempPath() + "-nope")
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_IO_ERROR)
+            XCTAssertEqual(errnoOut, ENOENT)
         }
 
         // MARK: - Peek (cheap identity-only classification)

--- a/Tests/EmbraceProfilingSamplerTests/ProfileRecoveryTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/ProfileRecoveryTests.swift
@@ -1,0 +1,240 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import EmbraceProfilingSampler
+    import Foundation
+    import XCTest
+
+    /// Accumulates records delivered by `emb_profile_recover`'s callback.
+    final class RecoverSink {
+        struct Rec { let ts: UInt64; let state: UInt8; let flags: UInt8; let frames: [UInt] }
+        var records: [Rec] = []
+    }
+
+    // Non-capturing → convertible to the C function pointer `emb_profile_record_cb`.
+    private let recoverCallback: emb_profile_record_cb = { ctx, ts, state, flags, framesPtr, count in
+        let sink = Unmanaged<RecoverSink>.fromOpaque(ctx!).takeUnretainedValue()
+        let frames = (framesPtr != nil && count > 0)
+            ? Array(UnsafeBufferPointer(start: framesPtr, count: Int(count)))
+            : []
+        sink.records.append(.init(ts: ts, state: state, flags: flags, frames: frames))
+    }
+
+    /// Tests for the read-only recovery scanner (Step 5).
+    final class ProfileRecoveryTests: XCTestCase {
+
+        private func tempPath() -> String {
+            (NSTemporaryDirectory() as NSString)
+                .appendingPathComponent("embprof-rec-\(UUID().uuidString).embprof")
+        }
+
+        private func recoverAll(_ path: String) -> (emb_profile_recover_status_t, [RecoverSink.Rec]) {
+            let sink = RecoverSink()
+            let status = emb_profile_recover(path, recoverCallback, Unmanaged.passUnretained(sink).toOpaque())
+            return (status, sink.records)
+        }
+
+        /// A store created + written + destroyed (but NOT finalized) is exactly a "crashed session"
+        /// file: valid version + records on disk. Recovery should return them in order.
+        func test_recover_crashedSession_emitsRecordsInOrder() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("create failed, errno=\(err)")
+            }
+            let buf = emb_profile_store_buffer(store)
+            XCTAssertEqual(ringWrite(buf, 100, [0x11, 0x12], 2, 1 /* running */, 0), EMB_RING_WRITE_OK)
+            XCTAssertEqual(ringWrite(buf, 200, [0x21], 1, 3 /* waiting */, 0), EMB_RING_WRITE_OK)
+            XCTAssertEqual(ringWrite(buf, 300, [0x31, 0x32, 0x33], 3, 1, 0), EMB_RING_WRITE_OK)
+            emb_profile_store_destroy(store)  // simulate process death (version stays 1)
+
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_OK)
+            XCTAssertEqual(recs.count, 3)
+            XCTAssertEqual(recs.map { $0.ts }, [100, 200, 300])
+            XCTAssertEqual(recs.map { $0.state }, [1, 3, 1])
+            XCTAssertEqual(recs[0].frames, [0x11, 0x12])
+            XCTAssertEqual(recs[1].frames, [0x21])
+            XCTAssertEqual(recs[2].frames, [0x31, 0x32, 0x33])
+        }
+
+        func test_recover_finalizedSession_returnsFinalized() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else { return XCTFail() }
+            ringWrite(emb_profile_store_buffer(store), 100, [0x11], 1, 1, 0)
+            emb_profile_store_finalize(store)   // clean stop → version 0
+            emb_profile_store_destroy(store)
+
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_FINALIZED)
+            XCTAssertEqual(recs.count, 0)
+        }
+
+        func test_recover_emptyBuffer_returnsOKWithNoRecords() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else { return XCTFail() }
+            emb_profile_store_destroy(store)  // never wrote anything
+
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_OK)
+            XCTAssertEqual(recs.count, 0)
+        }
+
+        func test_recover_notOurFile_returnsNotOurs() throws {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+            // A file big enough to pass the size check, but with no valid magic at EOF.
+            try Data(count: 64 * 1024).write(to: URL(fileURLWithPath: path))
+
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_NOT_OURS)
+            XCTAssertEqual(recs.count, 0)
+        }
+
+        func test_recover_missingFile_returnsIOError() {
+            let (status, _) = recoverAll(tempPath() + "-nope")
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_IO_ERROR)
+        }
+
+        // MARK: - Step 7: adversarial hardening
+
+        /// Recovery must read writer dirty pages that were NEVER explicitly flushed (no msync, no
+        /// munmap) — exactly the state a SIGKILL leaves behind. Proven in-process: write into the
+        /// MAP_SHARED mapping, then recover from a FRESH fd + mapping of the same file WITHOUT
+        /// destroying the store first. MAP_SHARED pages are coherent through the unified buffer cache,
+        /// so the fresh mapping observes the un-flushed writes. (`killtest.c` separately proves the
+        /// kernel flushes these same pages to the vnode on a real cross-process SIGKILL; `fork()` is
+        /// unavailable in Swift, so that half lives in the C harness.)
+        func test_recover_readsUnflushedSharedWrites() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("create failed, errno=\(err)")
+            }
+            defer { emb_profile_store_destroy(store) }
+            let buf = emb_profile_store_buffer(store)
+            _ = ringWrite(buf, 100, [0xAB], 1, 1, 0)
+            _ = ringWrite(buf, 200, [0xCD], 1, 3, 0)
+            _ = ringWrite(buf, 300, [0xEF], 1, 1, 0)
+            // NO destroy / flush / finalize here — recover the still-live file from a fresh mapping.
+
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_OK)
+            XCTAssertEqual(recs.count, 3)
+            XCTAssertEqual(recs.map { $0.ts }, [100, 200, 300])
+            XCTAssertEqual(recs.map { $0.state }, [1, 3, 1])
+        }
+
+        // --- deterministic on-disk corruption (two 1-frame records: rec0 @0, rec1 @24) ---
+
+        /// Writes two 1-frame records and tears down (flush), leaving a valid "crashed" file on disk.
+        private func makeTwoRecordFile(_ path: String) {
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("create failed, errno=\(err)")
+            }
+            let buf = emb_profile_store_buffer(store)
+            let f: [UInt] = [0xAB]
+            _ = ringWrite(buf, 100, f, 1, 1, 0)   // rec0 @ byte 0  (seq 0)
+            _ = ringWrite(buf, 200, f, 1, 3, 0)   // rec1 @ byte 24 (seq 2)
+            emb_profile_store_destroy(store)       // flush; format_version stays 1
+        }
+
+        private func patch(_ path: String, _ offset: Int, _ bytes: [UInt8]) {
+            guard let fh = FileHandle(forUpdatingAtPath: path) else { return XCTFail("open for update") }
+            try? fh.seek(toOffset: UInt64(offset))
+            fh.write(Data(bytes))
+            try? fh.close()
+        }
+
+        private func leBytes<T: FixedWidthInteger>(_ v: T) -> [UInt8] {
+            withUnsafeBytes(of: v.littleEndian) { Array($0) }
+        }
+
+        func test_recover_tornTail_stopsAtOddSeq() {
+            let path = tempPath(); defer { try? FileManager.default.removeItem(atPath: path) }
+            makeTwoRecordFile(path)
+            patch(path, 24, leBytes(UInt32(3)))  // rec1 seq → odd → torn
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_OK)
+            XCTAssertEqual(recs.count, 1, "walk stops at the torn second record")
+            XCTAssertEqual(recs.first?.ts, 100)
+        }
+
+        func test_recover_zeroedPage_stopsAtZeroFrameCount() {
+            let path = tempPath(); defer { try? FileManager.default.removeItem(atPath: path) }
+            makeTwoRecordFile(path)
+            patch(path, 28, leBytes(UInt16(0)))  // rec1 frame_count (offset 24+4) → 0 (zeroed-page sentinel)
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_OK)
+            XCTAssertEqual(recs.count, 1, "walk stops at the zeroed second record")
+            XCTAssertEqual(recs.first?.ts, 100)
+        }
+
+        func test_recover_corruptControlBlock_returnsCorrupt() {
+            let path = tempPath(); defer { try? FileManager.default.removeItem(atPath: path) }
+            makeTwoRecordFile(path)
+            let dataCapacity = 256 * 1024  // page-aligned for 4K/16K
+            patch(path, dataCapacity, leBytes(UInt64(dataCapacity * 4)))  // write_pos − oldest_pos > capacity
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_CORRUPT)
+            XCTAssertEqual(recs.count, 0)
+        }
+
+        func test_recover_wrongPageSize_returnsCorrupt() {
+            let path = tempPath(); defer { try? FileManager.default.removeItem(atPath: path) }
+            makeTwoRecordFile(path)
+            let page = Int(getpagesize())
+            let fileSize = 256 * 1024 + 2 * page
+            let trailerSize = MemoryLayout<emb_profile_trailer_v1_t>.size
+            let identSize = MemoryLayout<emb_profile_ident_t>.size
+            // page_size field sits after footer_offset(8) + data_capacity(8) in the trailer.
+            let pageSizeOffset = fileSize - identSize - trailerSize + 16
+            patch(path, pageSizeOffset, leBytes(UInt32(0xDEAD)))
+            let (status, _) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_CORRUPT)
+        }
+
+        /// Regression for the record-walk overflow: write_pos/oldest_pos are absolute monotonic byte
+        /// counters, and a crafted file can place write_pos within one record of UInt64.max. The OLD
+        /// overrun guard `pos + rsize > write_pos` overflowed and wrongly ACCEPTED an over-long record
+        /// (OOB read past the mapping on 4K-page builds; a garbage record on 16K). The fixed guard
+        /// (`rsize > write_pos - pos`) must REJECT it. We assert via emitted-record count, which
+        /// distinguishes old (≥1 garbage record) from new (0) even on this 16K-page host where the OOB
+        /// itself doesn't reproduce.
+        func test_recover_overflowGuard_rejectsRecordOverrunningNearUInt64Max() {
+            let path = tempPath(); defer { try? FileManager.default.removeItem(atPath: path) }
+            makeTwoRecordFile(path)  // gives a valid magic/trailer; we override the control block below
+
+            let dataCapacity = 256 * 1024
+            let writePos = UInt64.max - 84       // near the top of the u64 range
+            let oldestPos = writePos - 16        // diff == one header → passes (write-oldest) <= capacity
+            patch(path, dataCapacity, leBytes(writePos))           // control block: write_pos@0
+            patch(path, dataCapacity + 8, leBytes(oldestPos))      //                oldest_pos@8
+
+            // Plant a committed-looking header at oldest_pos's data offset, claiming the max frame count
+            // so its record would overrun the 16-byte window.
+            let recOffset = Int(oldestPos % UInt64(dataCapacity))
+            patch(path, recOffset, leBytes(UInt32(0)))             // seq = 0 (even → committed)
+            patch(path, recOffset + 4, leBytes(UInt16(1024)))      // frame_count = EMB_MAX_STACK_FRAMES
+
+            let (status, recs) = recoverAll(path)
+            XCTAssertEqual(status, EMB_PROFILE_RECOVER_OK)
+            XCTAssertEqual(recs.count, 0, "an overrunning record near UInt64.max must be rejected, not accepted")
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/ProfileStoreTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/ProfileStoreTests.swift
@@ -1,0 +1,132 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import EmbraceProfilingSampler
+    import Foundation
+    import XCTest
+
+    /// Tests for the file-backed store (Step 3: create + footer + mapping).
+    final class ProfileStoreTests: XCTestCase {
+
+        private func tempPath() -> String {
+            (NSTemporaryDirectory() as NSString)
+                .appendingPathComponent("embprof-\(UUID().uuidString).embprof")
+        }
+
+        func test_create_writeRead_roundTripsThroughFileBackedBuffer() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            let sid = [UInt8](repeating: 0xAB, count: 16)
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, sid, &err) else {
+                return XCTFail("store create failed, errno=\(err)")
+            }
+            defer { emb_profile_store_destroy(store) }
+
+            guard let buf = emb_profile_store_buffer(store) else { return XCTFail("no buffer") }
+
+            let frames: [UInt] = [0x1111, 0x2222, 0x3333]
+            XCTAssertEqual(ringWrite(buf, 1_000, frames, frames.count, 1 /* running */, 0), EMB_RING_WRITE_OK)
+            XCTAssertEqual(ringWrite(buf, 2_000, frames, frames.count, 3 /* waiting */, 0), EMB_RING_WRITE_OK)
+
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 2)
+            XCTAssertEqual(records[0].frames, frames)
+            XCTAssertEqual(records[0].thread_state, 1)
+            XCTAssertEqual(records[1].thread_state, 3)
+        }
+
+        func test_create_writesValidFrozenIdentityToDisk() throws {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("create failed, errno=\(err)")
+            }
+            // Write a record, then tear down — munmap flushes the dirty pages to the file.
+            ringWrite(emb_profile_store_buffer(store), 1_000, [0xDEAD], 1, 1, 0)
+            emb_profile_store_destroy(store)
+
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            XCTAssertGreaterThan(data.count, MemoryLayout<emb_profile_ident_t>.size)
+
+            // Frozen identity is the last 16 bytes. Copy into an aligned struct (avoids
+            // unaligned-load issues on the Data slice).
+            var ident = emb_profile_ident_t()
+            _ = withUnsafeMutableBytes(of: &ident) { data.suffix(16).copyBytes(to: $0) }
+            XCTAssertEqual(ident.magic, EMB_PROFILE_FILE_MAGIC)
+            XCTAssertEqual(ident.format_version, UInt64(EMB_PROFILE_FORMAT_VER))
+        }
+
+        func test_destroy_doesNotDeleteFile() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            let store = emb_profile_store_create(path, 256 * 1024, nil, &err)
+            XCTAssertNotNil(store, "create failed, errno=\(err)")
+            emb_profile_store_destroy(store)
+
+            // We never delete — Embrace owns deletion/retention.
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path),
+                          "store must not delete the file on destroy")
+        }
+
+        func test_create_badArgs_returnsNilWithErrno() {
+            var err: Int32 = 0
+            XCTAssertNil(emb_profile_store_create(nil, 256 * 1024, nil, &err))
+            XCTAssertEqual(err, EINVAL)
+        }
+
+        // MARK: - Step 4: reset + finalize
+
+        func test_reset_reusesFile_clearsRecords_thenUsable() {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("create failed, errno=\(err)")
+            }
+            defer { emb_profile_store_destroy(store) }
+            let buf = emb_profile_store_buffer(store)!
+
+            ringWrite(buf, 1_000, [0xAA], 1, 1, 0)
+            XCTAssertEqual(testReadRange(buf, 0, UINT64_MAX).count, 1)
+
+            XCTAssertTrue(emb_profile_store_reset(store))
+            XCTAssertEqual(testReadRange(buf, 0, UINT64_MAX).count, 0, "reset clears records")
+
+            // Still usable after reset (same file reused).
+            ringWrite(buf, 2_000, [0xBB], 1, 1, 0)
+            let records = testReadRange(buf, 0, UINT64_MAX)
+            XCTAssertEqual(records.count, 1)
+            XCTAssertEqual(records[0].frames, [0xBB])
+        }
+
+        func test_finalize_writesVersionZeroTombstoneToDisk() throws {
+            let path = tempPath()
+            defer { try? FileManager.default.removeItem(atPath: path) }
+
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("create failed, errno=\(err)")
+            }
+            ringWrite(emb_profile_store_buffer(store), 1_000, [0xCC], 1, 1, 0)
+            emb_profile_store_finalize(store)
+            emb_profile_store_destroy(store)
+
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            var ident = emb_profile_ident_t()
+            _ = withUnsafeMutableBytes(of: &ident) { data.suffix(16).copyBytes(to: $0) }
+            XCTAssertEqual(ident.magic, EMB_PROFILE_FILE_MAGIC, "magic stays intact")
+            XCTAssertEqual(ident.format_version, 0, "finalize writes the version-0 tombstone")
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferConcurrencyTests.swift
@@ -131,7 +131,7 @@
                 writerBlock: { _ in
                     for i in 0..<writeCount {
                         let f = self.makeFrames(writeIndex: i, count: frameCount)
-                        emb_ring_buffer_write(buf, UInt64(i) * intervalNs, f, frameCount)
+                        ringWrite(buf, UInt64(i) * intervalNs, f, frameCount)
                         Thread.sleep(forTimeInterval: 0.001)
                     }
                 }
@@ -160,7 +160,7 @@
                 writerBlock: { _ in
                     for i in 0..<10 {
                         let f: [UInt] = [UInt(i + 1)]
-                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, 1)
+                        ringWrite(buf, UInt64(i + 1) * 100_000_000, f, 1)
                         Thread.sleep(forTimeInterval: 0.001)
                     }
                 }
@@ -188,7 +188,7 @@
                     for i in 0..<10 {
                         let fc = (i % 8) + 1
                         let f = self.makeFrames(writeIndex: i, count: fc)
-                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, fc)
+                        ringWrite(buf, UInt64(i + 1) * 100_000_000, f, fc)
                         Thread.sleep(forTimeInterval: 0.001)
                     }
                 }
@@ -215,7 +215,7 @@
                     for i in 0..<60 {
                         let fc = (i % 12) + 1
                         let f = self.makeFrames(writeIndex: i, count: fc)
-                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, fc)
+                        ringWrite(buf, UInt64(i + 1) * 100_000_000, f, fc)
                         Thread.sleep(forTimeInterval: 0.001)
                     }
                 }
@@ -249,7 +249,7 @@
                 writerBlock: { _ in
                     for i in 0..<40 {
                         let f = self.makeFrames(writeIndex: i, count: 10)
-                        emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, 10)
+                        ringWrite(buf, UInt64(i + 1) * 100_000_000, f, 10)
                         Thread.sleep(forTimeInterval: 0.001)
                     }
                 }
@@ -266,7 +266,7 @@
             for i in 0..<20 {
                 let fc = (i % 5) + 1
                 let f = makeFrames(writeIndex: i, count: fc)
-                emb_ring_buffer_write(buf, UInt64(i + 1) * 1_000_000, f, fc)
+                ringWrite(buf, UInt64(i + 1) * 1_000_000, f, fc)
             }
 
             let readerCount = 8
@@ -339,7 +339,7 @@
 
             for i in 0..<10 {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, UInt64(i) * intervalNs, f, 1)
+                ringWrite(buf, UInt64(i) * intervalNs, f, 1)
                 Thread.sleep(forTimeInterval: 0.001)
             }
             stop.set()
@@ -386,7 +386,7 @@
             while Date() < deadline {
                 let fc = (writeCount % 10) + 1
                 let f = makeFrames(writeIndex: writeCount, count: fc)
-                emb_ring_buffer_write(buf, UInt64(writeCount + 1) * 1_000_000, f, fc)
+                ringWrite(buf, UInt64(writeCount + 1) * 1_000_000, f, fc)
                 writeCount += 1
             }
 
@@ -438,7 +438,7 @@
 
             for i in 0..<10 {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, UInt64(i) * intervalNs, f, 1)
+                ringWrite(buf, UInt64(i) * intervalNs, f, 1)
                 Thread.sleep(forTimeInterval: 0.001)
             }
             stop.set()
@@ -486,7 +486,7 @@
                 writerBlock: { _ in
                     for i in 0..<writeCount {
                         let f = self.makeFrames(writeIndex: i, count: frameCount)
-                        emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, frameCount)
+                        ringWrite(buf, UInt64(i) * 1_000, f, frameCount)
                         // No sleep. Maximum write pressure to force rapid wrap-around.
                     }
                 }
@@ -502,7 +502,7 @@
 
             for i in 0..<10 {
                 let f = makeFrames(writeIndex: i, count: 5)
-                emb_ring_buffer_write(buf, UInt64(i + 1) * 100_000_000, f, 5)
+                ringWrite(buf, UInt64(i + 1) * 100_000_000, f, 5)
             }
 
             let readerCount = 20

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferEdgeCaseTests.swift
@@ -14,7 +14,9 @@
 
         // Record layout constants (64-bit):
         //   uint32_t seq             = 4 bytes
-        //   uint32_t frame_count     = 4 bytes
+        //   uint16_t frame_count     = 2 bytes
+        //   uint8_t  thread_state    = 1 byte
+        //   uint8_t  flags           = 1 byte
         //   uint64_t timestamp_ns    = 8 bytes
         //   + 8 bytes per frame
         static let headerSize = 16
@@ -97,7 +99,7 @@
         func test_nextSeq_startsAtZero() {
             let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
-            XCTAssertEqual(buf.pointee.next_seq, 0)
+            XCTAssertEqual(buf.pointee.control.pointee.next_seq, 0)
         }
 
         func test_nextSeq_incrementsBy2PerSuccessfulWrite() {
@@ -106,9 +108,9 @@
 
             let frames: [UInt] = [0xCAFE]
             for i in 1...10 {
-                emb_ring_buffer_write(buf, UInt64(i) * 1_000, frames, frames.count)
+                ringWrite(buf, UInt64(i) * 1_000, frames, frames.count)
                 XCTAssertEqual(
-                    buf.pointee.next_seq, UInt64(i * 2),
+                    buf.pointee.control.pointee.next_seq, UInt64(i * 2),
                     "next_seq after \(i) writes")
             }
         }
@@ -117,16 +119,16 @@
             let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            emb_ring_buffer_write(nil, 1_000, [UInt(1)], 1)
-            XCTAssertEqual(buf.pointee.next_seq, 0)
+            ringWrite(nil, 1_000, [UInt(1)], 1)
+            XCTAssertEqual(buf.pointee.control.pointee.next_seq, 0)
         }
 
         func test_nextSeq_unchangedOnNilFramesWrite() {
             let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
 
-            emb_ring_buffer_write(buf, 1_000, nil, 5)
-            XCTAssertEqual(buf.pointee.next_seq, 0)
+            ringWrite(buf, 1_000, nil, 5)
+            XCTAssertEqual(buf.pointee.control.pointee.next_seq, 0)
         }
 
         func test_nextSeq_incrementsForZeroFrameRecords() {
@@ -134,27 +136,27 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let empty: [UInt] = []
-            emb_ring_buffer_write(buf, 1_000, empty, 0)
-            XCTAssertEqual(buf.pointee.next_seq, 2)
+            ringWrite(buf, 1_000, empty, 0)
+            XCTAssertEqual(buf.pointee.control.pointee.next_seq, 2)
         }
 
         // MARK: - Write returns false on bad inputs
 
         func test_write_nilBuffer_returnsBadArgs() {
             let frames: [UInt] = [1, 2, 3]
-            XCTAssertNotEqual(emb_ring_buffer_write(nil, 1_000, frames, frames.count), EMB_RING_WRITE_OK)
+            XCTAssertNotEqual(ringWrite(nil, 1_000, frames, frames.count), EMB_RING_WRITE_OK)
         }
 
         func test_write_nilFrames_returnsBadArgs() {
             let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
-            XCTAssertNotEqual(emb_ring_buffer_write(buf, 1_000, nil, 3), EMB_RING_WRITE_OK)
+            XCTAssertNotEqual(ringWrite(buf, 1_000, nil, 3), EMB_RING_WRITE_OK)
         }
 
         func test_write_nilFrames_leavesBufferEmpty() {
             let buf = emb_ring_buffer_create(1024 * 1024, nil)!
             defer { emb_ring_buffer_destroy(buf) }
-            emb_ring_buffer_write(buf, 1_000, nil, 3)
+            ringWrite(buf, 1_000, nil, 3)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
             XCTAssertEqual(records.count, 0)
@@ -167,7 +169,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames: [UInt] = [0xDEAD_BEEF, 0xCAFE_BABE, 0x1234_5678, 0xFFFF_FFFF]
-            emb_ring_buffer_write(buf, 42_000, frames, frames.count)
+            ringWrite(buf, 42_000, frames, frames.count)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
 
@@ -183,7 +185,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames = [UInt](repeating: 0, count: 8)
-            emb_ring_buffer_write(buf, 1_000, frames, frames.count)
+            ringWrite(buf, 1_000, frames, frames.count)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
 
@@ -198,7 +200,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let frames = [UInt](repeating: UInt.max, count: 8)
-            emb_ring_buffer_write(buf, 2_000, frames, frames.count)
+            ringWrite(buf, 2_000, frames, frames.count)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
 
@@ -214,7 +216,7 @@
 
             let count = 512
             let frames = (0..<count).map { UInt($0 + 1) }
-            emb_ring_buffer_write(buf, 99_000, frames, count)
+            ringWrite(buf, 99_000, frames, count)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
 
@@ -238,7 +240,7 @@
             ]
 
             for def in recordDefs {
-                emb_ring_buffer_write(buf, def.ts, def.frames, def.frames.count)
+                ringWrite(buf, def.ts, def.frames, def.frames.count)
             }
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -267,7 +269,7 @@
 
             for i in 0..<fits {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
+                ringWrite(buf, UInt64(i + 1), f, 1)
             }
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -287,11 +289,11 @@
 
             for i in 0..<fits {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
+                ringWrite(buf, UInt64(i + 1), f, 1)
             }
 
             let f: [UInt] = [0xBEEF]
-            emb_ring_buffer_write(buf, UInt64(fits + 1), f, 1)
+            ringWrite(buf, UInt64(fits + 1), f, 1)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
 
@@ -310,7 +312,7 @@
             let smallCount = page / RingBufferEdgeCaseTests.recordSize(1)
             for i in 0..<smallCount {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, UInt64(i + 1) * 100, f, 1)
+                ringWrite(buf, UInt64(i + 1) * 100, f, 1)
             }
 
             let cntBefore = testReadRange(buf, 0, UINT64_MAX).count
@@ -319,7 +321,7 @@
             let largeFC = 50
             let largeFrames = [UInt](repeating: 0xDEAD, count: largeFC)
             let largeTS: UInt64 = UInt64(smallCount + 1) * 100
-            emb_ring_buffer_write(buf, largeTS, largeFrames, largeFC)
+            ringWrite(buf, largeTS, largeFrames, largeFC)
 
             let after = testReadRange(buf, 0, UINT64_MAX)
 
@@ -345,13 +347,13 @@
 
             let empty: [UInt] = []
             for i in 0..<zeroCount {
-                emb_ring_buffer_write(buf, UInt64(i + 1) * 100, empty, 0)
+                ringWrite(buf, UInt64(i + 1) * 100, empty, 0)
             }
 
             let cntBefore = testReadRange(buf, 0, UINT64_MAX).count
             XCTAssertEqual(cntBefore, zeroCount)
 
-            emb_ring_buffer_write(buf, UInt64(zeroCount + 1) * 100, empty, 0)
+            ringWrite(buf, UInt64(zeroCount + 1) * 100, empty, 0)
 
             let after = testReadRange(buf, 0, UINT64_MAX)
 
@@ -372,7 +374,7 @@
 
             for i in 0..<totalWrites {
                 let f = [UInt](repeating: UInt(i + 1), count: 10)
-                emb_ring_buffer_write(buf, UInt64(i + 1), f, 10)
+                ringWrite(buf, UInt64(i + 1), f, 10)
             }
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -404,13 +406,13 @@
             while totalBytes + smallSz <= page {
                 ts += 1
                 let f: [UInt] = [UInt(ts)]
-                emb_ring_buffer_write(buf, ts, f, smallFC)
+                ringWrite(buf, ts, f, smallFC)
                 totalBytes += smallSz
 
                 if totalBytes + largeSz <= page {
                     ts += 1
                     let lf = [UInt](repeating: UInt(ts), count: largeFC)
-                    emb_ring_buffer_write(buf, ts, lf, largeFC)
+                    ringWrite(buf, ts, lf, largeFC)
                     totalBytes += largeSz
                 }
             }
@@ -419,7 +421,7 @@
 
             ts += 1
             let extra: [UInt] = [UInt(ts)]
-            emb_ring_buffer_write(buf, ts, extra, smallFC)
+            ringWrite(buf, ts, extra, smallFC)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
 
@@ -445,7 +447,7 @@
 
             for i in 0...fits {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, UInt64(i + 1), f, 1)
+                ringWrite(buf, UInt64(i + 1), f, 1)
             }
 
             let evicted = testReadRange(buf, 1, 1)
@@ -461,7 +463,7 @@
             // Monotonic timestamps; query skips the first two.
             for ts: UInt64 in [100, 200, 300, 400, 500] {
                 let f: [UInt] = [UInt(ts)]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 300, 400)
@@ -479,7 +481,7 @@
 
             for ts: UInt64 in [100, 200, 300, 400, 500] {
                 let f: [UInt] = [UInt(ts)]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 300, UINT64_MAX)
@@ -496,7 +498,7 @@
 
             for ts: UInt64 in [100, 200, 300, 400, 500] {
                 let f: [UInt] = [UInt(ts)]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 0, 300)
@@ -513,7 +515,7 @@
 
             for ts: UInt64 in [100, 200, 300] {
                 let f: [UInt] = [UInt(ts)]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 200, 200)
@@ -528,7 +530,7 @@
 
             for ts: UInt64 in [100, 200, 300] {
                 let f: [UInt] = [1]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 150, 150)
@@ -541,7 +543,7 @@
 
             for ts: UInt64 in [100, 200, 300] {
                 let f: [UInt] = [1]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 500, 100)
@@ -554,7 +556,7 @@
 
             for ts: UInt64 in [100, 200, 300] {
                 let f: [UInt] = [1]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 400, UINT64_MAX)
@@ -567,7 +569,7 @@
 
             for ts: UInt64 in [400, 500, 600] {
                 let f: [UInt] = [1]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 0, 300)
@@ -580,7 +582,7 @@
 
             for ts: UInt64 in [100, 300] {
                 let f: [UInt] = [1]
-                emb_ring_buffer_write(buf, ts, f, 1)
+                ringWrite(buf, ts, f, 1)
             }
 
             let records = testReadRange(buf, 150, 250)
@@ -594,7 +596,7 @@
             let sharedTS: UInt64 = 99_999
             for i in 0..<7 {
                 let f: [UInt] = [UInt(i + 1)]
-                emb_ring_buffer_write(buf, sharedTS, f, 1)
+                ringWrite(buf, sharedTS, f, 1)
             }
 
             let records = testReadRange(buf, sharedTS, sharedTS)
@@ -610,7 +612,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [0xABCD]
-            emb_ring_buffer_write(buf, 0, f, 1)
+            ringWrite(buf, 0, f, 1)
 
             let records = testReadRange(buf, 0, 0)
 
@@ -624,7 +626,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [0x1234]
-            emb_ring_buffer_write(buf, UINT64_MAX, f, 1)
+            ringWrite(buf, UINT64_MAX, f, 1)
 
             let records = testReadRange(buf, UINT64_MAX, UINT64_MAX)
 
@@ -638,7 +640,7 @@
 
             for i in 1...20 {
                 let f: [UInt] = [UInt(i)]
-                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 1)
+                ringWrite(buf, UInt64(i) * 1_000, f, 1)
             }
 
             let records = testReadRange(buf, 11_000, 11_000)
@@ -660,7 +662,7 @@
 
             for i in 1...20 {
                 let f: [UInt] = [UInt(i)]
-                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 1)
+                ringWrite(buf, UInt64(i) * 1_000, f, 1)
             }
 
             let records = testReadRange(buf, 5_000, 10_000)
@@ -679,7 +681,7 @@
 
             for i in 1...5 {
                 let f: [UInt] = [UInt(i * 10), UInt(i * 10 + 1)]
-                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
+                ringWrite(buf, UInt64(i) * 1_000, f, 2)
             }
 
             let r1 = testReadRange(buf, 0, UINT64_MAX)
@@ -703,7 +705,7 @@
 
             for i in 1...30 {
                 let f: [UInt] = [UInt(i)]
-                emb_ring_buffer_write(buf, UInt64(i) * 100_000_000, f, 1)
+                ringWrite(buf, UInt64(i) * 100_000_000, f, 1)
             }
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -731,7 +733,7 @@
             while total + rSize <= capacity {
                 ts += 1
                 let f: [UInt] = [UInt(ts), UInt(ts + 1), UInt(ts + 2)]
-                emb_ring_buffer_write(buf, ts, f, 3)
+                ringWrite(buf, ts, f, 3)
                 total += rSize
             }
 
@@ -740,7 +742,7 @@
 
             ts += 1
             let straddle: [UInt] = [UInt(ts), UInt(ts + 1), UInt(ts + 2)]
-            let ok = emb_ring_buffer_write(buf, ts, straddle, 3)
+            let ok = ringWrite(buf, ts, straddle, 3)
             XCTAssertEqual(ok, EMB_RING_WRITE_OK, "write straddling boundary must succeed")
 
             let records = testReadRange(buf, ts, ts)
@@ -766,7 +768,7 @@
 
             for i in 0..<total {
                 let f = [UInt](repeating: UInt(i + 1), count: 5)
-                emb_ring_buffer_write(buf, UInt64(i + 1), f, 5)
+                ringWrite(buf, UInt64(i + 1), f, 5)
             }
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -804,10 +806,10 @@
 
                 if fc == 0 {
                     let empty: [UInt] = []
-                    emb_ring_buffer_write(buf, ts, empty, 0)
+                    ringWrite(buf, ts, empty, 0)
                 } else {
                     let f = (0..<fc).map { UInt(sentinel) + UInt($0) }
-                    emb_ring_buffer_write(buf, ts, f, fc)
+                    ringWrite(buf, ts, f, fc)
                 }
             }
 
@@ -842,7 +844,7 @@
             let frameCount = (page / RingBufferEdgeCaseTests.frameSize) + 1
             let frames = [UInt](repeating: 0xDEAD, count: frameCount)
 
-            XCTAssertNotEqual(emb_ring_buffer_write(buf, 1_000, frames, frameCount), EMB_RING_WRITE_OK,
+            XCTAssertNotEqual(ringWrite(buf, 1_000, frames, frameCount), EMB_RING_WRITE_OK,
                 "Write should fail when record size exceeds buffer capacity")
 
             // Buffer should remain empty and functional.
@@ -851,7 +853,7 @@
 
             // A smaller write should still succeed.
             let small: [UInt] = [1]
-            XCTAssertEqual(emb_ring_buffer_write(buf, 2_000, small, 1), EMB_RING_WRITE_OK)
+            XCTAssertEqual(ringWrite(buf, 2_000, small, 1), EMB_RING_WRITE_OK)
         }
 
         func test_write_recordAtExactCapacity_succeeds() {
@@ -865,7 +867,7 @@
                 / RingBufferEdgeCaseTests.frameSize
 
             let frames = (0..<frameCount).map { UInt($0 + 1) }
-            XCTAssertEqual(emb_ring_buffer_write(buf, 42_000, frames, frameCount), EMB_RING_WRITE_OK,
+            XCTAssertEqual(ringWrite(buf, 42_000, frames, frameCount), EMB_RING_WRITE_OK,
                 "Write should succeed when record exactly fills buffer")
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -882,7 +884,7 @@
 
             for i in 1...20 {
                 let f: [UInt] = [UInt(i), UInt(i * 10)]
-                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
+                ringWrite(buf, UInt64(i) * 1_000, f, 2)
             }
 
             // Each record is header(16) + 2 frames(16) = 32 bytes.
@@ -905,7 +907,7 @@
 
             for i in 1...20 {
                 let f: [UInt] = [UInt(i), UInt(i * 10)]
-                emb_ring_buffer_write(buf, UInt64(i) * 1_000, f, 2)
+                ringWrite(buf, UInt64(i) * 1_000, f, 2)
             }
 
             // Each record is header(16) + 2 frames(16) = 32 bytes.
@@ -944,7 +946,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [1]
-            emb_ring_buffer_write(buf, 1_000, f, 1)
+            ringWrite(buf, 1_000, f, 1)
 
             // output_size = 0 triggers the NULL/empty guard in read_range.
             let output = UnsafeMutablePointer<UInt8>.allocate(capacity: 1)
@@ -960,7 +962,7 @@
             defer { emb_ring_buffer_destroy(buf) }
 
             let f: [UInt] = [1]
-            emb_ring_buffer_write(buf, 1_000, f, 1)
+            ringWrite(buf, 1_000, f, 1)
 
             let result = emb_ring_buffer_read_range(buf, 0, UINT64_MAX, nil, 1024)
             XCTAssertEqual(result.record_count, 0)
@@ -981,7 +983,7 @@
 
             // The C guard is: frames == NULL && frame_count > 0 → false.
             // NULL frames with 0 count should succeed and produce a zero-frame record.
-            XCTAssertEqual(emb_ring_buffer_write(buf, 42_000, nil, 0), EMB_RING_WRITE_OK,
+            XCTAssertEqual(ringWrite(buf, 42_000, nil, 0), EMB_RING_WRITE_OK,
                 "write with NULL frames and 0 frame_count should succeed")
 
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -999,7 +1001,7 @@
             // Fill with large records so reads take measurable time.
             for i in 0..<100 {
                 let frames = [UInt](repeating: UInt(i + 1), count: 100)
-                emb_ring_buffer_write(buf, UInt64(i + 1) * 1_000, frames, 100)
+                ringWrite(buf, UInt64(i + 1) * 1_000, frames, 100)
             }
 
             let capacity = emb_ring_buffer_capacity(buf)
@@ -1066,7 +1068,7 @@
             // Fill buffer with data.
             for i in 0..<50 {
                 let frames = [UInt](repeating: UInt(i + 1), count: 20)
-                emb_ring_buffer_write(buf, UInt64(i + 1) * 1_000, frames, 20)
+                ringWrite(buf, UInt64(i + 1) * 1_000, frames, 20)
             }
 
             let capacity = emb_ring_buffer_capacity(buf)
@@ -1130,7 +1132,7 @@
                     for j in 0..<10 {
                         let ts = UInt64(cycle * 10000 + j + 1)
                         let frames = [UInt](repeating: UInt(ts), count: 5)
-                        emb_ring_buffer_write(buf, ts, frames, 5)
+                        ringWrite(buf, ts, frames, 5)
                     }
                 }
             }
@@ -1150,7 +1152,7 @@
 
             // Write some valid data first.
             let f: [UInt] = [0xCAFE]
-            emb_ring_buffer_write(buf, 1_000, f, 1)
+            ringWrite(buf, 1_000, f, 1)
 
             let records = testReadRange(buf, 0, UINT64_MAX)
             XCTAssertEqual(records.count, 1, "Precondition: data should be readable")
@@ -1159,13 +1161,11 @@
             // so that write_pos - oldest_pos > capacity. The read path should detect
             // this and return empty rather than reading garbage.
             //
-            // Struct layout: data(8) + capacity(8) + next_seq(8) + write_pos(8)
-            // write_pos is at byte offset 24 from the start of the struct.
+            // write_pos is the first field (offset 0) of the control block.
             let capacity = buf.pointee.capacity
             let corruptWritePos = UInt64(capacity * 2)
-            let writePosOffset = 24  // data(8) + capacity(8) + next_seq(8)
-            UnsafeMutableRawPointer(buf).storeBytes(
-                of: corruptWritePos, toByteOffset: writePosOffset, as: UInt64.self)
+            UnsafeMutableRawPointer(buf.pointee.control).storeBytes(
+                of: corruptWritePos, toByteOffset: 0, as: UInt64.self)
 
             let corruptRecords = testReadRange(buf, 0, UINT64_MAX)
             XCTAssertEqual(corruptRecords.count, 0,

--- a/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingBufferWritePathTests.swift
@@ -24,7 +24,7 @@
             // Write a record.
             let testFrames: [UInt] = [0x1000, 0x2000, 0x3000]
             let timestamp: UInt64 = 123_456_789
-            XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, testFrames, testFrames.count), EMB_RING_WRITE_OK, "write should succeed")
+            XCTAssertEqual(ringWrite(buf, timestamp, testFrames, testFrames.count), EMB_RING_WRITE_OK, "write should succeed")
 
             // Read back all records.
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -64,7 +64,7 @@
 
                 let timestamp = UInt64(100_000 * (i + 1))
                 expectedTimestamps.append(timestamp)
-                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, frameCount), EMB_RING_WRITE_OK, "write \(i) should succeed")
+                XCTAssertEqual(ringWrite(buf, timestamp, frames, frameCount), EMB_RING_WRITE_OK, "write \(i) should succeed")
             }
 
             // Read back all records.
@@ -100,7 +100,7 @@
             // Write a zero-frame record.
             let timestamp: UInt64 = 999_999
             let frames: [UInt] = []
-            XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, 0), EMB_RING_WRITE_OK, "write should succeed")
+            XCTAssertEqual(ringWrite(buf, timestamp, frames, 0), EMB_RING_WRITE_OK, "write should succeed")
 
             // Read back.
             let records = testReadRange(buf, 0, UINT64_MAX)
@@ -135,7 +135,7 @@
 
                 let timestamp = UInt64(1_000_000 * (idx + 1))
                 expectedData.append((timestamp, frameCount))
-                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, frameCount), EMB_RING_WRITE_OK, "write \(idx) should succeed")
+                XCTAssertEqual(ringWrite(buf, timestamp, frames, frameCount), EMB_RING_WRITE_OK, "write \(idx) should succeed")
             }
 
             // Read back.
@@ -183,7 +183,7 @@
 
                 let timestamp = UInt64(i + 1)
                 lastTimestamps.append(timestamp)
-                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, 10), EMB_RING_WRITE_OK, "write \(i) should succeed")
+                XCTAssertEqual(ringWrite(buf, timestamp, frames, 10), EMB_RING_WRITE_OK, "write \(i) should succeed")
             }
 
             // Read back. Should get only the records that fit in the buffer
@@ -227,7 +227,7 @@
                     frames.append(UInt(i * 100 + j))
                 }
 
-                XCTAssertEqual(emb_ring_buffer_write(buf, UInt64(i), frames, 10), EMB_RING_WRITE_OK, "write \(i) should succeed")
+                XCTAssertEqual(ringWrite(buf, UInt64(i), frames, 10), EMB_RING_WRITE_OK, "write \(i) should succeed")
             }
 
             // Read back.
@@ -248,7 +248,7 @@
 
         func test_write_withNilBuffer_returnsFalse() {
             let frames: [UInt] = [0x1000, 0x2000]
-            XCTAssertNotEqual(emb_ring_buffer_write(nil, 123, frames, 2), EMB_RING_WRITE_OK)
+            XCTAssertNotEqual(ringWrite(nil, 123, frames, 2), EMB_RING_WRITE_OK)
         }
 
         func test_write_withNilFrames_returnsFalse() {
@@ -259,7 +259,7 @@
             }
             defer { emb_ring_buffer_destroy(buf) }
 
-            XCTAssertNotEqual(emb_ring_buffer_write(buf, 123, nil, 10), EMB_RING_WRITE_OK)
+            XCTAssertNotEqual(ringWrite(buf, 123, nil, 10), EMB_RING_WRITE_OK)
         }
 
         func test_write_recordTooLarge_returnsRecordTooLarge() {
@@ -277,7 +277,7 @@
             let frameCount = buf.pointee.capacity / MemoryLayout<UInt>.stride + 1
             let frames = [UInt](repeating: 0, count: frameCount)
             XCTAssertEqual(
-                emb_ring_buffer_write(buf, 1, frames, frameCount),
+                ringWrite(buf, 1, frames, frameCount),
                 EMB_RING_WRITE_RECORD_TOO_LARGE)
         }
 
@@ -294,7 +294,7 @@
             // The guard fires before any buffer access, so the frames array
             // size doesn't need to match the claimed count.
             XCTAssertEqual(
-                emb_ring_buffer_write(buf, 1, frames, Int(UInt32.max) + 1),
+                ringWrite(buf, 1, frames, Int(UInt32.max) + 1),
                 EMB_RING_WRITE_BAD_ARGS)
         }
         #endif
@@ -317,7 +317,7 @@
             for i in 0..<10 {
                 let frames: [UInt] = [UInt(i)]
                 let timestamp = UInt64((i + 1) * 1000)
-                XCTAssertEqual(emb_ring_buffer_write(buf, timestamp, frames, 1), EMB_RING_WRITE_OK)
+                XCTAssertEqual(ringWrite(buf, timestamp, frames, 1), EMB_RING_WRITE_OK)
             }
 
             // Read only records from 3000 to 7000 (inclusive).

--- a/Tests/EmbraceProfilingSamplerTests/RingWriteTestHelper.swift
+++ b/Tests/EmbraceProfilingSamplerTests/RingWriteTestHelper.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+//  Test shims that forward to the widened C APIs with default values for the
+//  Phase-2 additions (thread_state/flags on writes, is_truncated on the walker),
+//  so the many existing call sites don't each need editing. The first parameters
+//  match the C signatures exactly, so every prior call still type-checks.
+
+import EmbraceProfilingSampler
+
+#if !os(watchOS)
+
+@discardableResult
+func ringWrite(_ buf: UnsafeMutablePointer<emb_ring_buffer_t>?,
+               _ timestampNs: UInt64,
+               _ frames: UnsafePointer<UInt>?,
+               _ frameCount: Int,
+               _ threadState: UInt8 = 0,
+               _ flags: UInt8 = 0) -> emb_ring_write_status_t {
+    emb_ring_buffer_write(buf, timestampNs, frames, frameCount, threadState, flags)
+}
+
+@discardableResult
+func stackWalk(_ thread: thread_t,
+               _ stackBottom: UnsafeRawPointer?,
+               _ stackTop: UnsafeRawPointer?,
+               _ framesOut: UnsafeMutablePointer<UInt>?,
+               _ maxFrames: Int,
+               _ countOut: UnsafeMutablePointer<Int>?,
+               _ isTruncated: UnsafeMutablePointer<Bool>? = nil) -> Bool {
+    emb_stack_walk(thread, stackBottom, stackTop, framesOut, maxFrames, countOut, isTruncated)
+}
+
+#endif

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerBenchmarks.swift
@@ -23,7 +23,7 @@
             let maxFrames = 1024
             var frames = [UInt](repeating: 0, count: maxFrames)
             var count = 0
-            emb_stack_walk(port, stackBottom, stackTop, &frames, maxFrames, &count)
+            stackWalk(port, stackBottom, stackTop, &frames, maxFrames, &count)
             return count
         }
 

--- a/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
+++ b/Tests/EmbraceProfilingSamplerTests/StackWalkerTests.swift
@@ -38,7 +38,7 @@
 
             var frames = [UInt](repeating: 0, count: maxFrames)
             var count = 0
-            let walkResult = emb_stack_walk(port, bounds.bottom, bounds.top,
+            let walkResult = stackWalk(port, bounds.bottom, bounds.top,
                                             &frames, maxFrames, &count)
 
             thread_resume(port)
@@ -78,7 +78,7 @@
             let maxFrames = 512
             var frames = [UInt](repeating: 0, count: maxFrames)
             var count = 0
-            let walkResult = emb_stack_walk(machThread, bounds.bottom, bounds.top,
+            let walkResult = stackWalk(machThread, bounds.bottom, bounds.top,
                                             &frames, maxFrames, &count)
 
             // Resume immediately after walking.
@@ -104,7 +104,7 @@
             // Provide dummy stack bounds. The call should fail on thread_get_state.
             let dummy = UnsafeRawPointer(bitPattern: 1)!
             let dummyTop = UnsafeRawPointer(bitPattern: UInt.max)!
-            let result = emb_stack_walk(0, dummy, dummyTop, &frames, maxFrames, &count)
+            let result = stackWalk(0, dummy, dummyTop, &frames, maxFrames, &count)
             XCTAssertFalse(result, "Should fail with invalid thread")
             XCTAssertEqual(count, 0)
         }
@@ -113,7 +113,7 @@
             var count = 0
             let dummy = UnsafeRawPointer(bitPattern: 1)!
             let dummyTop = UnsafeRawPointer(bitPattern: UInt.max)!
-            let result = emb_stack_walk(mach_thread_self(), dummy, dummyTop, nil, 64, &count)
+            let result = stackWalk(mach_thread_self(), dummy, dummyTop, nil, 64, &count)
             XCTAssertFalse(result, "Should fail with null frames_out")
         }
 
@@ -122,7 +122,7 @@
             var count = 0
             let dummy = UnsafeRawPointer(bitPattern: 1)!
             let dummyTop = UnsafeRawPointer(bitPattern: UInt.max)!
-            let result = emb_stack_walk(mach_thread_self(), dummy, dummyTop, &frames, 0, &count)
+            let result = stackWalk(mach_thread_self(), dummy, dummyTop, &frames, 0, &count)
             XCTAssertFalse(result, "Should fail with max_frames == 0")
         }
 
@@ -200,7 +200,7 @@
                 let maxFrames = 512
                 var frames = [UInt](repeating: 0, count: maxFrames)
                 var count = 0
-                let ok = emb_stack_walk(port, bounds.bottom, bounds.top,
+                let ok = stackWalk(port, bounds.bottom, bounds.top,
                                         &frames, maxFrames, &count)
                 XCTAssertTrue(ok, "Walk \(i) should succeed")
 
@@ -249,7 +249,7 @@
             var frames = [UInt](repeating: 0, count: 64)
             var count = 0
             // Null stack_bottom.
-            let result = emb_stack_walk(port, nil, UnsafeRawPointer(bitPattern: UInt.max)!,
+            let result = stackWalk(port, nil, UnsafeRawPointer(bitPattern: UInt.max)!,
                                         &frames, 64, &count)
             XCTAssertFalse(result, "Should fail with null stack_bottom")
 
@@ -276,7 +276,7 @@
             var frames = [UInt](repeating: 0, count: 64)
             var count = 0
             // Inverted: bottom > top.
-            let result = emb_stack_walk(port, bounds.top, bounds.bottom,
+            let result = stackWalk(port, bounds.top, bounds.bottom,
                                         &frames, 64, &count)
             XCTAssertFalse(result, "Should fail with inverted stack bounds")
 
@@ -301,7 +301,7 @@
             XCTAssertEqual(suspendResult, KERN_SUCCESS)
 
             var frames = [UInt](repeating: 0, count: 64)
-            let result = emb_stack_walk(port, bounds.bottom, bounds.top,
+            let result = stackWalk(port, bounds.bottom, bounds.top,
                                         &frames, 64, nil)
             XCTAssertFalse(result, "Should fail with null count_out")
 
@@ -326,7 +326,7 @@
 
             var frames = [UInt](repeating: 0, count: 64)
             var count = 0
-            let result = emb_stack_walk(port, bounds.bottom, bounds.top, &frames, 64, &count)
+            let result = stackWalk(port, bounds.bottom, bounds.top, &frames, 64, &count)
             XCTAssertFalse(result, "Walk on a dead thread port should fail")
             XCTAssertEqual(count, 0)
         }

--- a/Tests/EmbraceProfilingSamplerTests/TestReadHelper.swift
+++ b/Tests/EmbraceProfilingSamplerTests/TestReadHelper.swift
@@ -12,6 +12,8 @@
         let timestamp_ns: UInt64
         let frame_count: Int
         let frames: [UInt]
+        var thread_state: UInt8 = 0
+        var flags: UInt8 = 0
     }
 
     /// Read matching records from a ring buffer into Swift-friendly structs.
@@ -49,7 +51,7 @@
             ) { $0.pointee }
 
             let fc = Int(hdr.frame_count)
-            let recordSize = Int(emb_ring_record_size(hdr.frame_count))
+            let recordSize = Int(emb_ring_record_size(UInt32(hdr.frame_count)))
             guard offset + recordSize <= validEnd else { break }
 
             var frames: [UInt] = []
@@ -65,7 +67,9 @@
             records.append(TestRecord(
                 timestamp_ns: hdr.timestamp_ns,
                 frame_count: fc,
-                frames: frames
+                frames: frames,
+                thread_state: hdr.thread_state,
+                flags: hdr.flags
             ))
 
             offset += recordSize

--- a/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
+++ b/Tests/EmbraceProfilingTests/FallbackBenchmarks.swift
@@ -50,7 +50,7 @@ final class FallbackBenchmarks: XCTestCase {
     private func walkWithFP(port: thread_t, stackBottom: UnsafeRawPointer, stackTop: UnsafeRawPointer) -> Int {
         var frames = [UInt](repeating: 0, count: Self.maxFrames)
         var count = 0
-        emb_stack_walk(port, stackBottom, stackTop, &frames, Self.maxFrames, &count)
+        emb_stack_walk(port, stackBottom, stackTop, &frames, Self.maxFrames, &count, nil)
         return count
     }
 

--- a/Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift
@@ -65,7 +65,8 @@ extension ProfilingEngine {
     /// TEST-ONLY: Write a synthetic sample directly to the ring buffer.
     /// Buffer must have been allocated (via ``allocateBufferForTesting(configuration:)`` or ``start(configuration:)``).
     /// Does NOT acquire the gate. Caller must ensure no concurrent access.
-    func writeSampleForTesting(timestamp: UInt64, frames: [UInt]) -> Bool {
+    func writeSampleForTesting(timestamp: UInt64, frames: [UInt],
+                               threadState: UInt8 = 0, flags: UInt8 = 0) -> Bool {
         #if os(watchOS)
             return false
         #else
@@ -74,7 +75,8 @@ extension ProfilingEngine {
             return frames.withUnsafeBufferPointer { buf in
                 guard let baseAddress = buf.baseAddress else { return false }
                 return baseAddress.withMemoryRebound(to: uintptr_t.self, capacity: frames.count) { ptr in
-                    emb_ring_buffer_write(ringBuffer, timestamp, ptr, frames.count) == EMB_RING_WRITE_OK
+                    emb_ring_buffer_write(ringBuffer, timestamp, ptr, frames.count,
+                                          threadState, flags) == EMB_RING_WRITE_OK
                 }
             }
         #endif
@@ -102,7 +104,11 @@ extension ProfilingEngine {
             // since we've already stopped the sampler.
             let gateAcquired = acquireGate()
 
-            if let rb = ringBuffer {
+            if let s = store {
+                emb_profile_store_destroy(s)  // frees the attached ring-buffer wrapper + unmaps
+                store = nil
+                ringBuffer = nil
+            } else if let rb = ringBuffer {
                 emb_ring_buffer_destroy(rb)
                 ringBuffer = nil
             }
@@ -112,6 +118,7 @@ extension ProfilingEngine {
             }
             readBufferSize = 0
             activeConfiguration = nil
+            activeSessionFileName = nil
 
             emb_sampler_reset_for_testing()
 

--- a/Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift
@@ -6,23 +6,19 @@
     @testable import EmbraceProfiling
     import EmbraceProfilingSampler
     import EmbraceProfilingTestSupport
-#endif
 
-extension ProfilingEngine {
+    extension ProfilingEngine {
 
-    /// TEST-ONLY: Allocate the ring buffer without starting the sampler.
-    /// Allows writing synthetic data via ``writeSampleForTesting(timestamp:frames:)``
-    /// then reading via ``retrieveSamples(from:through:)``.
-    /// Acquires the gate. Returns false on allocation failure, invalid config, or gate contention.
-    func allocateBufferForTesting(
-        configuration: ProfilingConfiguration = ProfilingConfiguration()
-    ) -> Bool {
-        #if os(watchOS)
-            return false
-        #else
+        /// TEST-ONLY: Allocate the ring buffer without starting the sampler.
+        /// Allows writing synthetic data via ``writeSampleForTesting(timestamp:frames:)``
+        /// then reading via ``retrieveSamples(from:through:)``.
+        /// Acquires the backing gate. Returns false on allocation failure, invalid config, or gate contention.
+        func allocateBufferForTesting(
+            configuration: ProfilingConfiguration = ProfilingConfiguration()
+        ) -> Bool {
             guard configuration.isValid else { return false }
-            guard acquireGate() else { return false }
-            defer { releaseGate() }
+            guard acquireBackingGate() else { return false }
+            defer { releaseBackingGate() }
 
             guard !emb_sampler_is_active() else { return false }
 
@@ -59,17 +55,13 @@ extension ProfilingEngine {
 
             activeConfiguration = configuration
             return true
-        #endif
-    }
+        }
 
-    /// TEST-ONLY: Write a synthetic sample directly to the ring buffer.
-    /// Buffer must have been allocated (via ``allocateBufferForTesting(configuration:)`` or ``start(configuration:)``).
-    /// Does NOT acquire the gate. Caller must ensure no concurrent access.
-    func writeSampleForTesting(timestamp: UInt64, frames: [UInt],
-                               threadState: UInt8 = 0, flags: UInt8 = 0) -> Bool {
-        #if os(watchOS)
-            return false
-        #else
+        /// TEST-ONLY: Write a synthetic sample directly to the ring buffer.
+        /// Buffer must have been allocated (via ``allocateBufferForTesting(configuration:)`` or ``start(configuration:)``).
+        /// Does NOT acquire the gate. Caller must ensure no concurrent access.
+        func writeSampleForTesting(timestamp: UInt64, frames: [UInt],
+                                   threadState: UInt8 = 0, flags: UInt8 = 0) -> Bool {
             guard let ringBuffer else { return false }
 
             return frames.withUnsafeBufferPointer { buf in
@@ -79,15 +71,13 @@ extension ProfilingEngine {
                                           threadState, flags) == EMB_RING_WRITE_OK
                 }
             }
-        #endif
-    }
+        }
 
-    /// TEST-ONLY: Reset the engine to a clean initial state.
-    /// Stops sampler if active (with polling wait), destroys ring buffer,
-    /// deallocates read buffer, resets C sampler state.
-    /// Acquires the gate.
-    func resetForTesting() {
-        #if !os(watchOS)
+        /// TEST-ONLY: Reset the engine to a clean initial state.
+        /// Stops sampler if active (with polling wait), destroys ring buffer,
+        /// deallocates read buffer, resets C sampler state.
+        /// Acquires the backing gate.
+        func resetForTesting() {
             emb_sampler_stop()
 
             let deadline = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) + 5_000_000_000
@@ -102,7 +92,7 @@ extension ProfilingEngine {
 
             // Best-effort gate acquisition: if it times out we still clean up
             // since we've already stopped the sampler.
-            let gateAcquired = acquireGate()
+            let gateAcquired = acquireBackingGate()
 
             if let s = store {
                 emb_profile_store_destroy(s)  // frees the attached ring-buffer wrapper + unmaps
@@ -123,8 +113,8 @@ extension ProfilingEngine {
             emb_sampler_reset_for_testing()
 
             if gateAcquired {
-                releaseGate()
+                releaseBackingGate()
             }
-        #endif
+        }
     }
-}
+#endif

--- a/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
@@ -62,6 +62,22 @@
             XCTAssertEqual(Array(result.frames), [0x11, 0x22])
         }
 
+        /// End-to-end: a real I/O failure (permission denied) at recovery time must surface its `errno`
+        /// in the `.unreadable` reason string, not just a flat "I/O error".
+        func test_recover_permissionDenied_reasonIncludesErrno() throws {
+            try XCTSkipIf(getuid() == 0, "root bypasses file permission checks")
+            makeCrashedSessionFile(named: "noperm.embprof", frames: [0x11], ts: 100)
+            let handle = try XCTUnwrap(ProfilingEngine.shared.recoverableSessions(in: dir).first)
+
+            try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: handle.url.path)
+            defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: handle.url.path) }
+
+            guard case let .unreadable(reason) = ProfilingEngine.shared.recover(handle) else {
+                return XCTFail("expected .unreadable for a permission-denied file")
+            }
+            XCTAssertTrue(reason.contains("errno"), "reason should include the errno: \(reason)")
+        }
+
         func test_recoverableSessions_skipsFinalizedForRecovery() {
             // A finalized (cleanly-stopped) file: listed with .finalized status, recover → .finalized.
             let path = dir.appendingPathComponent("ccdd.embprof").path

--- a/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
@@ -62,9 +62,9 @@
             XCTAssertEqual(Array(result.frames), [0x11, 0x22])
         }
 
-        /// End-to-end: a real I/O failure (permission denied) at recovery time must surface its `errno`
-        /// in the `.unreadable` reason string, not just a flat "I/O error".
-        func test_recover_permissionDenied_reasonIncludesErrno() throws {
+        /// End-to-end: a real I/O failure (permission denied) at recovery time must surface as a typed
+        /// `.ioError` carrying the causing `errno`, not collapse to an opaque failure.
+        func test_recover_permissionDenied_surfacesTypedIOError() throws {
             try XCTSkipIf(getuid() == 0, "root bypasses file permission checks")
             makeCrashedSessionFile(named: "noperm.embprof", frames: [0x11], ts: 100)
             let handle = try XCTUnwrap(ProfilingEngine.shared.recoverableSessions(in: dir).first)
@@ -72,10 +72,13 @@
             try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: handle.url.path)
             defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: handle.url.path) }
 
-            guard case let .unreadable(reason) = ProfilingEngine.shared.recover(handle) else {
+            guard case let .unreadable(failure) = ProfilingEngine.shared.recover(handle) else {
                 return XCTFail("expected .unreadable for a permission-denied file")
             }
-            XCTAssertTrue(reason.contains("errno"), "reason should include the errno: \(reason)")
+            guard case let .ioError(errno) = failure else {
+                return XCTFail("expected .ioError, got \(failure)")
+            }
+            XCTAssertNotEqual(errno, 0, "ioError should carry the causing errno")
         }
 
         func test_recoverableSessions_skipsFinalizedForRecovery() {

--- a/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
@@ -53,8 +53,9 @@
             XCTAssertEqual(handle.status, .recoverable)
             XCTAssertGreaterThan(handle.byteSize, 0)
 
-            guard case let .recovered(result) = ProfilingEngine.shared.recover(handle) else {
-                return XCTFail("expected .recovered, got \(ProfilingEngine.shared.recover(handle))")
+            let recovery = ProfilingEngine.shared.recover(handle)
+            guard case let .recovered(result) = recovery else {
+                return XCTFail("expected .recovered, got \(recovery)")
             }
             XCTAssertEqual(result.samples.count, 1)
             XCTAssertEqual(result.samples[0].threadState, .running)

--- a/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngineFileBackedTests.swift
@@ -1,0 +1,160 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import EmbraceProfilingSampler
+    import Foundation
+    import XCTest
+
+    @testable import EmbraceProfiling
+
+    /// Integration tests for the file-backed engine path + recovery (Step 6).
+    final class ProfilingEngineFileBackedTests: XCTestCase {
+        private var dir: URL!
+
+        override func setUp() {
+            super.setUp()
+            ProfilingEngine.shared.resetForTesting()
+            dir = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("embprof-engine-\(UUID().uuidString)", isDirectory: true)
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        override func tearDown() {
+            ProfilingEngine.shared.resetForTesting()
+            if let dir { try? FileManager.default.removeItem(at: dir) }
+            super.tearDown()
+        }
+
+        /// Build a "crashed previous session" file directly via the C store API: records written, then
+        /// destroyed WITHOUT finalize, so format_version stays 1 (exactly what a crash leaves behind).
+        private func makeCrashedSessionFile(named name: String, frames: [UInt], ts: UInt64) {
+            let path = dir.appendingPathComponent(name).path
+            var err: Int32 = 0
+            guard let store = emb_profile_store_create(path, 256 * 1024, nil, &err) else {
+                return XCTFail("store create failed, errno=\(err)")
+            }
+            let buf = emb_profile_store_buffer(store)
+            frames.withUnsafeBufferPointer { fb in
+                _ = emb_ring_buffer_write(buf, ts, fb.baseAddress, fb.count, 1 /* running */, 0)
+            }
+            emb_profile_store_destroy(store)
+        }
+
+        func test_recoverableSessions_listsCrashedSession_thenRecover() {
+            makeCrashedSessionFile(named: "aabb.embprof", frames: [0x11, 0x22], ts: 100)
+
+            let sessions = ProfilingEngine.shared.recoverableSessions(in: dir)
+            XCTAssertEqual(sessions.count, 1)
+            let handle = try! XCTUnwrap(sessions.first)
+            XCTAssertEqual(handle.sessionId, "aabb")
+            XCTAssertEqual(handle.status, .recoverable)
+            XCTAssertGreaterThan(handle.byteSize, 0)
+
+            guard case let .recovered(result) = ProfilingEngine.shared.recover(handle) else {
+                return XCTFail("expected .recovered, got \(ProfilingEngine.shared.recover(handle))")
+            }
+            XCTAssertEqual(result.samples.count, 1)
+            XCTAssertEqual(result.samples[0].threadState, .running)
+            XCTAssertEqual(Array(result.frames), [0x11, 0x22])
+        }
+
+        func test_recoverableSessions_skipsFinalizedForRecovery() {
+            // A finalized (cleanly-stopped) file: listed with .finalized status, recover → .finalized.
+            let path = dir.appendingPathComponent("ccdd.embprof").path
+            var err: Int32 = 0
+            let store = try! XCTUnwrap(emb_profile_store_create(path, 256 * 1024, nil, &err))
+            [0x11 as UInt].withUnsafeBufferPointer {
+                _ = emb_ring_buffer_write(emb_profile_store_buffer(store), 100, $0.baseAddress, 1, 1, 0)
+            }
+            emb_profile_store_finalize(store)  // version-0 tombstone
+            emb_profile_store_destroy(store)
+
+            let handle = try! XCTUnwrap(ProfilingEngine.shared.recoverableSessions(in: dir).first)
+            XCTAssertEqual(handle.status, .finalized)
+            guard case .finalized = ProfilingEngine.shared.recover(handle) else {
+                return XCTFail("finalized file should recover as .finalized")
+            }
+        }
+
+        func test_recoverableSessions_missingDirectory_returnsEmpty() {
+            let missing = dir.appendingPathComponent("does-not-exist", isDirectory: true)
+            XCTAssertTrue(ProfilingEngine.shared.recoverableSessions(in: missing).isEmpty)
+        }
+
+        func test_recoverableSessions_emptyDirectory_returnsEmpty() {
+            XCTAssertTrue(ProfilingEngine.shared.recoverableSessions(in: dir).isEmpty)
+        }
+
+        func test_delete_removesSessionFile() {
+            makeCrashedSessionFile(named: "dead.embprof", frames: [0x1], ts: 1)
+            let handle = try! XCTUnwrap(ProfilingEngine.shared.recoverableSessions(in: dir).first)
+
+            XCTAssertTrue(ProfilingEngine.shared.delete(handle))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: handle.url.path))
+            XCTAssertTrue(ProfilingEngine.shared.recoverableSessions(in: dir).isEmpty)
+        }
+
+        func test_fileBackedStart_writeRetrieve_andFinalize() {
+            let engine = ProfilingEngine.shared
+            let sid = [UInt8](repeating: 0xCD, count: 16)
+
+            let r = engine.start(configuration: ProfilingConfiguration(startPaused: true),
+                                 directory: dir, sessionId: sid)
+            XCTAssertEqual(r, .started)
+
+            // startPaused → the worker isn't writing, so a direct test write is race-free.
+            XCTAssertTrue(engine.writeSampleForTesting(timestamp: 100, frames: [0xAA], threadState: 3 /* waiting */))
+
+            guard case let .success(pr) = engine.retrieveSamples(from: 0, through: .max) else {
+                return XCTFail("retrieve failed")
+            }
+            XCTAssertEqual(pr.samples.count, 1)
+            XCTAssertEqual(pr.samples[0].threadState, .waiting)
+            XCTAssertEqual(Array(pr.frames), [0xAA])
+
+            // The session's file exists under the injected directory.
+            let fileName = sid.map { String(format: "%02x", $0) }.joined() + ".embprof"
+            XCTAssertTrue(FileManager.default.fileExists(atPath: dir.appendingPathComponent(fileName).path))
+
+            engine.stop()
+            let deadline = Date().addingTimeInterval(2)
+            while engine.isActive && Date() < deadline { usleep(1000) }
+            engine.finalizeStorage()  // clean stop → version-0 tombstone
+        }
+
+        /// finalizeStorage() must refuse to tombstone while the worker is still active — otherwise the
+        /// version-0 marker would make recovery discard the whole (not-yet-drained) file. We start a
+        /// file-backed (paused, so still active) session with a sample, call finalizeStorage() while
+        /// active, then tear down without finalizing and confirm the session is STILL recoverable —
+        /// proving the call was a no-op. (Without the guard, recovery would return FINALIZED instead.)
+        func test_finalizeStorage_whileActive_isNoOp_sessionStaysRecoverable() {
+            let engine = ProfilingEngine.shared
+            let sid = [UInt8](repeating: 0x5A, count: 16)
+
+            XCTAssertEqual(engine.start(configuration: ProfilingConfiguration(startPaused: true),
+                                        directory: dir, sessionId: sid), .started)
+            XCTAssertTrue(engine.writeSampleForTesting(timestamp: 100, frames: [0xAA], threadState: 1))
+            XCTAssertTrue(engine.isActive)
+
+            engine.finalizeStorage()  // active → must be a no-op (leave the session recoverable)
+
+            engine.stop()
+            let deadline = Date().addingTimeInterval(2)
+            while engine.isActive && Date() < deadline { usleep(1000) }
+            engine.resetForTesting()  // tears down the store (file persists, NOT finalized), clears active name
+
+            // Still recoverable (version 1) → finalize while active was a no-op. Were it not, the file
+            // would be tombstoned (.finalized) and recover would return nothing.
+            let handle = try! XCTUnwrap(engine.recoverableSessions(in: dir).first)
+            XCTAssertEqual(handle.status, .recoverable)
+            guard case let .recovered(result) = engine.recover(handle) else {
+                return XCTFail("session should still be recoverable; finalize while active must be a no-op")
+            }
+            XCTAssertEqual(result.samples.count, 1)
+        }
+    }
+
+#endif

--- a/Tests/EmbraceProfilingTests/ProfilingEnginePauseTests.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEnginePauseTests.swift
@@ -210,20 +210,31 @@
             // STARTING when pause() runs. Pre-fix this returned false (pause
             // only accepted RUNNING) and the engine emitted samples until the
             // caller noticed and re-issued pause. With the C1 fix, pause()
-            // accepts STARTING and the request takes effect on the worker's
-            // first loop iteration.
+            // accepts STARTING and takes effect from the worker's next loop
+            // iteration onward.
             XCTAssertEqual(engine.start(configuration: Self.fastConfig), .started)
             XCTAssertTrue(engine.pause(),
                 "pause() called immediately after start() must succeed even"
                 + " when the worker is still in STARTING")
 
-            // Wait long enough for the worker to reach RUNNING and process
-            // many cycles. With a working pause, none of them sample.
             Thread.sleep(forTimeInterval: 0.25)
             XCTAssertTrue(engine.isPaused)
             XCTAssertFalse(engine.isCapturing)
-            XCTAssertEqual(currentSampleCount(), 0,
-                "No samples should be captured: pause was applied during STARTING")
+
+            // The worker samples immediately on reaching RUNNING (the cadence sleep is at the
+            // end of its loop), so it can win the race against this pause() and land exactly
+            // one sample. That is inherent to starting unpaused and is not what this test
+            // pins down — `startPaused: true` is the race-free way to begin at zero, covered
+            // by test_resume_immediatelyAfterStartPaused_takesEffect. What must hold here is
+            // that pause() is honoured rather than lost: at a 50ms cadence the 0.25s above
+            // would have produced ~5 samples if it were.
+            let afterPause = currentSampleCount()
+            XCTAssertLessThanOrEqual(afterPause, 1,
+                "at most the single immediate sample may precede pause()")
+
+            Thread.sleep(forTimeInterval: 0.25)
+            XCTAssertEqual(currentSampleCount(), afterPause,
+                "pause() applied during STARTING must stop all further sampling")
 
             engine.stop()
             XCTAssertTrue(waitForFullStop())

--- a/Tests/EmbraceProfilingTests/ProfilingEngineTests.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngineTests.swift
@@ -1148,12 +1148,13 @@
             let secondHeaderOffset = firstRecordSize
             let frameCountOffset = secondHeaderOffset + 4  // Skip seq field
 
-            // Write an impossibly large frame_count (> EMB_MAX_STACK_FRAMES).
+            // Write an impossibly large frame_count (> EMB_MAX_STACK_FRAMES). frame_count is a
+            // uint16 at offset 4, so 0xFFFF (65535) is well above the 1024 cap.
             let data = ringBuffer.pointee.data!
             data.advanced(by: frameCountOffset).withMemoryRebound(
-                to: UInt32.self, capacity: 1
+                to: UInt16.self, capacity: 1
             ) { ptr in
-                ptr.pointee = 0xFFFF_FFFF  // Way above 1024
+                ptr.pointee = 0xFFFF  // 65535, way above 1024
             }
 
             // retrieveSamples should stop parsing at the corrupted record.

--- a/Tests/EmbraceProfilingTests/ThreadStateTests.swift
+++ b/Tests/EmbraceProfilingTests/ThreadStateTests.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS)
+
+    import Darwin
+    import XCTest
+
+    @testable import EmbraceProfiling
+
+    /// The Swift `ThreadState` enum and the C `emb_thread_run_state_t` both independently mirror the
+    /// Mach `TH_STATE_*` constants (the C side is locked by a `_Static_assert` in emb_ring_buffer.h).
+    /// This anchors the Swift side to the same source of truth so the two can't silently drift.
+    final class ThreadStateTests: XCTestCase {
+        func test_threadState_rawValuesMatchMachConstants() {
+            XCTAssertEqual(ThreadState.running.rawValue, UInt8(TH_STATE_RUNNING))
+            XCTAssertEqual(ThreadState.stopped.rawValue, UInt8(TH_STATE_STOPPED))
+            XCTAssertEqual(ThreadState.waiting.rawValue, UInt8(TH_STATE_WAITING))
+            XCTAssertEqual(ThreadState.uninterruptible.rawValue, UInt8(TH_STATE_UNINTERRUPTIBLE))
+            XCTAssertEqual(ThreadState.halted.rawValue, UInt8(TH_STATE_HALTED))
+        }
+
+        /// 255 is the "couldn't capture" sentinel — a value Mach never returns for `run_state`.
+        func test_threadState_unknownIsSentinel() {
+            XCTAssertEqual(ThreadState.unknown.rawValue, 255)
+            XCTAssertNil(ThreadState(rawValue: 254))  // unmapped values decode to nil (→ .unknown at call sites)
+        }
+    }
+
+#endif


### PR DESCRIPTION
## Summary

Adds optional file-backed persistence to `EmbraceProfiling` so sampling-profiler data survives abrupt process death (crash, OOM, or Jetsam) and can be recovered on the next launch. In-memory profiling (the default) is unchanged.

## Motivation

The sampling profiler previously held samples only in memory, so anything captured before an abrupt termination was lost. This adds a persistence path whose samples are flushed to disk by the kernel even on SIGKILL/Jetsam, plus a read-only recovery API to retrieve them next launch.

## How it works

- Samples are written into a double-mapped ("magic ring") `MAP_SHARED` region backed by a per-session file. The single-writer / multi-reader lock-free ring buffer is unchanged; only its backing store and control block moved into the mapping.
- On process death the kernel flushes the dirty `MAP_SHARED` pages to the file. (Validated on the macOS host and a physical device across all kill modes, including Jetsam.)
- The file carries a frozen 16-byte tail identity (magic + format version) and a versioned trailer; `format_version == 0` doubles as the transactional "disregard" marker and the clean-stop tombstone.
- Hardening: a `PROT_NONE` guard page bounds runaway writes; the metadata page is `mprotect`-locked write-once; on iOS the file uses data-protection Class B (CompleteUnlessOpen) so it keeps accepting writes while the device is locked.
- Recovery is strictly read-only. It validates the trailer/control block and walk records with torn-tail / zeroed-page / overrun stop conditions, discarding anything inconsistent. It never writes or deletes.

## API

- `start(configuration:directory:sessionId:)`: Pass a `directory` for file-backed mode (default `nil` = in-memory, unchanged). `sessionId` is an opaque 16-byte per-launch id.
- `recoverableSessions(in:) -> [RecoverableSession]`: Cheap enumeration (file metadata + a 16-byte identity peek, no samples loaded). Each handle exposes `sessionId`, `lastModified`, `byteSize`, and `status` (`.recoverable` / `.finalized`).
- `recover(_:) -> SessionRecoveryResult`: Recover a single session's samples.
- `delete(_:)`: Remove a session's file. The host app owns retention; the SDK never auto-deletes.
- `flush()`: `msync` ahead of a possible background Jetsam (call on background/terminate).
- `finalizeStorage()`: Write the clean-stop tombstone after the worker has stopped.
- `ProfilingSample` gains `threadState` (captured pre-suspend).

## Integration notes

- On a clean stop, call `finalizeStorage()` once the worker has exited (poll `isActive`); otherwise the session is listed as recoverable next launch: harmless, and `delete()`-able.
- Recovery calls are read-only and intended to run off the main thread at launch; process one handle at a time to bound memory.
- Retrieve any live samples before `finalizeStorage()`. Finalizing discards the on-disk copy.

## Compatibility

- In-memory mode is the default and behaves exactly as before; no change for existing callers.
- watchOS remains a no-op (file-backed APIs return empty / `.notSupported`).

## Testing

- 260 unit tests, 0 failures.
- Host + on-device kill-tests confirm samples survive SIGKILL/Jetsam and clean finalize.
- AddressSanitizer: clean. ThreadSanitizer: lock-free concurrency tests pass with only the inherent, by-design seqlock read/write pattern flagged (safe via sequence re-validation).
- iOS (arm64) and macOS builds verified.


## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
