### PR TITLE
[EMBR-12758] Fix: Bump test simulator devices to iPhone 17 / Apple Watch Series 11

### DIFF
--- a/.github/actions/run-xcodebuild/action.yml
+++ b/.github/actions/run-xcodebuild/action.yml
@@ -81,9 +81,9 @@ runs:
         PLATFORM_VERSION="${PLATFORM_VERSION:-latest}"
 
         case "$PLATFORM" in
-          iOS)          SIM_PLATFORM="iOS Simulator";      SIM_NAME="iPhone 16" ;;
+          iOS)          SIM_PLATFORM="iOS Simulator";      SIM_NAME="iPhone 17" ;;
           tvOS)         SIM_PLATFORM="tvOS Simulator";     SIM_NAME="Apple TV" ;;
-          watchOS)      SIM_PLATFORM="watchOS Simulator";  SIM_NAME="Apple Watch Series 10 (46mm)" ;;
+          watchOS)      SIM_PLATFORM="watchOS Simulator";  SIM_NAME="Apple Watch Series 11 (46mm)" ;;
           visionOS)     SIM_PLATFORM="visionOS Simulator"; SIM_NAME="Apple Vision Pro" ;;
           macOS)        DESTINATION="platform=macOS,arch=${ARCH}" ;;
           mac-catalyst) DESTINATION="platform=macOS,variant=Mac Catalyst,arch=${ARCH}" ;;

--- a/.github/workflows/cocoapod-lint.yml
+++ b/.github/workflows/cocoapod-lint.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-and-lint-cocoapod:
     name: Cocoapod Build And Lint
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 60
     strategy:
       fail-fast: true


### PR DESCRIPTION
 ## Summary

Bumps the `test`-path simulator devices in `run-xcodebuild` to the current generation:

- iOS: `iPhone 16` → `iPhone 17`
- watchOS: `Apple Watch Series 10 (46mm)` → `Apple Watch Series 11 (46mm)`

`tvOS` (`Apple TV`) and `visionOS` (`Apple Vision Pro`) are already the newest base devices —  unchanged. 

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
