### PR TITLE
[EMBR-12820] Chore: Fill in unit-test gaps from the 7.0 coverage analysis

### DIFF
--- a/Sources/EmbraceCommonInternal/CrashReporter/CrashSignal.swift
+++ b/Sources/EmbraceCommonInternal/CrashReporter/CrashSignal.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public enum CrashSignal: Int {
+public enum CrashSignal: Int, CaseIterable {
     case SIGHUP = 1
     case SIGINT = 2
     case SIGQUIT = 3

--- a/Tests/EmbraceCaptureServiceTests/CaptureServiceTests.swift
+++ b/Tests/EmbraceCaptureServiceTests/CaptureServiceTests.swift
@@ -92,4 +92,61 @@ class CaptureServiceTests: XCTestCase {
         // then onStop is called
         XCTAssertTrue(service.stopCalled)
     }
+
+    func test_startBeforeInstall_isNoOp() throws {
+        // given an uninstalled capture service
+        let service = MockCaptureService()
+
+        // when starting before installing
+        service.start()
+
+        // then it stays uninstalled and onStart is not called
+        XCTAssertEqual(service.state.load(), .uninstalled)
+        XCTAssertFalse(service.startCalled)
+    }
+
+    func test_stopBeforeStart_isNoOp() throws {
+        // given an installed (but not started) capture service
+        let service = MockCaptureService()
+        service.install(otel: nil)
+
+        // when stopping before starting
+        service.stop()
+
+        // then it stays installed and onStop is not called
+        XCTAssertEqual(service.state.load(), .installed)
+        XCTAssertFalse(service.stopCalled)
+    }
+
+    func test_install_isIdempotent() throws {
+        // given an installed capture service
+        let service = MockCaptureService()
+        service.install(otel: nil)
+        XCTAssertTrue(service.installCalled)
+
+        // when installing again
+        service.installCalled = false
+        service.install(otel: nil)
+
+        // then it remains installed and onInstall is not called a second time
+        XCTAssertEqual(service.state.load(), .installed)
+        XCTAssertFalse(service.installCalled)
+    }
+
+    func test_resumeFromPaused() throws {
+        // given a paused capture service
+        let service = MockCaptureService()
+        service.install(otel: nil)
+        service.start()
+        service.stop()
+        XCTAssertEqual(service.state.load(), .paused)
+
+        // when starting again from paused
+        service.startCalled = false
+        service.start()
+
+        // then it becomes active again and onStart is called
+        XCTAssertEqual(service.state.load(), .active)
+        XCTAssertTrue(service.startCalled)
+    }
 }

--- a/Tests/EmbraceCommonInternalTests/CrashReporter/CrashSignalTests.swift
+++ b/Tests/EmbraceCommonInternalTests/CrashReporter/CrashSignalTests.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import EmbraceCommonInternal
+
+class CrashSignalTests: XCTestCase {
+
+    func test_from_stringValue_roundTripsEveryCase() {
+        // a typo in either the `from(string:)` or `stringValue` table breaks the round-trip
+        for signal in CrashSignal.allCases {
+            XCTAssertEqual(
+                CrashSignal.from(string: signal.stringValue),
+                signal,
+                "round-trip failed for \(signal.stringValue)"
+            )
+        }
+    }
+
+    func test_from_isCaseInsensitive() {
+        XCTAssertEqual(CrashSignal.from(string: "sigsegv"), .SIGSEGV)
+        XCTAssertEqual(CrashSignal.from(string: "SigAbrt"), .SIGABRT)
+    }
+
+    func test_from_unknownOrEmptyString_returnsNil() {
+        XCTAssertNil(CrashSignal.from(string: "SIGFOO"))
+        XCTAssertNil(CrashSignal.from(string: ""))
+    }
+}

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
@@ -141,4 +141,33 @@
         }
     }
 
+    class WebViewCaptureServiceTests_Five: WebViewCaptureServiceTests {
+
+        // `getUrlString` is private and swizzle-independent, so we verify it through the event that
+        // `didLoad` emits rather than the swizzle path — no `checkTestAllowed()` gating needed.
+        func test_didLoad_stripQueryParams_controlsQueryInCapturedURL() {
+            let url = URL(string: "https://example.com/path?token=secret&id=42")!
+
+            // stripQueryParams = true -> the query (which can carry auth tokens / PII) is removed
+            let stripping = WebViewCaptureService(options: .init(stripQueryParams: true))
+            let strippingOtel = MockOTelSignalsHandler()
+            stripping.install(otel: strippingOtel)
+            stripping.didLoad(url: url, statusCode: 200)
+            XCTAssertEqual(
+                strippingOtel.events.last!.attributes["webview.url"]!.description,
+                "https://example.com/path"
+            )
+
+            // stripQueryParams = false -> the full query string is preserved
+            let preserving = WebViewCaptureService(options: .init(stripQueryParams: false))
+            let preservingOtel = MockOTelSignalsHandler()
+            preserving.install(otel: preservingOtel)
+            preserving.didLoad(url: url, statusCode: 200)
+            XCTAssertEqual(
+                preservingOtel.events.last!.attributes["webview.url"]!.description,
+                url.absoluteString
+            )
+        }
+    }
+
 #endif

--- a/Tests/EmbraceCoreTests/FileSystem/EmbraceFileSystemTests.swift
+++ b/Tests/EmbraceCoreTests/FileSystem/EmbraceFileSystemTests.swift
@@ -30,4 +30,40 @@ class EmbraceFileSystemTests: XCTestCase {
             XCTAssert(urls.contains(url.path))
         }
     }
+
+    func test_typedDirectoryURLs_useVersionedPartitionedLayout() throws {
+        let partition = "myPartition"
+        // reference the source constant for the version segment so a version bump is a single change there
+        let versioned = "io.embrace.data/\(EmbraceFileSystem.versionDirectoryName)/\(partition)"
+
+        let storage = try XCTUnwrap(EmbraceFileSystem.storageDirectoryURL(partitionId: partition))
+        XCTAssertTrue(storage.path.hasSuffix("\(versioned)/storage"))
+
+        let uploads = try XCTUnwrap(EmbraceFileSystem.uploadsDirectoryPath(partitionIdentifier: partition))
+        XCTAssertTrue(uploads.path.hasSuffix("\(versioned)/uploads"))
+
+        let capture = try XCTUnwrap(EmbraceFileSystem.captureDirectoryURL(partitionIdentifier: partition))
+        XCTAssertTrue(capture.path.hasSuffix("\(versioned)/capture"))
+
+        let config = try XCTUnwrap(EmbraceFileSystem.configDirectoryURL(partitionIdentifier: partition))
+        XCTAssertTrue(config.path.hasSuffix("\(versioned)/config"))
+    }
+
+    func test_rootLevelFileURLs_liveAtRoot_notUnderVersionDirectory() throws {
+        // device-id, critical-logs and pending-logs are intentionally at the root, NOT under the
+        // version directory; putting them there would break crash/log promotion across SDK upgrades.
+        let versionSegment = "/\(EmbraceFileSystem.versionDirectoryName)/"
+
+        let deviceId = try XCTUnwrap(EmbraceFileSystem.deviceIdURL)
+        XCTAssertTrue(deviceId.path.hasSuffix("io.embrace.data/device-identifier"))
+        XCTAssertFalse(deviceId.path.contains(versionSegment))
+
+        let critical = try XCTUnwrap(EmbraceFileSystem.criticalLogsURL)
+        XCTAssertTrue(critical.path.hasSuffix("io.embrace.data/critical-logs"))
+        XCTAssertFalse(critical.path.contains(versionSegment))
+
+        let pending = try XCTUnwrap(EmbraceFileSystem.pendingLogsURL)
+        XCTAssertTrue(pending.path.hasSuffix("io.embrace.data/pending-logs"))
+        XCTAssertFalse(pending.path.contains(versionSegment))
+    }
 }

--- a/Tests/EmbraceCoreTests/Internal/Logs/LogControllerSeverityTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/LogControllerSeverityTests.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceCommonInternal
+import EmbraceSemantics
+import EmbraceStorageInternal
+import TestSupport
+import XCTest
+
+@testable import EmbraceCore
+
+class LogControllerSeverityTests: XCTestCase {
+
+    private func makeController(batcher: LogBatcher) -> LogController {
+        LogController(
+            storage: nil,
+            upload: nil,
+            sessionController: MockSessionController(),
+            batcher: batcher,
+            queue: DispatchQueue(label: "com.embrace.logcontroller.severity.test")
+        )
+    }
+
+    func test_createLog_criticalSeverity_isRejected() {
+        // given a log controller
+        let batcher = SpyLogBatcher()
+        let controller = makeController(batcher: batcher)
+
+        // when creating a log with the internal-only `.critical` severity
+        controller.createLog("internal only", severity: .critical)
+
+        // then no log is handed to the batcher (the public API rejects `.critical`)
+        XCTAssertTrue(batcher.addedLogs.isEmpty)
+    }
+
+    func test_onSessionPartWillEnd_forceEndsCurrentBatch() {
+        // given a log controller observing session-part-will-end
+        let batcher = SpyLogBatcher()
+        let controller = makeController(batcher: batcher)
+        _ = controller  // keep alive for the duration of the notification dispatch
+
+        // when a session part is about to end
+        NotificationCenter.default.post(name: .embraceSessionPartWillEnd, object: nil)
+
+        // then the current batch is force-ended synchronously so the session's logs ship with it
+        XCTAssertEqual(batcher.forceEndCallCount, 1)
+        XCTAssertEqual(batcher.lastForceEndWaitUntilFinished, true)
+    }
+}
+
+private final class SpyLogBatcher: LogBatcher {
+    private(set) var addedLogs: [EmbraceLog] = []
+    private(set) var forceEndCallCount = 0
+    private(set) var lastForceEndWaitUntilFinished: Bool?
+
+    let logBatchLimits = LogBatchLimits()
+    weak var delegate: LogBatcherDelegate?
+    var batch: LogsBatch?
+
+    func addLog(_ log: EmbraceLog) {
+        addedLogs.append(log)
+    }
+
+    func renewBatch(withLogs logRecords: [EmbraceLog]) {}
+
+    func forceEndCurrentBatch(waitUntilFinished: Bool) {
+        forceEndCallCount += 1
+        lastForceEndWaitUntilFinished = waitUntilFinished
+    }
+}

--- a/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
+++ b/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
@@ -4,10 +4,11 @@
 
 import EmbraceConfigInternal
 import EmbraceConfiguration
-import EmbraceCore
 import EmbraceSemantics
 import TestSupport
 import XCTest
+
+@testable import EmbraceCore
 
 final class Embrace_OptionsTests: XCTestCase {
 
@@ -34,5 +35,39 @@ final class Embrace_OptionsTests: XCTestCase {
         )
 
         XCTAssertTrue(mockObj === options.runtimeConfiguration)
+    }
+
+    func test_validate_validAppId_doesNotThrow() throws {
+        // "myApp" is exactly 5 characters
+        let options = Embrace.Options(appId: "myApp", captureServices: [], crashReporter: nil)
+        XCTAssertNoThrow(try options.validate())
+    }
+
+    func test_validate_appIdWrongLength_throwsInvalidAppId() throws {
+        let options = Embrace.Options(appId: "abc", captureServices: [], crashReporter: nil)
+        XCTAssertThrowsError(try options.validate()) { error in
+            guard let setupError = error as? EmbraceSetupError, case .invalidAppId = setupError else {
+                return XCTFail("expected EmbraceSetupError.invalidAppId, got \(error)")
+            }
+        }
+    }
+
+    func test_validate_emptyAppGroupId_throwsInvalidAppGroupId() throws {
+        let options = Embrace.Options(appId: "myApp", appGroupId: "", captureServices: [], crashReporter: nil)
+        XCTAssertThrowsError(try options.validate()) { error in
+            guard let setupError = error as? EmbraceSetupError, case .invalidAppGroupId = setupError else {
+                return XCTFail("expected EmbraceSetupError.invalidAppGroupId, got \(error)")
+            }
+        }
+    }
+
+    func test_validate_nilAppId_doesNotThrow() throws {
+        // the local-configuration initializer leaves appId nil, which is valid
+        let options = Embrace.Options(
+            captureServices: [],
+            crashReporter: nil,
+            runtimeConfiguration: MockEmbraceConfigurable()
+        )
+        XCTAssertNoThrow(try options.validate())
     }
 }

--- a/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Public/Metadata/MetadataHandlerTests.swift
@@ -279,4 +279,56 @@ final class MetadataHandlerTests: XCTestCase {
         let metadata: [MetadataRecord] = storage.fetchAll()
         XCTAssertEqual(metadata.count, 0)
     }
+
+    // MARK: Key / value validation
+
+    func test_addProperty_keyExceedingMaxLength_isDropped() throws {
+        let handler = MetadataHandler(
+            storage: storage,
+            sessionController: sessionController,
+            syncronizationQueue: MockQueue()
+        )
+
+        // a key at the 128-char limit is stored
+        let okKey = String(repeating: "k", count: 128)
+        handler.addProperty(key: okKey, value: "v", lifespan: .session)
+
+        // a key over the limit (129) is dropped
+        let longKey = String(repeating: "k", count: 129)
+        handler.addProperty(key: longKey, value: "v", lifespan: .session)
+
+        let records = storage.fetchCustomPropertiesForSessionId(sessionController.currentSession!.id)
+        XCTAssertNotNil(records.first { $0.key == okKey })
+        XCTAssertNil(records.first { $0.key == longKey })
+    }
+
+    func test_addProperty_valueExceedingMaxLength_isTruncatedWithEllipsis() throws {
+        let handler = MetadataHandler(
+            storage: storage,
+            sessionController: sessionController,
+            syncronizationQueue: MockQueue()
+        )
+
+        handler.addProperty(key: "big", value: String(repeating: "a", count: 2000), lifespan: .session)
+
+        // first 1020+1 characters are preserved, then an ellipsis is appended -> 1024 chars total
+        let record = storage.fetchCustomPropertiesForSessionId(sessionController.currentSession!.id)
+            .first { $0.key == "big" }
+        XCTAssertEqual(record?.value, String(repeating: "a", count: 1021) + "...")
+    }
+
+    func test_addProperty_valueAtMaxLength_isStoredUnchanged() throws {
+        let handler = MetadataHandler(
+            storage: storage,
+            sessionController: sessionController,
+            syncronizationQueue: MockQueue()
+        )
+
+        let value = String(repeating: "a", count: 1024)
+        handler.addProperty(key: "exact", value: value, lifespan: .session)
+
+        let record = storage.fetchCustomPropertiesForSessionId(sessionController.currentSession!.id)
+            .first { $0.key == "exact" }
+        XCTAssertEqual(record?.value, value)
+    }
 }

--- a/Tests/EmbraceCoreTests/Utils/DataGzipTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/DataGzipTests.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import EmbraceCore
+
+class DataGzipTests: XCTestCase {
+
+    func test_gzipRoundTrip_largeMultiChunkPayload() throws {
+        // given a payload larger than the internal chunk buffer (exercises the multi-chunk deflate/inflate loop)
+        let original = Data((0..<200_000).map { UInt8($0 % 251) })
+
+        // when gzipping it
+        let compressed = try original.gzipped()
+
+        // then the result is gzip-framed and differs from the input
+        XCTAssertTrue(compressed.isGzipped)
+        XCTAssertNotEqual(compressed, original)
+
+        // and gunzipping restores the original bytes
+        XCTAssertEqual(try compressed.gunzipped(), original)
+    }
+
+    func test_gzipped_emptyData_returnsEmpty() throws {
+        // empty input is a no-op in both directions (and must not crash)
+        XCTAssertEqual(try Data().gzipped(), Data())
+        XCTAssertEqual(try Data().gunzipped(), Data())
+    }
+
+    func test_gunzipped_corruptData_throwsDataError() throws {
+        // given bytes that are not valid gzip/zlib
+        let garbage = Data([0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78])
+
+        // when gunzipping, then it throws a GzipError with the data-corruption kind
+        XCTAssertThrowsError(try garbage.gunzipped()) { error in
+            guard let gzipError = error as? GzipError else {
+                return XCTFail("expected GzipError, got \(error)")
+            }
+            XCTAssertEqual(gzipError.kind, .data)
+        }
+    }
+
+    func test_gzipped_inputExceedingMaxSize_throwsMemoryError() throws {
+        // given data larger than the allowed max input size
+        let data = Data(repeating: 0xAB, count: 1024)
+
+        // when gzipping with a smaller cap, then it throws a GzipError with the memory kind
+        XCTAssertThrowsError(try data.gzipped(maxInputSize: 512)) { error in
+            guard let gzipError = error as? GzipError else {
+                return XCTFail("expected GzipError, got \(error)")
+            }
+            XCTAssertEqual(gzipError.kind, .memory)
+        }
+    }
+}

--- a/Tests/EmbraceCoreTests/Utils/EncodableJSONTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/EncodableJSONTests.swift
@@ -76,4 +76,26 @@ class EncodableJSONTests: XCTestCase {
         XCTAssertEqual(result["double"] as! Double, 11)
         XCTAssertEqual(result["null"] as! NSNull, NSNull())
     }
+
+    func test_encoding_unsupportedValueInDictionary_throwsInvalidValue() {
+        // Date is not a JSON-encodable primitive in our switch -> hits the `default` throw
+        let model = TestableEncodable(with: ["bad": Date()])
+
+        XCTAssertThrowsError(try JSONEncoder().encode(model)) { error in
+            guard let encodingError = error as? EncodingError, case .invalidValue = encodingError else {
+                return XCTFail("expected EncodingError.invalidValue, got \(error)")
+            }
+        }
+    }
+
+    func test_encoding_unsupportedValueInArray_throwsInvalidValue() {
+        // the unkeyed-container path has its own `default` throw for non-JSON array elements
+        let model = TestableEncodable(with: ["arr": [Date()]])
+
+        XCTAssertThrowsError(try JSONEncoder().encode(model)) { error in
+            guard let encodingError = error as? EncodingError, case .invalidValue = encodingError else {
+                return XCTFail("expected EncodingError.invalidValue, got \(error)")
+            }
+        }
+    }
 }

--- a/Tests/EmbraceCoreTests/Utils/KeychainAccessTest.swift
+++ b/Tests/EmbraceCoreTests/Utils/KeychainAccessTest.swift
@@ -45,4 +45,43 @@ class KeychainAccessTests: XCTestCase {
 
         XCTAssertNotNil(deviceId)
     }
+
+    func test_deviceId_withNonUUIDStoredValue_selfHealsToNewUUID() {
+        // given a keychain holding a corrupt (non-UUID) value
+        mockKeyChain.value = "not-a-uuid"
+
+        // when reading the device id
+        let deviceId = KeychainAccess.deviceId
+
+        // then a fresh valid UUID is generated and persisted over the garbage
+        XCTAssertEqual(mockKeyChain.value, deviceId.uuidString)
+        XCTAssertNotEqual(mockKeyChain.value, "not-a-uuid")
+    }
+
+    func test_deviceId_whenWriteFails_returnsFreshValidIdEachTime() {
+        // given a keychain that has nothing stored and whose writes fail
+        KeychainAccess.keychain = FailingWriteKeychainInterface()
+
+        // when reading the device id twice
+        let id1 = KeychainAccess.deviceId
+        let id2 = KeychainAccess.deviceId
+
+        // then each call still returns a valid UUID; the failed write means nothing persists,
+        // so the ids differ (the call never crashes or returns a stale/invalid value)
+        XCTAssertNotEqual(id1, id2)
+    }
+}
+
+private class FailingWriteKeychainInterface: KeychainInterface {
+    func valueFor(service: CFString, account: CFString) -> (value: String?, status: OSStatus) {
+        return (nil, errSecItemNotFound)
+    }
+
+    func setValue(service: CFString, account: CFString, value: String, completion: (OSStatus) -> Void) {
+        completion(errSecIO)
+    }
+
+    func deleteValue(service: CFString, account: CFString) -> OSStatus {
+        return errSecSuccess
+    }
 }

--- a/Tests/EmbraceCoreTests/Utils/URLEmbraceTests.swift
+++ b/Tests/EmbraceCoreTests/Utils/URLEmbraceTests.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import EmbraceCore
+
+class URLEmbraceTests: XCTestCase {
+
+    func test_endpoints_appendVersionedApiPath() {
+        // the three telemetry endpoints append their versioned api path to the base
+        let base = "https://example.com"
+        XCTAssertEqual(URL.spansEndpoint(basePath: base)?.absoluteString, "https://example.com/v2/spans")
+        XCTAssertEqual(URL.logsEndpoint(basePath: base)?.absoluteString, "https://example.com/v2/logs")
+        XCTAssertEqual(URL.attachmentsEndpoint(basePath: base)?.absoluteString, "https://example.com/v2/attachments")
+    }
+
+}

--- a/Tests/EmbraceIOTests/EmbraceIOOptionsTests.swift
+++ b/Tests/EmbraceIOTests/EmbraceIOOptionsTests.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceConfiguration
+import EmbraceSemantics
+import TestSupport
+import XCTest
+
+@testable import EmbraceIO
+
+class EmbraceIOOptionsTests: XCTestCase {
+
+    func test_withAppId_derivesEndpointsFromAppId_andNilsRuntimeConfiguration() {
+        let options = EmbraceIO.Options.withAppId("myApp")
+
+        XCTAssertEqual(options.appId, "myApp")
+
+        // endpoints default to the Embrace endpoints derived from the appId
+        let expected = EmbraceEndpoints(appId: "myApp")
+        XCTAssertEqual(options.endpoints?.baseURL, expected.baseURL)
+        XCTAssertEqual(options.endpoints?.configBaseURL, expected.configBaseURL)
+
+        // the appId mode never carries a local runtime configuration
+        XCTAssertNil(options.runtimeConfiguration)
+    }
+
+    func test_withAppId_honorsExplicitEndpoints() {
+        let custom = EmbraceEndpoints(baseURL: "base", configBaseURL: "config")
+        let options = EmbraceIO.Options.withAppId("myApp", endpoints: custom)
+
+        XCTAssertEqual(options.endpoints?.baseURL, "base")
+        XCTAssertEqual(options.endpoints?.configBaseURL, "config")
+    }
+
+    func test_withLocalConfiguration_keepsConfig_andHasNilAppIdAndEndpoints() throws {
+        let config = MockEmbraceConfigurable()
+        let options = EmbraceIO.Options.withLocalConfiguration(config, otel: EmbraceIO.OTelOptions())
+
+        // local-config mode has no appId, so no derived endpoints either
+        XCTAssertNil(options.appId)
+        XCTAssertNil(options.endpoints)
+
+        // and the provided configuration is retained
+        let stored = try XCTUnwrap(options.runtimeConfiguration as? MockEmbraceConfigurable)
+        XCTAssertTrue(stored === config)
+    }
+}

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadExponentialBackoffTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadExponentialBackoffTests.swift
@@ -1,0 +1,39 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable import EmbraceUploadInternal
+
+class EmbraceUploadExponentialBackoffTests: XCTestCase {
+
+    func test_calculateDelay_doublesEachRetryUntilCapped() {
+        let backoff = EmbraceUpload.ExponentialBackoff(baseDelay: 0.25, maxDelay: 32.0)
+
+        // delay doubles starting from baseDelay (retryNumber is 1-based)
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 1), 0.25, accuracy: 0.0001)
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 2), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 3), 1.0, accuracy: 0.0001)
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 4), 2.0, accuracy: 0.0001)
+
+        // and is capped at maxDelay once the doubling would exceed it
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 20), 32.0, accuracy: 0.0001)
+    }
+
+    func test_calculateDelay_appendsExtraDelay() {
+        let backoff = EmbraceUpload.ExponentialBackoff(baseDelay: 0.25, maxDelay: 32.0)
+
+        // extraDelay is added on top of the (capped) exponential delay
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 1, appending: 5), 5.25, accuracy: 0.0001)
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 20, appending: 5), 37.0, accuracy: 0.0001)
+    }
+
+    func test_init_clampsMaxDelayToAtLeastBaseDelay() {
+        // a maxDelay smaller than baseDelay is clamped up to baseDelay, so the cap never undercuts the first delay
+        let backoff = EmbraceUpload.ExponentialBackoff(baseDelay: 10.0, maxDelay: 2.0)
+
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 1), 10.0, accuracy: 0.0001)
+        XCTAssertEqual(backoff.calculateDelay(forRetryNumber: 5), 10.0, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary

Fills in **value-ranked unit-test gaps** identified by the 7.0 coverage analysis (`specs/ios-sdk/release-7.0/coverage`). One commit per area; each test was filtered to assertions that exercise **our** logic (not stdlib), and verified green before commit.

## Coverage impact

Measured before/after on macOS (`swift test --enable-code-coverage`), same 18,087 executable lines both runs (test-only changes), so the columns are directly comparable.

**Overall: 84.21% → 85.78% (+1.57 pts), +284 lines covered.** Only the thin modules moved; the already-strong ones (Storage, Upload, OTelBridge, Config) were untouched by design.

| Module | before → after | Δ |
|---|---|---:|
| EmbraceIO | 32.4% → 43.7% | **+11.3** |
| EmbraceCaptureService | 46.3% → 52.8% | +6.5 |
| EmbraceSemantics | 69.8% → 74.7% | +4.9 |
| EmbraceCommonInternal | 80.5% → 85.0% | +4.5 |
| EmbraceCore | 85.1% → 86.6% | +1.6 |
| others (Storage/Upload/OTelBridge/Config/CoreData) | unchanged | +0.0 |

> Note: **EmbraceUploadInternal shows +0.0 despite the new `ExponentialBackoff` tests** — those lines were already *executed* via the `.withNoDelay()` stub, so the new tests add *assertion quality* (pinning the actual delay math) rather than line coverage. Line-% doesn't capture that, which is why the work was ranked by value, not percentage. iOS wasn't re-measured post-PR; its delta would be at least as large (WebView coverage is iOS-only).

## Tests added (13 commits)
- **Data+Gzip** — round-trip over a multi-chunk payload + corrupt/oversized/empty error paths (hand-rolled zlib buffer code on the upload path)
- **URL+Embrace** — the `/v2/spans|logs|attachments` endpoint path constants
- **ExponentialBackoff** — the `min(base·2^(n-1), max)+extra` delay formula + the `maxDelay >= baseDelay` init clamp
- **CrashSignal** — full round-trip across both 32-case string tables, case-insensitivity, unknown→nil (made the enum `CaseIterable`)
- **Embrace.Options.validate** — appId-length and appGroupId rules
- **CaptureService** — lifecycle guards (start-before-install / stop-before-start no-ops, install idempotency, paused→active resume)
- **MetadataHandler** — key (128) drop + value (1024) truncation, with the exact off-by-one pinned
- **Encodable+JSON** — the `default:` `invalidValue` throw in both containers
- **EmbraceFileSystem** — `v7/<partition>/<name>` layout + root-level files staying out of the version dir
- **KeychainAccess** — `deviceId` self-heal on a corrupt value + non-fatal write failure
- **EmbraceIO.Options** — `withAppId` (derives endpoints, nils config) vs `withLocalConfiguration`
- **LogController** — `.critical` severity rejection + `onSessionEnd` force-flush (via the real notification, so the observer wiring is covered)
- **WebView** — `getUrlString` query/PII stripping honoring `stripQueryParams`

### Small production changes (for testability, behavior-neutral)
- `CrashSignal` → `CaseIterable` (enables `allCases`-driven round-trip; zero runtime cost)
- `Tests/.../Embrace+OptionsTests.swift` import flipped to `@testable` to reach the `internal` `validate()`

### Deliberately not covered
- **Public CrashReporter wrapper** — passthrough/stdlib-enum glue; pinning it needs a full `Embrace` instance for thin value.
- **`CaptureServices.unique` dedup** — `fileprivate`/unreachable without the heavy production init; the fan-out alone is low value. A note in `by-module.md` records the true test and the one-word visibility change it needs.

_See `specs/ios-sdk/release-7.0/coverage/README.md` for the full analysis and value/complexity ranking._
