### PR TITLE
[EMBR-12799] Fix: Fix On Device Benchmarks CI: install iOS device platform on macOS 26 runner

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -41,6 +41,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.0.app
           xcodebuild -version
 
+      - name: Install iOS platform
+        # Xcode 26 ships platforms as on-demand downloads; the hosted runner image
+        # does not include the iOS device platform, so `archive -sdk iphoneos` finds
+        # no destinations. Idempotent: a no-op once the platform is present.
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 5


### PR DESCRIPTION
## Problem

`On Device Benchmarks` has been failing on both `main` and `7.0` since ~Jun 24,
when the `macos-latest-xlarge` image migrated to macOS 26.

The failure surfaced misleadingly in the **Export IPA** step (`cp: ...Benchmarks.app:
No such file or directory`), but the real failure is one step earlier in **Archive
Benchmarks App**:

```
Ineligible destinations for the "Benchmarks" scheme:
  { platform:iOS, name:Any iOS Device,
    error:iOS 26.0 is not installed. Please download and install the platform
          from Xcode > Settings > Components. }
xcodebuild: error: Found no destinations for the scheme 'Benchmarks' and action archive.
```

Xcode 26 ships device platforms as on-demand downloads, and the migrated runner
image doesn't include the iOS device platform — so `archive -sdk iphoneos` has no
destinations and bails before compiling. Nothing in the repo changed; this is a
runner-image regression.

## Fix

Add `xcodebuild -downloadPlatform iOS` after selecting Xcode. It's idempotent — a
no-op once the platform is present in the image.
