### PR TITLE
[EMBR-12756] Fix: Guard MockSpanProcessor span arrays against TSan data race

### DIFF
--- a/Tests/TestSupport/Mocks/MockSpanProcessor.swift
+++ b/Tests/TestSupport/Mocks/MockSpanProcessor.swift
@@ -9,10 +9,35 @@ import OpenTelemetrySdk
 
 public class MockSpanProcessor: SpanProcessor {
 
-    private(set) public var startedSpans = [SpanData]()
-    private(set) public var endedSpans = [SpanData]()
-    private(set) public var didShutdown = false
-    private(set) public var didForceFlush = false
+    private let lock = NSLock()
+
+    private var _startedSpans = [SpanData]()
+    public var startedSpans: [SpanData] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _startedSpans
+    }
+
+    private var _endedSpans = [SpanData]()
+    public var endedSpans: [SpanData] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _endedSpans
+    }
+
+    private var _didShutdown = false
+    public var didShutdown: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _didShutdown
+    }
+
+    private var _didForceFlush = false
+    public var didForceFlush: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _didForceFlush
+    }
 
     public init() {}
 
@@ -21,19 +46,29 @@ public class MockSpanProcessor: SpanProcessor {
     public let isEndRequired: Bool = true
 
     public func onStart(parentContext: SpanContext?, span: ReadableSpan) {
-        startedSpans.append(span.toSpanData())
+        let data = span.toSpanData()
+        lock.lock()
+        defer { lock.unlock() }
+        _startedSpans.append(data)
     }
 
     public func onEnd(span: ReadableSpan) {
-        endedSpans.append(span.toSpanData())
+        let data = span.toSpanData()
+        lock.lock()
+        defer { lock.unlock() }
+        _endedSpans.append(data)
     }
 
     public func forceFlush(timeout: TimeInterval?) {
-        didForceFlush = true
+        lock.lock()
+        defer { lock.unlock() }
+        _didForceFlush = true
     }
 
     public func shutdown(explicitTimeout: TimeInterval?) {
-        didShutdown = true
+        lock.lock()
+        defer { lock.unlock() }
+        _didShutdown = true
     }
 
 }


### PR DESCRIPTION
## Summary

`HangCaptureServiceTests` crashes intermittently under ThreadSanitizer with `Test crashed with signal abrt`. The crash is a data race in the `MockSpanProcessor` mock, not in production code:  `HangCaptureService` appends spans from its background `spanQueue` (`onStart`/`onEnd`) while the test reads `endedSpans` / `startedSpans` on the main thread. The backing arrays were unsynchronized, so concurrent append + read tripped TSan and aborted the process.

This PR guards `startedSpans`, `endedSpans`, and the `didShutdown` / `didForceFlush` flags with an `NSLock`. 

**Test-only change — no production code is affected.**

## Fix

- Back each exposed property with a private `_`-prefixed field plus a lock-guarded computed accessor.
- Take the lock in `onStart` / `onEnd` / `forceFlush` / `shutdown` mutators (snapshotting `toSpanData()` before locking to keep the critical section minimal).

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
