### PR TITLE
[EMBR-12784] Chore: Unblock AppSizeTester on current Tuist and clear its stale SwiftNIO Dependabot alerts

### DIFF
--- a/Examples/AppSizeTester/README.md
+++ b/Examples/AppSizeTester/README.md
@@ -23,8 +23,18 @@ To use this example project, you should follow these steps:
 
 Ensure that you have the following tools installed on your system:
 - **[Xcode](https://developer.apple.com/xcode/)**
-- **[Tuist](https://github.com/tuist/tuist/)**: Needed to set up and generate the Xcode project and workspace.
-- **[Bundler](https://bundler.io/)**: Used to manage Ruby dependencies and ensure that you can run `Fastlane`.
+- **[Tuist](https://github.com/tuist/tuist/)**: Needed to set up and generate the Xcode project and workspace. The default (remote-SDK) flow works with current Tuist; the local-SDK mode below has a version constraint.
+- **[Bundler](https://bundler.io/)**: Used to manage Ruby dependencies and ensure that you can run `Fastlane`. Versions are pinned in `Gemfile.lock`.
+
+### Which SDK gets measured
+
+By default the project resolves the Embrace SDK **remotely from the `main` branch**, so generation works with current Tuist. Two environment variables control the source:
+
+- `EMBRACE_APPSIZE_SDK_REF` — the remote branch to measure (default `main`).
+- `EMBRACE_APPSIZE_LOCAL_SDK=1` — measure the **working-tree** SDK (`../../../`) instead, e.g. to size uncommitted changes.
+
+> [!IMPORTANT]
+> Local-SDK mode requires **Tuist ≤ 4.181.1**. Tuist 4.182.0 introduced "preserve test targets for local SPM packages", which pulls the SDK's test targets into the generated graph; those depend on the test-only `TestSupport` helper that Tuist ignores by product type, so project generation fails with `Couldn't find target 'TestSupport'`. **This still fails as of Tuist 4.200.5 (latest verified 2026-06-26)**, so local mode stays constrained to ≤ 4.181.1 until a fix lands. The default remote mode is unaffected. (Track [tuist/tuist](https://github.com/tuist/tuist).)
 
 ### Steps
 

--- a/Examples/AppSizeTester/README.md
+++ b/Examples/AppSizeTester/README.md
@@ -30,7 +30,7 @@ Ensure that you have the following tools installed on your system:
 
 By default the project resolves the Embrace SDK **remotely from the `main` branch**, so generation works with current Tuist. Two environment variables control the source:
 
-- `EMBRACE_APPSIZE_SDK_REF` — the remote branch to measure (default `main`).
+- `EMBRACE_APPSIZE_SDK_REF` — the remote ref to measure: a branch (default `main`) or a release tag (e.g. `6.20.0`).
 - `EMBRACE_APPSIZE_LOCAL_SDK=1` — measure the **working-tree** SDK (`../../../`) instead, e.g. to size uncommitted changes.
 
 > [!IMPORTANT]

--- a/Examples/AppSizeTester/Tuist/Package.resolved
+++ b/Examples/AppSizeTester/Tuist/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "embrace-apple-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/embrace-io/embrace-apple-sdk",
+      "state" : {
+        "branch" : "main",
+        "revision" : "189c994ba74cf3beeb3a856434e941a154af1391"
+      }
+    },
+    {
       "identity" : "kscrash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kstenerud/KSCrash",
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -32,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     }
   ],

--- a/Examples/AppSizeTester/Tuist/Package.resolved
+++ b/Examples/AppSizeTester/Tuist/Package.resolved
@@ -1,48 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "datacompression",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mw99/DataCompression",
-      "state" : {
-        "revision" : "5ab15951321b08b74511601cbd0497667649d70b",
-        "version" : "3.8.0"
-      }
-    },
-    {
-      "identity" : "grpc-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift.git",
-      "state" : {
-        "revision" : "a56a157218877ef3e9625f7e1f7b2cb7e46ead1b",
-        "version" : "1.26.1"
-      }
-    },
-    {
       "identity" : "kscrash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kstenerud/KSCrash",
       "state" : {
-        "revision" : "0c515d8533318fc882f5b316abb17f2110fb4f9e",
-        "version" : "2.2.0"
+        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
+        "version" : "2.5.1"
       }
     },
     {
-      "identity" : "opentelemetry-swift",
+      "identity" : "opentelemetry-swift-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/open-telemetry/opentelemetry-swift",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core",
       "state" : {
-        "revision" : "ed2b110d2bb4516e9c73df86c56a7836f5068666",
-        "version" : "2.0.0"
-      }
-    },
-    {
-      "identity" : "opentracing-objc",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/opentracing-objc",
-      "state" : {
-        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
-        "version" : "0.5.2"
+        "revision" : "d77f1400f4c5738f04a1aec0a1246aec5240e9fa",
+        "version" : "2.5.0"
       }
     },
     {
@@ -55,120 +28,12 @@
       }
     },
     {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types",
-      "state" : {
-        "revision" : "ae67c8178eb46944fd85e4dc6dd970e1f3ed6ccd",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
-        "version" : "1.6.3"
-      }
-    },
-    {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "4c83e1cdf4ba538ef6e43a9bbd0bcc33a0ca46e3",
-        "version" : "2.7.0"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "a5fea865badcb1c993c85b0f0e8d05a4bd2270fb",
-        "version" : "2.85.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
-        "version" : "1.24.1"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "c7e95421334b1068490b5d41314a50e70bab23d1",
-        "version" : "2.29.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "decfd235996bc163b44e10b8a24997a3d2104b90",
-        "version" : "1.25.0"
-      }
-    },
-    {
-      "identity" : "swift-protobuf",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
-      "state" : {
-        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
-        "version" : "1.30.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
-      }
-    },
-    {
-      "identity" : "thrift-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
-      "state" : {
-        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
-        "version" : "1.1.2"
       }
     }
   ],

--- a/Examples/AppSizeTester/Tuist/Package.swift
+++ b/Examples/AppSizeTester/Tuist/Package.swift
@@ -1,4 +1,5 @@
 // swift-tools-version: 5.9
+import Foundation
 import PackageDescription
 
 #if TUIST
@@ -9,11 +10,30 @@ import PackageDescription
     )
 #endif
 
+let environment = ProcessInfo.processInfo.environment
+
+// The SDK dependency is resolved remotely by default so the project generates with current Tuist.
+//
+// Set EMBRACE_APPSIZE_LOCAL_SDK=1 to instead build the working-tree SDK (../../../) — useful for
+// measuring uncommitted changes. That path requires Tuist <= 4.181.1: Tuist 4.182.0 added "preserve
+// test targets for local SPM packages", which pulls the SDK's test targets into the graph; those
+// depend on the test-only `TestSupport` helper (which Tuist ignores by product type), so generation
+// fails. Remote dependencies are not affected by that feature.
+//
+// In remote mode, EMBRACE_APPSIZE_SDK_REF overrides the branch (default "main").
+// `Package` is ambiguous here because Tuist evaluates this manifest with `-D TUIST`, which imports
+// ProjectDescription (it also defines a `Package` type) — so qualify the SwiftPM one explicitly.
+let sdkDependency: PackageDescription.Package.Dependency
+if environment["EMBRACE_APPSIZE_LOCAL_SDK"] != nil {
+    sdkDependency = .package(path: "../../../")
+} else {
+    let ref = environment["EMBRACE_APPSIZE_SDK_REF"] ?? "main"
+    sdkDependency = .package(url: "https://github.com/embrace-io/embrace-apple-sdk", branch: ref)
+}
+
 let package = Package(
     name: "AppSizeTester",
     dependencies: [
-        .package(
-            path: "../../../"
-        )
+        sdkDependency
     ]
 )

--- a/Examples/AppSizeTester/Tuist/Package.swift
+++ b/Examples/AppSizeTester/Tuist/Package.swift
@@ -20,15 +20,22 @@ let environment = ProcessInfo.processInfo.environment
 // depend on the test-only `TestSupport` helper (which Tuist ignores by product type), so generation
 // fails. Remote dependencies are not affected by that feature.
 //
-// In remote mode, EMBRACE_APPSIZE_SDK_REF overrides the branch (default "main").
-// `Package` is ambiguous here because Tuist evaluates this manifest with `-D TUIST`, which imports
-// ProjectDescription (it also defines a `Package` type) — so qualify the SwiftPM one explicitly.
+// In remote mode, EMBRACE_APPSIZE_SDK_REF picks what to measure: a branch (default "main") or a
+// release tag. A semver-looking value is resolved as an exact tag; anything else as a branch.
+//
+// `Package`/`Version` are ambiguous here because Tuist evaluates this manifest with `-D TUIST`, which
+// imports ProjectDescription (it defines those types too) — so qualify the SwiftPM ones explicitly.
 let sdkDependency: PackageDescription.Package.Dependency
 if environment["EMBRACE_APPSIZE_LOCAL_SDK"] != nil {
     sdkDependency = .package(path: "../../../")
 } else {
     let ref = environment["EMBRACE_APPSIZE_SDK_REF"] ?? "main"
-    sdkDependency = .package(url: "https://github.com/embrace-io/embrace-apple-sdk", branch: ref)
+    let url = "https://github.com/embrace-io/embrace-apple-sdk"
+    if let tag = PackageDescription.Version(ref) {
+        sdkDependency = .package(url: url, exact: tag)
+    } else {
+        sdkDependency = .package(url: url, branch: ref)
+    }
 }
 
 let package = Package(


### PR DESCRIPTION
## Summary

Two related fixes for `Examples/AppSizeTester`, both contained to that folder (no SDK changes):

1. **Clears 5 Dependabot alerts** (SwiftNIO/gRPC: #15, #20, #21, #26, #27). Its `Tuist/Package.resolved` was ~11 months stale and still listed the pre-`opentelemetry-swift-core` graph (full `opentelemetry-swift` + `grpc-swift` + SwiftNIO). Regenerating against today's SDK drops all of it.
2. **Makes the project generate on current Tuist again.** It had stopped generating with `Couldn't find target 'TestSupport'` with recent Tuist releases.

## Root cause of the generation failure

Tuist **4.182.0** introduced *"preserve test targets for local SPM packages."* AppSizeTester consumes the SDK via a local path dep, so this applies: tuist now pulls the SDK's test targets into the graph, and they depend on the test-only `TestSupport` helper that tuist ignores by product type → dangling reference → hard error.

- Bisected: last good = **4.181.1**, first bad = **4.182.0** (both 2026-04-17), still broken on **4.200.5** (latest as of 2026-06-26).
- The SDK manifest is unchanged since 2023 — purely a tuist behavior change, and only for **local** package deps.

## Fix

`Tuist/Package.swift` now selects the SDK source via env vars, defaulting to **remote** (which the 4.182.0 feature doesn't touch, so it generates on current tuist):

- default: remote `main`
- `EMBRACE_APPSIZE_SDK_REF=<ref>` — remote branch (default `main`) or release tag (e.g. `6.20.0`)
- `EMBRACE_APPSIZE_LOCAL_SDK=1` — working-tree SDK (`../../../`), for sizing uncommitted changes; documented to require tuist ≤ 4.181.1

No global tuist pin (that would wrongly constrain the default path); the version caveat is local-mode-only and documented in the README.

## Validation (via mise)

| Mode | tuist 4.200.5 | tuist 4.181.1 |
|---|---|---|
| default (remote `main`) | ✅ generates | — |
| `EMBRACE_APPSIZE_SDK_REF=6.20.0` (tag) | ✅ generates | — |
| `EMBRACE_APPSIZE_LOCAL_SDK=1` | ❌ `TestSupport` (documented) | ✅ generates |

Regenerated lockfile is NIO/gRPC-free.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
