### PR TITLE
[EMBR-12811] Fix: CaptureServicesOptionsBuilder.remove(ofType:) removed the wrong service

### DIFF
--- a/Sources/EmbraceIO/Capture/CaptureServicesOptionsBuilder.swift
+++ b/Sources/EmbraceIO/Capture/CaptureServicesOptionsBuilder.swift
@@ -236,7 +236,7 @@ public class CaptureServicesOptionsBuilder: NSObject {
             map[.pushNotification] = nil
         }
 
-        if type == LowPowerModeCaptureService.self {
+        if type == LowMemoryWarningCaptureService.self {
             map[.lowMemoryWarning] = nil
         }
 

--- a/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
@@ -269,6 +269,36 @@ class CaptureServicesOptionsBuilderTests: XCTestCase {
         XCTAssertFalse(options.lowPowerMode)
     }
 
+    func test_lowMemoryWarning_removeOfType() throws {
+        // given a builder with default services
+        let builder = CaptureServicesOptionsBuilder()
+        builder.addDefaults()
+
+        // when removing low memory warning via the class-type overload
+        builder.remove(ofType: LowMemoryWarningCaptureService.self)
+
+        // then only low memory warning is removed; low power mode is untouched
+        let options = builder.build()
+
+        XCTAssertFalse(options.lowMemoryWarning)
+        XCTAssertTrue(options.lowPowerMode)
+    }
+
+    func test_lowPowerMode_removeOfType() throws {
+        // given a builder with default services
+        let builder = CaptureServicesOptionsBuilder()
+        builder.addDefaults()
+
+        // when removing low power mode via the class-type overload
+        builder.remove(ofType: LowPowerModeCaptureService.self)
+
+        // then only low power mode is removed; low memory warning is untouched
+        let options = builder.build()
+
+        XCTAssertFalse(options.lowPowerMode)
+        XCTAssertTrue(options.lowMemoryWarning)
+    }
+
     #if !os(watchOS) && !os(macOS)
         func test_hang() throws {
             // given a builder


### PR DESCRIPTION
## Summary

`CaptureServicesOptionsBuilder.remove(ofType:)` (the `AnyClass` overload) had a copy-paste defect — both conditional branches tested `LowPowerModeCaptureService.self`:

```swift
if type == LowPowerModeCaptureService.self {   // ← should be LowMemoryWarningCaptureService
    map[.lowMemoryWarning] = nil
}
if type == LowPowerModeCaptureService.self {
    map[.lowPowerMode] = nil
}
```

Customer-visible effect:
- `remove(ofType: LowMemoryWarningCaptureService.self)` did **nothing** — the low-memory service couldn't be removed via the class overload.
- `remove(ofType: LowPowerModeCaptureService.self)` removed **both** the low-memory and low-power services.

It slipped by because the existing builder tests only exercised the `remove(embraceType:)` enum overload, never the `remove(ofType:)` class overload.

## Changes
- Fix the first condition to test `LowMemoryWarningCaptureService.self`.
- Add `test_lowMemoryWarning_removeOfType` and `test_lowPowerMode_removeOfType` exercising the class overload, each asserting the sibling service is left intact.

## Testing
`swift test --filter CaptureServicesOptionsBuilderTests` — 16 tests, 0 failures.

_Found during the 7.0 test-coverage audit._
