### PR TITLE
[EMBR-12798] Fix: Run off-main session lifecycle test on a dedicated thread, not the GCD global pool

### DIFF
--- a/Tests/EmbraceCoreTests/Session/Lifecycle/Implementations/iOSSessionLifecycleTests.swift
+++ b/Tests/EmbraceCoreTests/Session/Lifecycle/Implementations/iOSSessionLifecycleTests.swift
@@ -58,7 +58,11 @@ import XCTest
 
         func test_startSession_fromNonMainThread_callsControllerStartSession_andSetsSessionState() {
             let expectation = XCTestExpectation(description: "startSession called off the main thread")
-            DispatchQueue.global(qos: .default).async { [self] in
+            // Use a dedicated thread instead of DispatchQueue.global: the global concurrent pool is
+            // a bounded, shared resource that can be exhausted under CI load, starving this block so
+            // the timeout flakes — which was a recurring source of CI failures here. A detached
+            // thread is always scheduled.
+            Thread.detachNewThread { [self] in
                 XCTAssertFalse(Thread.isMainThread)
                 lifecycle.startSession()
                 expectation.fulfill()


### PR DESCRIPTION
## What

`test_startSession_fromNonMainThread_callsControllerStartSession_andSetsSessionState` dispatched its
off-main work to `DispatchQueue.global(qos: .default)` and waited on an expectation with a bounded
timeout. This was a recurring source of CI flakiness. Switch the off-main hop to
`Thread.detachNewThread`.

## Why

The test's purpose is to call `startSession()` **off the main thread** — the global queue was just an
incidental way to get there, and the wrong one. GCD's global concurrent queues are backed by a
**bounded, lazily-grown worker-thread pool**. On a core-constrained, CPU-loaded CI runner that pool
can't always schedule a freshly dispatched block within the timeout window, so the expectation times
out and the test fails. QoS doesn't help — priority can't conjure a thread — which is why two prior
`.background → .default` fixes didn't hold.

A dedicated thread (`Thread.detachNewThread`) is created and scheduled immediately, with no
dependence on the shared pool, so the work always runs. The timeout becomes a pure backstop that
only fires on a genuine hang.

## Evidence

Ran the four candidate off-main mechanisms ×50 in CI, on the same runner that flakes, under
deliberate GCD-pool saturation (and isolated as a control):

| Variation | Saturated | Isolated |
| --- | --- | --- |
| `.global(qos: .default)` (old) | **0 passes** (only failures) | 50/50 |
| `.global(qos: .userInitiated)` | **0 passes** (only failures) | 50/50 |
| `Thread.detachNewThread` (this PR) | **50/50** | 50/50 |
| dedicated `DispatchQueue` | **50/50** | 50/50 |

Both global-queue variations fail regardless of QoS (→ pool exhaustion, not priority); the
dedicated-thread approach passes 50/50. Isolated, everything passes (→ load-induced, not a code
bug). Locally the patched test passes 10/10.

## Scope

Test-only change. Production code is untouched. 