### PR TITLE
[EMBR-12758] Fix: Bump test simulator devices + pin cocoapod-lint runner (re-land)

### DIFF
--- a/.github/actions/run-xcodebuild/action.yml
+++ b/.github/actions/run-xcodebuild/action.yml
@@ -81,9 +81,9 @@ runs:
         PLATFORM_VERSION="${PLATFORM_VERSION:-latest}"
 
         case "$PLATFORM" in
-          iOS)          SIM_PLATFORM="iOS Simulator";      SIM_NAME="iPhone 16" ;;
+          iOS)          SIM_PLATFORM="iOS Simulator";      SIM_NAME="iPhone 17" ;;
           tvOS)         SIM_PLATFORM="tvOS Simulator";     SIM_NAME="Apple TV" ;;
-          watchOS)      SIM_PLATFORM="watchOS Simulator";  SIM_NAME="Apple Watch Series 10 (46mm)" ;;
+          watchOS)      SIM_PLATFORM="watchOS Simulator";  SIM_NAME="Apple Watch Series 11 (46mm)" ;;
           visionOS)     SIM_PLATFORM="visionOS Simulator"; SIM_NAME="Apple Vision Pro" ;;
           macOS)        DESTINATION="platform=macOS,arch=${ARCH}" ;;
           mac-catalyst) DESTINATION="platform=macOS,variant=Mac Catalyst,arch=${ARCH}" ;;

--- a/.github/workflows/cocoapod-lint.yml
+++ b/.github/workflows/cocoapod-lint.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-and-lint-cocoapod:
     name: Cocoapod Build And Lint
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 60
     strategy:
       fail-fast: true


### PR DESCRIPTION
## Summary

Re-land of #656 (EMBR-12758), whose changes never reached `main`: #656 was stacked on #655's branch and got merged into that base ~20s after #655 had already merged the base into `main`, so GitHub's auto-retarget lost the race and the two commits never propagated. `main` still has the old values.

This re-applies them directly on top of `main`:

- `run-xcodebuild` test destinations: `iPhone 16` → **`iPhone 17`**, `Apple Watch Series 10 (46mm)` → **`Apple Watch Series 11 (46mm)`** (only the `test` path uses named devices; builds use the generic destination from #655).
- `cocoapod-lint.yml`: `runs-on: macos-latest` → **`macos-15`**, matching `run-tests` / `build-platforms` / `build-example-apps` so it can't silently jump to `macos-26` when that label rolls to GA.

## Note

Open against `main` (not stacked). 3-line diff across 2 files.
