### PR TITLE
[EMBR-12771] Fix: Poll request count in test_queueCapLimitsOperations instead of draining queues

### DIFF
--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOrderedDeliveryTests.swift
@@ -146,18 +146,16 @@ class EmbraceUploadOrderedDeliveryTests: XCTestCase {
             }
         }
 
-        wait(for: [completionExpectation], timeout: .defaultTimeout)
+        wait(for: [completionExpectation], timeout: .longTimeout)
 
-        // Wait for all operations to drain (fillQueue refills after each completion)
-        module.queue.sync {}
-        module.spansQueue.waitUntilAllOperationsAreFinished()
-        // Allow any remaining fillQueue cycles to complete
-        module.queue.sync {}
-        module.spansQueue.waitUntilAllOperationsAreFinished()
-
-        // All records should eventually be uploaded
-        let requests = EmbraceHTTPMock.requestsForUrl(spansUrl)
-        XCTAssertEqual(requests.count, totalRecords)
+        // fillQueue refills the capped queue after each completion, so the final
+        // request can land just after its completion callback fires. Poll the mock
+        // until every record has been uploaded rather than draining the queues,
+        // which races that refill cycle.
+        wait(timeout: .longTimeout, interval: .shortInterval) {
+            EmbraceHTTPMock.requestsForUrl(spansUrl).count == totalRecords
+        }
+        XCTAssertEqual(EmbraceHTTPMock.requestsForUrl(spansUrl).count, totalRecords)
     }
 
     // MARK: - 3. fillQueue excludes in-flight


### PR DESCRIPTION
 ## Summary

`EmbraceUploadOrderedDeliveryTests.test_queueCapLimitsOperations` flakes with `XCTAssertEqual failed: ("4") is not equal to ("5")` — it reproduces on the first iteration under `-test-iterations` locally, and hit `main` on 2026-05-29 (run 26652716715) and 2026-06-24 (run 28117020059), iOS sanitizer-none both times.

## Root cause

The test enqueues 5 records with a queue cap of 2, then decided "uploads are done" by draining machinery state:

  ```swift
  wait(for: completionExpectation, timeout: .defaultTimeout)
  module.queue.sync {}
  module.spansQueue.waitUntilAllOperationsAreFinished()
  module.queue.sync {}
  module.spansQueue.waitUntilAllOperationsAreFinished()
  XCTAssertEqual(requests.count, 5)
  ```

`fillQueue` refills the capped queue across two queues with async hops: an operation finishes (and leaves `spansQueue`) *before* the `handleOperationFinished` → `fillQueue` hop that enqueues the next record has run — so `spansQueue` is transiently empty *between* refills. `waitUntilAllOperationsAreFinished()`returns true in one of those gaps, and `queue.sync {}` only flushes work already submitted, so the assertion can read the request count before the last record's request goes out → 4. 

## Fix

Poll the monotonic observable outcome — the mock's request count — instead of draining the queues.

The count only increases, so once it reaches 5 the condition is permanently true; the poll returns immediately when work is already done and otherwise waits out the final refill cycle. Same poll-the-end-state approach as the merged #636 / the SessionController fix. 

Test-only change.

## Validation

`test_queueCapLimitsOperations` looped **50/50** under `-test-iterations` on the iPhone 16 simulator (previously failed on iteration 1). 

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
