### PR TITLE
[EMBR-12801] Fix: Add on-demand Xcode/SDK/runtime inventory workflow for runner images

### DIFF
--- a/.github/workflows/xcode-inventory.yml
+++ b/.github/workflows/xcode-inventory.yml
@@ -1,0 +1,48 @@
+name: Xcode Inventory
+
+# Manual diagnostic: snapshot the Xcode versions, simulator SDKs, and simulator
+# runtimes baked into a runner image. Use it before migrating runners (e.g. to
+# macos-26) to confirm which Xcode_*.app paths exist and which platform SDKs are
+# preinstalled vs. need an on-demand download. Read-only; never runs on PRs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner image label to snapshot
+        default: macos-26
+        type: choice
+        options:
+          - macos-26
+          - macos-15
+          - macos-latest
+
+permissions:
+  contents: read
+
+jobs:
+  inventory:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 15
+    steps:
+      - name: Dump Xcode / SDK / runtime inventory
+        env:
+          RUNNER_LABEL: ${{ inputs.runner }}
+        run: |
+          # No `set -e`: a single bad Xcode shouldn't abort the whole inventory.
+          {
+            echo "# Inventory for \`${RUNNER_LABEL}\` (image ${ImageVersion:-unknown})"
+            echo ""
+            for app in /Applications/Xcode_*.app; do
+              dev="$app/Contents/Developer"
+              ver=$(DEVELOPER_DIR="$dev" xcodebuild -version 2>/dev/null | tr '\n' ' ')
+              echo "## \`$(basename "$app")\` — ${ver:-(version unavailable)}"
+              echo '```'
+              echo "--- simulator SDKs ---"
+              DEVELOPER_DIR="$dev" xcodebuild -showsdks 2>/dev/null | grep -i simulator || echo "(no simulator SDKs)"
+              echo "--- simulator runtimes ---"
+              DEVELOPER_DIR="$dev" xcrun simctl list runtimes 2>/dev/null || echo "(simctl unavailable)"
+              echo '```'
+              echo ""
+            done
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` diagnostic, `Xcode Inventory`, that snapshots a runner image's installed Xcode versions, simulator SDKs, and simulator runtimes into the run summary.

## Why

We're migrating CI from `macos-15` to `macos-26`. The image readme is fetched/summarized and imprecise about Xcode's on-demand platform model — and we already know the current `Xcode_26.0.app` pins are at risk on macos-26 (the image ships `26.0.1`, not a plain `26.0`). This job gives ground truth on demand: which `Xcode_*.app` paths exist and which platform SDKs/runtimes are baked vs. need downloading — so we pin the runner-migration PR against reality, not a readme.

## Notes

- Read-only and manual (`workflow_dispatch` only); never runs on PRs or push.
- `runner` input selects the image to snapshot (`macos-26` default, plus `macos-15`/`macos-latest`).
- Uses per-Xcode `DEVELOPER_DIR` rather than `sudo xcode-select`, so it mutates no global state.