### PR TITLE
[EMBR-12805] Fix: ThreadSanitizer data race in KSCrash binary-image cache during startup

### DIFF
--- a/Sources/EmbraceCommonInternal/Locks/KSCrashGlobalsLock.swift
+++ b/Sources/EmbraceCommonInternal/Locks/KSCrashGlobalsLock.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Serializes every entry point that reaches KSCrash's process-global C state.
+///
+/// KSCrash's binary-image cache (`ksbic_init`) rewrites the global `g_all_image_infos` on *every*
+/// call — it has no init guard — and the Swift demangle filter lazily caches the `swift_demangle`
+/// function pointer in another global. Both are written without synchronization, so the
+/// crash-reporter install path (`Embrace.start` → `KSCrashReporter.install` → `ksbic_init`) races
+/// the background log symbolication path (`LogController.createLog` → `EmbraceBacktraceFrame.symbolicated`
+/// → `ksbt_symbolicateAddress` → `ksbic_init`).
+///
+/// Every call site that triggers those lazy inits — symbolication, backtrace capture, and
+/// crash-reporter install — funnels through this lock so they can never run concurrently.
+public enum KSCrashGlobalsLock {
+    private static let lock = ReadWriteLock()
+
+    public static func withLock<ReturnValue>(_ body: () throws -> ReturnValue) rethrows -> ReturnValue {
+        try lock.lockedForWriting(body)
+    }
+}

--- a/Sources/ThirdParty/EmbraceKSCrashBacktraceSupport/EmbraceKSCrashBacktraceSupport.swift
+++ b/Sources/ThirdParty/EmbraceKSCrashBacktraceSupport/EmbraceKSCrashBacktraceSupport.swift
@@ -4,6 +4,10 @@
 
 import Foundation
 
+#if !EMBRACE_COCOAPOD_BUILDING_SDK
+    import EmbraceCommonInternal
+#endif
+
 #if canImport(KSCrash)
     import KSCrash
 #else
@@ -38,7 +42,11 @@ public class KSCrashBacktracing {
         if thread == pthread_self() {
             addresses = Thread.callStackReturnAddresses.compactMap { $0 as? UInt }
         } else {
-            let count = captureBacktrace(thread: thread, addresses: &addresses, count: Int32(entries))
+            // `captureBacktrace` reaches KSCrash's binary-image cache; serialize against the
+            // crash-reporter install and symbolication paths. See `KSCrashGlobalsLock`.
+            let count = KSCrashGlobalsLock.withLock {
+                captureBacktrace(thread: thread, addresses: &addresses, count: Int32(entries))
+            }
             addresses = Array(addresses[0..<Int(count)])
         }
         return addresses
@@ -46,21 +54,25 @@ public class KSCrashBacktracing {
 
     package func resolve(address: UInt) -> SymbolicatedFrame? {
 
-        var result = SymbolInformation()
-        guard symbolicate(address: UInt(address), result: &result) else {
-            return nil
-        }
+        // `symbolicate` (-> `ksbt_symbolicateAddress` -> `ksbic_init`) and the Swift demangler both
+        // touch unsynchronized KSCrash globals; serialize against install/capture. See `KSCrashGlobalsLock`.
+        KSCrashGlobalsLock.withLock {
+            var result = SymbolInformation()
+            guard symbolicate(address: UInt(address), result: &result) else {
+                return nil
+            }
 
-        return SymbolicatedFrame(
-            returnAddress: result.returnAddress,
-            callInstruction: result.callInstruction,
-            symbolAddress: result.symbolAddress,
-            symbolName: result.symbolName.flatMap { backtraceDemangle(String(cString: $0)) },
-            imageName: result.imageName.flatMap { String(cString: $0) },
-            imageUUID: NSUUID(uuidBytes: result.imageUUID).uuidString,
-            imageAddress: result.imageAddress,
-            imageSize: result.imageSize
-        )
+            return SymbolicatedFrame(
+                returnAddress: result.returnAddress,
+                callInstruction: result.callInstruction,
+                symbolAddress: result.symbolAddress,
+                symbolName: result.symbolName.flatMap { backtraceDemangle(String(cString: $0)) },
+                imageName: result.imageName.flatMap { String(cString: $0) },
+                imageUUID: NSUUID(uuidBytes: result.imageUUID).uuidString,
+                imageAddress: result.imageAddress,
+                imageSize: result.imageSize
+            )
+        }
     }
 
     private func backtraceDemangle(_ symbol: String?) -> String {

--- a/Sources/ThirdParty/EmbraceKSCrashSupport/KSCrashReporter.swift
+++ b/Sources/ThirdParty/EmbraceKSCrashSupport/KSCrashReporter.swift
@@ -84,7 +84,12 @@ package final class KSCrashReporter: CrashReporter {
                 $0.reportID = reportID
             }
         }
-        try reporter.install(with: config)
+        // `reporter.install` reaches `ksbic_init`, which rewrites KSCrash's unsynchronized
+        // `g_all_image_infos` global. Serialize against background log symbolication, which hits the
+        // same global concurrently during startup. See `KSCrashGlobalsLock`.
+        try KSCrashGlobalsLock.withLock {
+            try reporter.install(with: config)
+        }
         registerForHangs()
     }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent ThreadSanitizer data race in the KSCrash binary-image cache.

`ksbic_init` rewrites the global `g_all_image_infos` on **every** call (no init guard), and the
Swift demangle filter lazily caches `swift_demangle` in another global. Two SDK paths reach these
unsynchronized C globals concurrently:

- crash-reporter install — `Embrace.start()` → `KSCrashReporter.install` → `ksbic_init` (main thread)
- background log symbolication — `LogController.createLog` → `EmbraceBacktraceFrame.symbolicated` → `ksbt_symbolicateAddress` → `ksbic_init` (GCD worker)

## Fix

Add `KSCrashGlobalsLock` (a shared serializer over the existing `ReadWriteLock`) and route all
callers that trigger those lazy inits through it: `KSCrashReporter.install`, and
`KSCrashBacktracing.resolve` / `.backtrace`. Since `ksbic_init` is not idempotent, mutual exclusion
(not warm-up) is required. The two racers don't nest, so no deadlock.

## Verification

Local TSan loop (`PerformanceTests` + `PerformanceBacktraceTests`, `-run-tests-until-failure`,
iPhone 17 sim): `ksbic_init`/`g_all_image_infos`/`swift_demangle` races went **2 → 0**.
