### PR TITLE
[EMBR-12822] Fix: span eviction over-eviction on type-prefix collision

### DIFF
--- a/Sources/EmbraceStorageInternal/Operations/EmbraceStorage+Span.swift
+++ b/Sources/EmbraceStorageInternal/Operations/EmbraceStorage+Span.swift
@@ -403,7 +403,7 @@ extension EmbraceStorage {
         let limit = options.spanLimits[type, default: limitByType(type)]
 
         let request = SpanRecord.createFetchRequest()
-        request.predicate = NSPredicate(format: "typeRaw BEGINSWITH %@", type.rawValue)
+        request.predicate = NSPredicate(format: "typeRaw == %@", type.rawValue)
         let count = coreData.count(withRequest: request)
 
         if count >= limit {

--- a/Tests/EmbraceStorageInternalTests/Records/SpanRecord/EmbraceStorage+SpanTests.swift
+++ b/Tests/EmbraceStorageInternalTests/Records/SpanRecord/EmbraceStorage+SpanTests.swift
@@ -108,4 +108,40 @@ final class EmbraceStorage_SpanTests: XCTestCase {
 
         XCTAssertEqual(allRecords.count, storage.options.spanLimitDefault)
     }
+
+    func test_upsertSpan_limitForType_doesNotEvictDeeperTypeSharingPrefix() throws {
+        // `.performance` (raw "performance") is a prefix of `.networkRequest`
+        // (raw "performance.network_request"). Enforcing the small `.performance` limit must NOT
+        // count or evict network-request spans, which keep their own (default 1500) limit.
+        storage.options.spanLimits[.performance] = 3
+
+        let base = Date(timeIntervalSince1970: 0)
+
+        // three OLDER network-request spans (deeper type that shares the "performance" prefix)
+        for i in 0..<3 {
+            storage.upsertSpan(
+                MockSpan(
+                    name: "network \(i)",
+                    type: .networkRequest,
+                    startTime: base.addingTimeInterval(TimeInterval(i))
+                ))
+        }
+
+        // one NEWER bare `.performance` span — enforcing its limit of 3 should not touch the network spans
+        storage.upsertSpan(
+            MockSpan(
+                name: "performance",
+                type: .performance,
+                startTime: base.addingTimeInterval(100)
+            ))
+
+        let request = SpanRecord.createFetchRequest()
+        let allRecords: [SpanRecord] = storage.coreData.fetch(withRequest: request)
+
+        XCTAssertEqual(allRecords.count, 4)
+        XCTAssertEqual(
+            Set(allRecords.map(\.name)),
+            ["network 0", "network 1", "network 2", "performance"]
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a span over-eviction bug in `EmbraceStorage.removeOldSpanIfNeeded`.

The eviction query matched candidates with `typeRaw BEGINSWITH <type>`. Because an `EmbraceType`'s rawValue is `<primary>.<secondary>`, a short-prefix type is a prefix of its deeper variants — e.g. `.performance` (`"performance"`) is a prefix of `.networkRequest` (`"performance.network_request"`). So enforcing a small limit on `.performance` **counted and evicted network-request spans**, even though those have their own (default 1500) limit. Result: silent loss of unrelated telemetry.

### Fix
One line — use an exact type match:
```diff
- request.predicate = NSPredicate(format: "typeRaw BEGINSWITH %@", type.rawValue)
+ request.predicate = NSPredicate(format: "typeRaw == %@", type.rawValue)
```

### Test
Adds `test_upsertSpan_limitForType_doesNotEvictDeeperTypeSharingPrefix`: with `spanLimits[.performance] = 3`, three older `.networkRequest` spans plus one newer `.performance` span — all four must survive. This **fails on `BEGINSWITH`** (one network span wrongly evicted) and passes with `==`. The three existing eviction tests still pass (their types don't prefix-collide).
