### PR TITLE
[EMBR-12774] Fix: Use .veryLongTimeout for test_fetchCrashReports_count to absorb CI contention under ASan

### DIFF
--- a/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
+++ b/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
@@ -82,7 +82,11 @@
                 expectation.fulfill()
             }
 
-            wait(for: [expectation], timeout: .defaultTimeout)
+            // The fetch itself is fast (tens of ms, even under the address sanitizer); the
+            // flake is scheduling starvation on a contended CI runner, where ASan's CPU
+            // overhead across parallel test processes can delay this completion well past the
+            // default timeout. Use a generous timeout so a contention spike doesn't flake.
+            wait(for: [expectation], timeout: .veryLongTimeout)
         }
 
         func test_appendCrashInfo_addsKeyValuesInKSCrashUserInfo() throws {


### PR DESCRIPTION
## Summary

`EmbraceCrashReporterTests.test_fetchCrashReports_count` intermittently fails on the iOS **address sanitizer** job with `Asynchronous wait failed: Exceeded timeout of 3 seconds` — the `fetchUnsentCrashReports` completion isn't observed within the 3 s (`.defaultTimeout`) wait.

## Suspected root cause

The work isn't inherently slow -- seeding 9 reports and scanning/hydrating them runs in ~tens of ms, even under ASan when run locally on a fast Mac. The flake is most likely scheduling starvation on a contended CI runner — ASan's CPU overhead across many parallel test processes on a slow shared macOS runner, which delays the completion callback well past 3 s, even though the work is trivial.

## Attempted fix

Bump the wait to `.veryLongTimeout` (7 s). If this is not sufficient, we will increase it even more.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
