### PR TITLE
EXPERIMENT — DO NOT MERGE: iOSSessionLifecycle off-main flake repro/fix

### DIFF
--- a/.github/workflows/experiment-flaky.yml
+++ b/.github/workflows/experiment-flaky.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Run variations x50
         run: |
           set +e
-          if [ "${{ matrix.mode }}" = "saturated" ]; then export EXPERIMENT_SATURATE=1; fi
+          # TEST_RUNNER_ prefix forwards the var into the simulator test process (a bare
+          # EXPERIMENT_SATURATE in the host shell never reaches it, so saturation wouldn't engage).
+          if [ "${{ matrix.mode }}" = "saturated" ]; then export TEST_RUNNER_EXPERIMENT_SATURATE=1; fi
           # Raw xcodebuild output is tee'd to the job log AND out.log so results are recoverable.
           xcodebuild test \
             -workspace .swiftpm/xcode/package.xcworkspace \

--- a/.github/workflows/experiment-flaky.yml
+++ b/.github/workflows/experiment-flaky.yml
@@ -18,7 +18,8 @@ env:
 
 jobs:
   # Run the 4 variations x50 in two modes:
-  #   saturated → GCD pool deliberately exhausted (deterministic mechanism check)
+  #   saturated → GCD pool deliberately exhausted (mechanism check; expect v0/v3 to fail on the
+  #               core-constrained runner, v1/v2 to pass)
   #   isolated  → no saturation (do they pass alone, under normal load?)
   variations:
     name: variations-${{ matrix.mode }}
@@ -43,6 +44,7 @@ jobs:
         run: |
           set +e
           if [ "${{ matrix.mode }}" = "saturated" ]; then export EXPERIMENT_SATURATE=1; fi
+          # Raw xcodebuild output is tee'd to the job log AND out.log so results are recoverable.
           xcodebuild test \
             -workspace .swiftpm/xcode/package.xcworkspace \
             -scheme EmbraceIO-Package \
@@ -50,55 +52,19 @@ jobs:
             -only-testing:"$ONLY" \
             -test-iterations 50 \
             -skipPackagePluginValidation -skipMacroValidation \
-            > out.log 2>&1
+            2>&1 | tee out.log
           echo "## variations (${{ matrix.mode }}) — of 50 iterations" >> "$GITHUB_STEP_SUMMARY"
+          total=0
           for v in v0_control_defaultGlobal v1_detachNewThread v2_dedicatedQueue v3_userInitiatedGlobal; do
-            p=$(grep -cE "test_${v}'\\)? passed" out.log)
-            f=$(grep -cE "test_${v}'\\)? failed" out.log)
+            p=$(grep -cE "test_${v}\]' passed" out.log)
+            f=$(grep -cE "test_${v}\]' failed" out.log)
+            total=$((total + p + f))
             echo "- test_${v}: ${p} passed / ${f} failed" >> "$GITHUB_STEP_SUMMARY"
           done
           cat "$GITHUB_STEP_SUMMARY"
-
-  # Soak: run the FULL suite many times as independent fresh-process samples (each ~= one real CI
-  # run) under genuine contention. The point isn't just to confirm the known fix — it's to give any
-  # OTHER, unknown failure mode a chance to surface against the candidate (V1). If V1 ever fails here
-  # for any reason while controls flake, that's a second problem to chase before we ship.
-  realsuite:
-    name: realsuite-${{ matrix.run }}
-    timeout-minutes: 40
-    runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        run:
-          [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
-    steps:
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
-      - name: Ensure iOS platform
-        run: |
-          xcodebuild -runFirstLaunch
-          for i in 1 2 3; do xcodebuild -downloadPlatform iOS && break; sleep 15; done
-          xcodebuild -runFirstLaunch
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Run full suite once
-        run: |
-          set +e
-          xcodebuild test \
-            -workspace .swiftpm/xcode/package.xcworkspace \
-            -scheme EmbraceIO-Package \
-            -destination "$DESTINATION" \
-            -skipPackagePluginValidation -skipMacroValidation \
-            > out.log 2>&1
-          echo "## realsuite run ${{ matrix.run }}" >> "$GITHUB_STEP_SUMMARY"
-          # experiment variations
-          for v in v0_control_defaultGlobal v1_detachNewThread v2_dedicatedQueue v3_userInitiatedGlobal; do
-            r=$(grep -oE "test_${v}'\\)? (passed|failed)" out.log | grep -oE "passed|failed" | head -1)
-            echo "- test_${v}: ${r:-not-run}" >> "$GITHUB_STEP_SUMMARY"
-          done
-          # the real shipping test (currently .default global)
-          rr=$(grep -oE "test_startSession_fromNonMainThread_callsControllerStartSession_andSetsSessionState'\\)? (passed|failed)" out.log | grep -oE "passed|failed" | head -1)
-          echo "- (real) test_startSession_fromNonMainThread: ${rr:-not-run}" >> "$GITHUB_STEP_SUMMARY"
-          cat "$GITHUB_STEP_SUMMARY"
+          # Guard against a false-green run: if no variation produced any result, the harness
+          # (build/target resolution) broke — fail loudly instead of reporting empty success.
+          if [ "$total" -eq 0 ]; then
+            echo "::error::No test results parsed — harness broke, results are not trustworthy."
+            exit 1
+          fi

--- a/.github/workflows/experiment-flaky.yml
+++ b/.github/workflows/experiment-flaky.yml
@@ -1,0 +1,104 @@
+# EXPERIMENT — not for merge. Finds a robust fix for the flaky
+# iOSSessionLifecycleTests off-main-thread test by stressing candidate variations in CI.
+# Runs only on the experiment branch (no PR) so the normal workflows stay off.
+name: EXPERIMENT flaky iOSSessionLifecycle
+
+on:
+  push:
+    branches:
+      - experiment/ios-session-lifecycle-nonmain-flake
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  ONLY: "EmbraceCoreTests/iOSSessionLifecycleConcurrencyExperimentTests"
+  DESTINATION: "platform=iOS Simulator,name=iPhone 17,OS=latest"
+
+jobs:
+  # Run the 4 variations x50 in two modes:
+  #   saturated → GCD pool deliberately exhausted (deterministic mechanism check)
+  #   isolated  → no saturation (do they pass alone, under normal load?)
+  variations:
+    name: variations-${{ matrix.mode }}
+    timeout-minutes: 40
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [saturated, isolated]
+    steps:
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+      - name: Ensure iOS platform
+        run: |
+          xcodebuild -runFirstLaunch
+          for i in 1 2 3; do xcodebuild -downloadPlatform iOS && break; sleep 15; done
+          xcodebuild -runFirstLaunch
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run variations x50
+        run: |
+          set +e
+          if [ "${{ matrix.mode }}" = "saturated" ]; then export EXPERIMENT_SATURATE=1; fi
+          xcodebuild test \
+            -workspace .swiftpm/xcode/package.xcworkspace \
+            -scheme EmbraceIO-Package \
+            -destination "$DESTINATION" \
+            -only-testing:"$ONLY" \
+            -test-iterations 50 \
+            -skipPackagePluginValidation -skipMacroValidation \
+            > out.log 2>&1
+          echo "## variations (${{ matrix.mode }}) — of 50 iterations" >> "$GITHUB_STEP_SUMMARY"
+          for v in v0_control_defaultGlobal v1_detachNewThread v2_dedicatedQueue v3_userInitiatedGlobal; do
+            p=$(grep -cE "test_${v}'\\)? passed" out.log)
+            f=$(grep -cE "test_${v}'\\)? failed" out.log)
+            echo "- test_${v}: ${p} passed / ${f} failed" >> "$GITHUB_STEP_SUMMARY"
+          done
+          cat "$GITHUB_STEP_SUMMARY"
+
+  # Soak: run the FULL suite many times as independent fresh-process samples (each ~= one real CI
+  # run) under genuine contention. The point isn't just to confirm the known fix — it's to give any
+  # OTHER, unknown failure mode a chance to surface against the candidate (V1). If V1 ever fails here
+  # for any reason while controls flake, that's a second problem to chase before we ship.
+  realsuite:
+    name: realsuite-${{ matrix.run }}
+    timeout-minutes: 40
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        run:
+          [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
+    steps:
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+      - name: Ensure iOS platform
+        run: |
+          xcodebuild -runFirstLaunch
+          for i in 1 2 3; do xcodebuild -downloadPlatform iOS && break; sleep 15; done
+          xcodebuild -runFirstLaunch
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run full suite once
+        run: |
+          set +e
+          xcodebuild test \
+            -workspace .swiftpm/xcode/package.xcworkspace \
+            -scheme EmbraceIO-Package \
+            -destination "$DESTINATION" \
+            -skipPackagePluginValidation -skipMacroValidation \
+            > out.log 2>&1
+          echo "## realsuite run ${{ matrix.run }}" >> "$GITHUB_STEP_SUMMARY"
+          # experiment variations
+          for v in v0_control_defaultGlobal v1_detachNewThread v2_dedicatedQueue v3_userInitiatedGlobal; do
+            r=$(grep -oE "test_${v}'\\)? (passed|failed)" out.log | grep -oE "passed|failed" | head -1)
+            echo "- test_${v}: ${r:-not-run}" >> "$GITHUB_STEP_SUMMARY"
+          done
+          # the real shipping test (currently .default global)
+          rr=$(grep -oE "test_startSession_fromNonMainThread_callsControllerStartSession_andSetsSessionState'\\)? (passed|failed)" out.log | grep -oE "passed|failed" | head -1)
+          echo "- (real) test_startSession_fromNonMainThread: ${rr:-not-run}" >> "$GITHUB_STEP_SUMMARY"
+          cat "$GITHUB_STEP_SUMMARY"

--- a/Tests/EmbraceCoreTests/Session/Lifecycle/Implementations/iOSSessionLifecycleConcurrencyExperimentTests.swift
+++ b/Tests/EmbraceCoreTests/Session/Lifecycle/Implementations/iOSSessionLifecycleConcurrencyExperimentTests.swift
@@ -1,0 +1,127 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+//  EXPERIMENT — not for merge.
+//
+//  `test_startSession_fromNonMainThread` flakes in CI with a 5s expectation timeout. Two fixes
+//  (.background -> .default QoS) failed to hold. Hypothesis: it's GCD global-pool starvation, not
+//  QoS priority — under suite load every global worker thread is busy/blocked, so a newly dispatched
+//  block can't get a thread and the expectation never fulfils in time.
+//
+//  This file reproduces that deterministically: setUp saturates the .default global concurrent pool
+//  with blocked workers, then each variation dispatches the same off-main `startSession` work a
+//  different way. The control (.default global) should fail; an approach that doesn't depend on the
+//  shared GCD pool (e.g. a dedicated Thread) should pass. We stress these in CI to pick a winner,
+//  then ship only that one under a real ticket and delete this file.
+//
+
+import EmbraceCommonInternal
+import TestSupport
+import XCTest
+
+@testable import EmbraceCore
+
+#if os(iOS) || os(tvOS)
+
+    final class iOSSessionLifecycleConcurrencyExperimentTests: XCTestCase {
+
+        var mockController = MockSessionController()
+        var lifecycle: iOSSessionLifecycle!
+
+        private let saturationRelease = DispatchSemaphore(value: 0)
+        private var saturationCount = 0
+
+        // Short on purpose: a robust approach runs in milliseconds, so 2s cleanly separates
+        // "ran" from "starved". (Production uses .longTimeout = 5s.)
+        private let timeout: TimeInterval = 2.0
+
+        override func setUpWithError() throws {
+            lifecycle = iOSSessionLifecycle(controller: mockController)
+            lifecycle.setup()
+            // Saturation is opt-in so the same variations can run two ways:
+            //   EXPERIMENT_SATURATE set   → deterministic pool-exhaustion (mechanism arm)
+            //   EXPERIMENT_SATURATE unset → isolation/real-suite (do they pass under normal load?)
+            if ProcessInfo.processInfo.environment["EXPERIMENT_SATURATE"] != nil {
+                saturateGlobalPool()
+            }
+        }
+
+        override func tearDownWithError() throws {
+            releaseGlobalPool()
+            lifecycle = nil
+        }
+
+        /// Flood the `.default` global concurrent queue with blocked workers so a freshly dispatched
+        /// `.default` block can't obtain a thread — the starvation we believe CI hits under load.
+        private func saturateGlobalPool() {
+            let count = 256
+            for _ in 0..<count {
+                DispatchQueue.global(qos: .default).async { [saturationRelease] in
+                    saturationRelease.wait()
+                }
+            }
+            saturationCount = count
+            // Let GCD actually occupy its worker threads before the test dispatches its block.
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+
+        private func releaseGlobalPool() {
+            for _ in 0..<saturationCount {
+                saturationRelease.signal()
+            }
+            saturationCount = 0
+        }
+
+        private func verify(_ expectation: XCTestExpectation) {
+            wait(for: [expectation], timeout: timeout)
+            XCTAssertTrue(mockController.didCallStartSession)
+            XCTAssertEqual(mockController.currentSession?.state, "foreground")
+        }
+
+        // MARK: - Variations
+
+        /// V0 — control: the current shipping approach. Expected to FAIL under saturation.
+        func test_v0_control_defaultGlobal() {
+            let expectation = XCTestExpectation(description: "v0")
+            DispatchQueue.global(qos: .default).async { [self] in
+                lifecycle.startSession()
+                expectation.fulfill()
+            }
+            verify(expectation)
+        }
+
+        /// V1 — dedicated OS thread (not the GCD pool). Expected to PASS.
+        func test_v1_detachNewThread() {
+            let expectation = XCTestExpectation(description: "v1")
+            Thread.detachNewThread { [self] in
+                lifecycle.startSession()
+                expectation.fulfill()
+            }
+            verify(expectation)
+        }
+
+        /// V2 — a dedicated (non-global) serial DispatchQueue. Still draws from the GCD pool, so this
+        /// tells us whether a private queue is enough or whether the pool itself is the problem.
+        func test_v2_dedicatedQueue() {
+            let queue = DispatchQueue(label: "experiment.nonmain")
+            let expectation = XCTestExpectation(description: "v2")
+            queue.async { [self] in
+                lifecycle.startSession()
+                expectation.fulfill()
+            }
+            verify(expectation)
+        }
+
+        /// V3 — higher QoS global. If priority were the issue this would pass; if it's pool
+        /// exhaustion it should fail like V0.
+        func test_v3_userInitiatedGlobal() {
+            let expectation = XCTestExpectation(description: "v3")
+            DispatchQueue.global(qos: .userInitiated).async { [self] in
+                lifecycle.startSession()
+                expectation.fulfill()
+            }
+            verify(expectation)
+        }
+    }
+
+#endif


### PR DESCRIPTION
Throwaway experiment to find a robust fix for the flaky `iOSSessionLifecycleTests` off-main-thread test (two prior fixes — `.background`→`.default` QoS — didn't hold).

Adds `iOSSessionLifecycleConcurrencyExperimentTests` with 4 candidate variations + an opt-in GCD-pool-saturation harness, plus a throwaway `experiment-flaky.yml` workflow that stresses them. This draft PR also runs the **real** `run-tests` flow against the branch for an authentic reproduction.

Not for merge — once a variation proves robust across the synthetic + real soak, we ship only that fix under a real ticket and delete all of this.