### PR TITLE
[EMBR-12794] Fix: CocoaPods: drop removed EmbraceOTelInternal subspec

### DIFF
--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceConfigInternal"
     subs.dependency "EmbraceIO/EmbraceKSCrashBacktraceSupport"
-    subs.dependency "EmbraceIO/EmbraceOTelInternal"
+    subs.dependency "EmbraceIO/EmbraceOTelBridge"
     subs.dependency "EmbraceIO/EmbraceStorageInternal"
     subs.dependency "EmbraceIO/EmbraceUploadInternal"
     subs.dependency "EmbraceIO/EmbraceObjCUtilsInternal"
@@ -67,7 +67,7 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'EmbraceCaptureService' do |subs|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
-    subs.dependency "EmbraceIO/EmbraceOTelInternal"
+    subs.dependency "EmbraceIO/EmbraceOTelBridge"
     subs.dependency "EmbraceIO/OpenTelemetrySdk"
     subs.dependency "EmbraceIO/EmbraceConfiguration"
   end
@@ -81,15 +81,6 @@ Pod::Spec.new do |spec|
   spec.subspec 'EmbraceConfiguration' do |subs|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceSemantics"
-  end
-
-  spec.subspec 'EmbraceOTelInternal' do |subs|
-    subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
-    subs.dependency "EmbraceIO/EmbraceCommonInternal"
-    subs.dependency "EmbraceIO/EmbraceSemantics"
-    subs.dependency "EmbraceIO/OpenTelemetrySdk"
-    subs.dependency "EmbraceIO/EmbraceCoreDataInternal"
-    subs.dependency "EmbraceIO/EmbraceStorageInternal"
   end
 
   spec.subspec 'EmbraceOTelBridge' do |subs|
@@ -116,7 +107,7 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceCoreDataInternal"
-    subs.dependency "EmbraceIO/EmbraceOTelInternal"
+    subs.dependency "EmbraceIO/EmbraceOTelBridge"
   end
 
   spec.subspec 'EmbraceCrashlyticsSupport' do |subs|

--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -40,7 +40,6 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceConfigInternal"
     subs.dependency "EmbraceIO/EmbraceKSCrashBacktraceSupport"
-    subs.dependency "EmbraceIO/EmbraceOTelBridge"
     subs.dependency "EmbraceIO/EmbraceStorageInternal"
     subs.dependency "EmbraceIO/EmbraceUploadInternal"
     subs.dependency "EmbraceIO/EmbraceObjCUtilsInternal"
@@ -67,8 +66,8 @@ Pod::Spec.new do |spec|
 
   spec.subspec 'EmbraceCaptureService' do |subs|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
-    subs.dependency "EmbraceIO/EmbraceOTelBridge"
-    subs.dependency "EmbraceIO/OpenTelemetrySdk"
+    subs.dependency "EmbraceIO/EmbraceSemantics"
+    subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceConfiguration"
   end
 
@@ -107,7 +106,6 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
     subs.dependency "EmbraceIO/EmbraceCommonInternal"
     subs.dependency "EmbraceIO/EmbraceCoreDataInternal"
-    subs.dependency "EmbraceIO/EmbraceOTelBridge"
   end
 
   spec.subspec 'EmbraceCrashlyticsSupport' do |subs|


### PR DESCRIPTION
## Problem
`Cocoapod Build And Lint` is failing on every 7.0 PR:

```
ERROR | [iOS] [EmbraceIO/EmbraceOTelInternal] file patterns: The source_files pattern did not match any file. [!] EmbraceIO did not pass validation, due to 1 error.
```

#658 removed the `EmbraceOTelInternal` module (`Sources/EmbraceOTelInternal/`), but `EmbraceIO.podspec` still declared an `EmbraceOTelInternal` subspec whose `source_files` pattern now matches nothing, so `pod lib lint` fails deterministically.

## Fix
- Removed the dead `EmbraceOTelInternal` subspec.
- Repointed its three dependents — `EmbraceCore`, `EmbraceCaptureService`, `EmbraceUploadInternal` — to the replacement `EmbraceOTelBridge` subspec (where the OTel code now lives).

## Verification

Ran the exact CI command locally:

`pod lib lint --allow-warnings --verbose --platforms=iOS` → EmbraceIO passed validation.

## Checklist

- [ ] PR Description to summarize changes
- [ ] Add sufficient test coverage
- [ ] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
