### PR TITLE
[EMBR-12776] Fix: Stabilize iOSSessionLifecycle off-main-thread startSession test

### DIFF
--- a/Tests/EmbraceCoreTests/Session/Lifecycle/Implementations/iOSSessionLifecycleTests.swift
+++ b/Tests/EmbraceCoreTests/Session/Lifecycle/Implementations/iOSSessionLifecycleTests.swift
@@ -56,9 +56,10 @@ import XCTest
             XCTAssertEqual(mockController.currentSession?.state, "foreground")
         }
 
-        func test_startSession_fromBackgroundQueue_callsControllerStartSession_andSetsSessionState() {
-            let expectation = XCTestExpectation(description: "startSession called from background queue")
-            DispatchQueue.global(qos: .background).async { [self] in
+        func test_startSession_fromNonMainThread_callsControllerStartSession_andSetsSessionState() {
+            let expectation = XCTestExpectation(description: "startSession called off the main thread")
+            DispatchQueue.global(qos: .default).async { [self] in
+                XCTAssertFalse(Thread.isMainThread)
                 lifecycle.startSession()
                 expectation.fulfill()
             }


### PR DESCRIPTION
## Summary

`iOSSessionLifecycleTests.test_startSession_fromBackgroundQueue_…` flakes on CI: `Asynchronous wait failed: Exceeded timeout of 5 seconds … "startSession called from background queue"`, then `mockController.currentSession?.state` is `nil` instead of `"foreground"` — seen on both regular and ASan runs.

## What the test is for

It's the off-main-thread counterpart of `test_startSession_callsControllerStartSession_andSetsSessionState` directly above it: identical assertions, the only variable is that `startSession()` is invoked from a non-main dispatch queue. It verifies `startSession()` is safe to call off the main thread (it reads active`/`currentState` and calls the controller; only `setup()` is main-thread-bound).

## Suspected root cause

The block was dispatched on `DispatchQueue.global(qos: .background)` — the **lowest** QoS. Under CI load the worker pool probably deprioritizes it to the point that the block isn't scheduled within the 5s expectation and the  test times out. The QoS is irrelevant to what's being verified — any non-main thread is fine.

## Changes

- `qos: .background` → `.default` so the block is scheduled more promptly (still a global worker thread, so it still exercises the off-main path).
- Rename `…_fromBackgroundQueue_…` → `…_fromNonMainThread_…`. "Background" was ambiguous: in this domain it reads as the app **session state** (the test asserts state `"foreground"`) and it collides with the dispatch QoS. The intent is simply "not the main thread."
- Add `XCTAssertFalse(Thread.isMainThread)` inside the block to make that intent explicit.

Test-only change.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
