### PR TITLE
[EMBR-12812] Fix: revive dead/masked tests from the 7.0 coverage audit

### DIFF
--- a/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
+++ b/Sources/EmbraceUploadInternal/Operations/EmbraceUploadOperation.swift
@@ -223,7 +223,7 @@ class EmbraceUploadOperation: AsyncOperation, @unchecked Sendable {
     /// Extracts the suggested delay from `Retry-After` header from the `URLResponse` if present.
     /// - Parameter response: the URLResponse recevied when executing a request.
     /// - Returns:the time in seconds (as `Int`) extracted from the `Retry-After` header.
-    private func getSuggestedDelay(fromResponse response: URLResponse?) -> Int {
+    func getSuggestedDelay(fromResponse response: URLResponse?) -> Int {
         guard let httpResponse = response as? HTTPURLResponse,
             let retryAfterHeaderValue = httpResponse.allHeaderFields["Retry-After"] as? String,
             let retryAfterDelay = Int(retryAfterHeaderValue)

--- a/Tests/EmbraceCoreTests/Public/OTel/EmbraceSpanEndErrorCodeTests.swift
+++ b/Tests/EmbraceCoreTests/Public/OTel/EmbraceSpanEndErrorCodeTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class EmbraceSpanEndErrorCodeTests: XCTestCase {
 
-    func end_withErrorCode() throws {
+    func test_end_withErrorCode_failure() throws {
         // given a span
         let span = MockSpan(name: "test")
 
@@ -21,10 +21,38 @@ class EmbraceSpanEndErrorCodeTests: XCTestCase {
         // and has the error code attribute
         XCTAssertEqual(span.endTime, endTime)
         XCTAssertEqual(span.status, .error)
-        XCTAssertEqual(span.attributes["emb.error_code"] as! String, "faliure")
+        XCTAssertEqual(span.attributes["emb.error_code"] as! String, "failure")
     }
 
-    func end_withErrorCode_nil() throws {
+    func test_end_withErrorCode_userAbandon() throws {
+        // given a span
+        let span = MockSpan(name: "test")
+
+        // when ending it with the user-abandon error code
+        let endTime = Date(timeIntervalSince1970: 50)
+        span.end(errorCode: .userAbandon, endTime: endTime)
+
+        // then it ends correctly with status "error" and the matching attribute
+        XCTAssertEqual(span.endTime, endTime)
+        XCTAssertEqual(span.status, .error)
+        XCTAssertEqual(span.attributes["emb.error_code"] as! String, "user_abandon")
+    }
+
+    func test_end_withErrorCode_unknown() throws {
+        // given a span
+        let span = MockSpan(name: "test")
+
+        // when ending it with the unknown error code
+        let endTime = Date(timeIntervalSince1970: 50)
+        span.end(errorCode: .unknown, endTime: endTime)
+
+        // then it ends correctly with status "error" and the matching attribute
+        XCTAssertEqual(span.endTime, endTime)
+        XCTAssertEqual(span.status, .error)
+        XCTAssertEqual(span.attributes["emb.error_code"] as! String, "unknown")
+    }
+
+    func test_end_withErrorCode_nil() throws {
         // given a span
         let span = MockSpan(name: "test")
 

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadOperationTests.swift
@@ -495,4 +495,34 @@ class EmbraceUploadOperationTests: XCTestCase {
 
         XCTAssertEqual(headers["x-emb-retry-count"], "1")
     }
+
+    func test_getSuggestedDelay_parsesRetryAfterHeader() throws {
+        // given an upload operation
+        let operation = EmbraceUploadOperation(
+            urlSession: urlSession,
+            queue: queue,
+            metadataOptions: testMetadataOptions,
+            endpoint: TestConstants.url,
+            identifier: "id",
+            data: Data(),
+            retryCount: 0,
+            exponentialBackoffBehavior: .withNoDelay(),
+            attemptCount: 0
+        ) { _, _ in }
+
+        func response(_ headers: [String: String]) -> HTTPURLResponse {
+            HTTPURLResponse(url: TestConstants.url, statusCode: 429, httpVersion: nil, headerFields: headers)!
+        }
+
+        // a valid integer header is honored
+        XCTAssertEqual(operation.getSuggestedDelay(fromResponse: response(["Retry-After": "5"])), 5)
+        // a fractional value is not an Int, so it falls back to 0 (documents the current contract)
+        XCTAssertEqual(operation.getSuggestedDelay(fromResponse: response(["Retry-After": "0.01"])), 0)
+        // a non-numeric value falls back to 0
+        XCTAssertEqual(operation.getSuggestedDelay(fromResponse: response(["Retry-After": "soon"])), 0)
+        // a missing header falls back to 0
+        XCTAssertEqual(operation.getSuggestedDelay(fromResponse: response([:])), 0)
+        // a nil / non-HTTP response falls back to 0
+        XCTAssertEqual(operation.getSuggestedDelay(fromResponse: nil), 0)
+    }
 }


### PR DESCRIPTION
## Summary

Two test-correctness defects surfaced by the 7.0 coverage audit, where coverage *looked* present but wasn't.

### `EmbraceSpanEndErrorCodeTests` — dead tests
Both test methods lacked the `test_` prefix, so XCTest never ran them. The surviving assertion also checked the typo `"faliure"` instead of `"failure"`, so it would have failed had it run.
- Rename both methods to `test_*`.
- Fix the assertion to `"failure"`.
- Add the missing `.userAbandon` (`"user_abandon"`) and `.unknown` (`"unknown"`) cases.

### `Retry-After` parsing — masked assertion
The only `Retry-After` test passed `"0.01"`, which `Int(_:)` parses to `nil` → `0`, so the header was never actually validated as working.
- Make `getSuggestedDelay` `internal` (the test target already uses `@testable import`) so the parser is unit-testable without a flaky timing-based test.
- Add `test_getSuggestedDelay_parsesRetryAfterHeader` pinning the contract: valid integer honored; fractional / non-numeric / missing / nil response all fall back to `0`.

## Testing
`swift test --filter EmbraceSpanEndErrorCodeTests --filter test_getSuggestedDelay_parsesRetryAfterHeader` — 5 tests, 0 failures.
