### PR TITLE
[EMBR-12757] Fix: Use a generic simulator destination for builds in run-xcodebuild

### DIFF
--- a/.github/actions/run-xcodebuild/action.yml
+++ b/.github/actions/run-xcodebuild/action.yml
@@ -81,14 +81,29 @@ runs:
         PLATFORM_VERSION="${PLATFORM_VERSION:-latest}"
 
         case "$PLATFORM" in
-          iOS)          DESTINATION="platform=iOS Simulator,OS=${PLATFORM_VERSION},name=iPhone 16" ;;
-          tvOS)         DESTINATION="platform=tvOS Simulator,OS=${PLATFORM_VERSION},name=Apple TV" ;;
-          watchOS)      DESTINATION="platform=watchOS Simulator,OS=${PLATFORM_VERSION},name=Apple Watch Series 10 (46mm)" ;;
-          visionOS)     DESTINATION="platform=visionOS Simulator,OS=${PLATFORM_VERSION},name=Apple Vision Pro" ;;
+          iOS)          SIM_PLATFORM="iOS Simulator";      SIM_NAME="iPhone 16" ;;
+          tvOS)         SIM_PLATFORM="tvOS Simulator";     SIM_NAME="Apple TV" ;;
+          watchOS)      SIM_PLATFORM="watchOS Simulator";  SIM_NAME="Apple Watch Series 10 (46mm)" ;;
+          visionOS)     SIM_PLATFORM="visionOS Simulator"; SIM_NAME="Apple Vision Pro" ;;
           macOS)        DESTINATION="platform=macOS,arch=${ARCH}" ;;
           mac-catalyst) DESTINATION="platform=macOS,variant=Mac Catalyst,arch=${ARCH}" ;;
           *)            echo "::error::run-xcodebuild: unknown platform '$PLATFORM'"; exit 1 ;;
         esac
+
+        # Simulator platforms split by action. A `build` needs no concrete
+        # device — or even a populated runtime — so it targets the generic
+        # simulator destination, which is immune to runner-image device/runtime
+        # churn (e.g. an image that ships "iPhone 16e" but not "iPhone 16", or an
+        # `-downloadPlatform` runtime with no devices created against it — both
+        # of which broke cocoapod-lint on 2026-06-24). A `test` must run on a
+        # real device, so it resolves a named one against the latest runtime.
+        if [[ -n "${SIM_PLATFORM:-}" ]]; then
+          if [[ "$XCODE_ACTION" == "build" ]]; then
+            DESTINATION="generic/platform=${SIM_PLATFORM}"
+          else
+            DESTINATION="platform=${SIM_PLATFORM},OS=${PLATFORM_VERSION},name=${SIM_NAME}"
+          fi
+        fi
 
         # `-skip*Validation` flags suppress the interactive trust prompt for
         # SwiftPM plugins and Swift macros, which would hang non-interactive CI.
@@ -162,6 +177,18 @@ runs:
           echo "::warning::xcodebuild log not readable at $XCODEBUILD_LOG — failure summary unavailable"
           ls -la "$(dirname "$XCODEBUILD_LOG")" 2>&1 || true
           exit 0
+        fi
+
+        # A destination-resolution failure ("Unable to find a device matching
+        # …") is almost always runner-image device/runtime drift, not a code
+        # bug. Dump the devices that ARE available so the fix is copying the
+        # right name out of the log rather than a forensic dig. (Builds use a
+        # generic simulator destination and won't hit this; only the named
+        # test destination can.)
+        if grep -q "Unable to find a device matching" "$XCODEBUILD_LOG"; then
+          echo "::group::Available simulator devices (destination resolution failed)"
+          xcrun simctl list devices available || true
+          echo "::endgroup::"
         fi
 
         # `: error: ` is xcodebuild's diagnostic prefix and covers compile


### PR DESCRIPTION
## Summary

The shared `run-xcodebuild` composite action pinned every iOS destination to `platform=iOS Simulator,OS=latest,name=iPhone 16` — for both `build` and `test`. A **build**  doesn't run on a device, so naming one (and an OS) is needless coupling to the runner image. On 2026-06-24 that coupling broke `main`'s `cocoapod-lint`:

- the macOS-26 runner shipped `iPhone 16e`, not `iPhone 16`, and
- the `Ensure the Platform is Downloaded` step pulled an iOS 26.0.1 runtime with **no devices created against it**, so `OS=latest` pointed at an empty runtime.

## Change

- **Builds** now target `generic/platform=<X> Simulator` for all simulator platforms (iOS / tvOS / watchOS / visionOS). No concrete device, no OS, no populated runtime required — immune to runner-image device/runtime churn. macOS / Mac Catalyst destinations are unchanged.
- **Tests** are unchanged — they must run on a real device, so they keep resolving a named device against the latest runtime.
- On an `Unable to find a device matching` failure, the failure-summary step now dumps `xcrun simctl list devices available`, so any future device drift  is a copy-the-right-name fix.

## Affected callers

| Workflow | Action | Effect |
|---|---|---|
| `cocoapod-lint` (iOS) | build | **Fixed** — was red on 2026-06-24 |
| `build-example-apps` (iOS) | build | More robust |
| `build-platforms` (matrix) | build | More robust (simulator platforms) |
| `run-tests` (matrix) | test | **No behavior change** |

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
