### PR TITLE
[EMBR-12826] Chore: Add EmbraceStorage durability test coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -226,7 +226,7 @@ let package = Package(
         ),
         .testTarget(
             name: "EmbraceStorageInternalTests",
-            dependencies: ["EmbraceStorageInternal", "TestSupport"],
+            dependencies: ["EmbraceStorageInternal", "EmbraceCoreDataInternal", "TestSupport"],
             resources: [
                 .copy("Mocks/")
             ]

--- a/Tests/EmbraceStorageInternalTests/EmbraceStorageConcurrencyTests.swift
+++ b/Tests/EmbraceStorageInternalTests/EmbraceStorageConcurrencyTests.swift
@@ -1,0 +1,44 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceCommonInternal
+import Foundation
+import TestSupport
+import XCTest
+
+@testable import EmbraceStorageInternal
+
+final class EmbraceStorageConcurrencyTests: XCTestCase {
+
+    func test_concurrentUpsertFetchCleanup_isThreadSafeAndConsistent() throws {
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let count = 200
+        let queue = DispatchQueue(label: "com.embrace.storage.stress", attributes: .concurrent)
+        let group = DispatchGroup()
+
+        // Hammer the shared background context from many threads at once: writers inserting distinct
+        // open spans, readers counting, and cleanup passes — all interleaved. Open spans from the
+        // current process are never eligible for cleanUpSpans, so the final count stays deterministic.
+        for i in 0..<count {
+            queue.async(group: group) {
+                storage.upsertSpan(MockSpan(name: "span-\(i)"))
+            }
+            queue.async(group: group) {
+                _ = storage.coreData.count(withRequest: SpanRecord.createFetchRequest())
+            }
+            queue.async(group: group) {
+                storage.cleanUpSpans()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(result, .success, "concurrent storage operations timed out (possible deadlock)")
+
+        // every distinct span survived — nothing lost, duplicated, or corrupted under contention
+        let total = storage.coreData.count(withRequest: SpanRecord.createFetchRequest())
+        XCTAssertEqual(total, count)
+    }
+}

--- a/Tests/EmbraceStorageInternalTests/EmbraceStorageCorruptionTests.swift
+++ b/Tests/EmbraceStorageInternalTests/EmbraceStorageCorruptionTests.swift
@@ -1,0 +1,44 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import CoreData
+import EmbraceCommonInternal
+import EmbraceCoreDataInternal
+import Foundation
+import TestSupport
+import XCTest
+
+@testable import EmbraceStorageInternal
+
+final class EmbraceStorageCorruptionTests: XCTestCase {
+
+    func test_coreDataWrapper_onDisk_corruptStore_throwsInsteadOfCrashing() throws {
+        // copy the committed corrupted sqlite fixture to a unique on-disk location
+        let fixturePath = try XCTUnwrap(
+            Bundle.module.path(forResource: "db_corrupted", ofType: "sqlite", inDirectory: "Mocks")
+        )
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let name = "db_corrupted"
+        try FileManager.default.copyItem(
+            atPath: fixturePath,
+            toPath: dir.appendingPathComponent(name + ".sqlite").path
+        )
+
+        let options = CoreDataWrapper.Options(
+            storageMechanism: .onDisk(name: name, baseURL: dir, journalMode: .delete),
+            enableBackgroundTasks: false,
+            entities: [SessionRecord.entityDescription]
+        )
+
+        // `isTesting: false` forces the real on-disk SQLite store (otherwise tests run in-memory).
+        // A corrupt store must throw at init — failing fast — rather than crash later on first fetch/save.
+        XCTAssertThrowsError(
+            try CoreDataWrapper(options: options, logger: MockLogger(), isTesting: false)
+        )
+    }
+}

--- a/Tests/EmbraceStorageInternalTests/EmbraceStorageMigrationTests.swift
+++ b/Tests/EmbraceStorageInternalTests/EmbraceStorageMigrationTests.swift
@@ -1,0 +1,87 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import CoreData
+import EmbraceCommonInternal
+import EmbraceCoreDataInternal
+import Foundation
+import TestSupport
+import XCTest
+
+@testable import EmbraceStorageInternal
+
+final class EmbraceStorageMigrationTests: XCTestCase {
+
+    /// The v7 user-session columns were added as nullable/additive so a pre-v7 on-disk store
+    /// lightweight-migrates on upgrade instead of failing to load (which would crash on launch).
+    /// This seeds a pre-v7 store (current `SessionRecord` schema minus those columns), then opens
+    /// it with the current model via `CoreDataWrapper` and asserts the row survives migration.
+    func test_preV7Store_lightweightMigratesUserSessionColumns() throws {
+        let userSessionColumns: Set<String> = [
+            "userSessionIdRaw", "userSessionStartTime", "userSessionMaxDuration",
+            "userSessionInactivityTimeout", "userSessionLastForegroundEnd",
+            "userSessionPartIndex", "userSessionTerminationReason"
+        ]
+
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let name = "migration"
+        let fileURL = dir.appendingPathComponent(name + ".sqlite")
+
+        // 1) Build a pre-v7 model: the current Session entity minus the user-session columns.
+        //    Properties must be copied (a property can't belong to two entities), and the class is
+        //    generic NSManagedObject so we don't touch SessionRecord's @NSManaged user-session accessors.
+        let oldEntity = NSEntityDescription()
+        oldEntity.name = SessionRecord.entityName
+        oldEntity.managedObjectClassName = NSStringFromClass(NSManagedObject.self)
+        oldEntity.properties =
+            SessionRecord.entityDescription.properties
+            .filter { !userSessionColumns.contains($0.name) }
+            .compactMap { $0.copy() as? NSPropertyDescription }
+        let oldModel = NSManagedObjectModel()
+        oldModel.entities = [oldEntity]
+
+        // 2) Create the pre-v7 on-disk store and write one session row.
+        let oldCoordinator = NSPersistentStoreCoordinator(managedObjectModel: oldModel)
+        let oldStore = try oldCoordinator.addPersistentStore(
+            ofType: NSSQLiteStoreType, configurationName: nil, at: fileURL, options: nil)
+        let oldContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        oldContext.persistentStoreCoordinator = oldCoordinator
+
+        let row = NSEntityDescription.insertNewObject(forEntityName: SessionRecord.entityName, into: oldContext)
+        row.setValue("session-1", forKey: "idRaw")
+        row.setValue("proc-1", forKey: "processIdRaw")
+        row.setValue("foreground", forKey: "state")
+        row.setValue("trace-1", forKey: "traceId")
+        row.setValue("span-1", forKey: "spanId")
+        row.setValue(Date(), forKey: "startTime")
+        row.setValue(Date(), forKey: "lastHeartbeatTime")
+        row.setValue(false, forKey: "coldStart")
+        row.setValue(false, forKey: "cleanExit")
+        row.setValue(false, forKey: "appTerminated")
+        try oldContext.save()
+        try oldCoordinator.remove(oldStore)  // close the pre-v7 store
+
+        // 3) Open the same file with the CURRENT model — triggers lightweight migration.
+        let options = CoreDataWrapper.Options(
+            storageMechanism: .onDisk(name: name, baseURL: dir, journalMode: .delete),
+            enableBackgroundTasks: false,
+            entities: [SessionRecord.entityDescription]
+        )
+        let wrapper = try CoreDataWrapper(options: options, logger: MockLogger(), isTesting: false)
+
+        // 4) The pre-v7 row survived; the new user-session columns read back as nil/default.
+        let records: [SessionRecord] = wrapper.fetch(withRequest: SessionRecord.createFetchRequest())
+        XCTAssertEqual(records.count, 1)
+        let record = try XCTUnwrap(records.first)
+        XCTAssertEqual(record.idRaw, "session-1")
+        XCTAssertNil(record.userSessionIdRaw)
+        XCTAssertNil(record.userSessionStartTime)
+        XCTAssertNil(record.userSessionTerminationReason)
+        XCTAssertEqual(record.userSessionPartIndex, 0)
+    }
+}

--- a/Tests/EmbraceStorageInternalTests/EmbraceStorageOnDiskTests.swift
+++ b/Tests/EmbraceStorageInternalTests/EmbraceStorageOnDiskTests.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import CoreData
+import EmbraceCommonInternal
+import EmbraceCoreDataInternal
+import Foundation
+import TestSupport
+import XCTest
+
+@testable import EmbraceStorageInternal
+
+final class EmbraceStorageOnDiskTests: XCTestCase {
+
+    func test_onDiskStore_persistsRecordsAcrossReopen() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let options = CoreDataWrapper.Options(
+            storageMechanism: .onDisk(name: "roundtrip", baseURL: dir, journalMode: .delete),
+            enableBackgroundTasks: false,
+            entities: SpanRecord.entityDescriptions
+        )
+
+        // write a span to a real on-disk store (isTesting:false), then release the wrapper
+        do {
+            let wrapper = try CoreDataWrapper(options: options, logger: MockLogger(), isTesting: false)
+            SpanRecord.create(context: wrapper.context, span: MockSpan(name: "survivor"))
+            wrapper.save()
+        }
+
+        // reopen a fresh wrapper on the same file — the record must survive
+        let reopened = try CoreDataWrapper(options: options, logger: MockLogger(), isTesting: false)
+        let records: [SpanRecord] = reopened.fetch(withRequest: SpanRecord.createFetchRequest())
+
+        XCTAssertEqual(records.count, 1)
+        XCTAssertEqual(records.first?.name, "survivor")
+    }
+}


### PR DESCRIPTION
## Summary

Adds storage durability tests from the 7.0 coverage analysis. These cover the on-disk / concurrency / migration paths that the rest of the suite can't reach, because `CoreDataWrapper`'s `isTesting` default forces an **in-memory** store under XCTest — so every other storage test runs in-memory.

### Tests (one commit each)

- **#18 — corruption recovery:** constructs `CoreDataWrapper(isTesting: false)` against the committed-but-previously-unused `db_corrupted.sqlite` fixture and asserts `init` **throws** (the fail-fast contract: `loadPersistentStores` error → rethrow), rather than appearing initialized and crashing later. (`SQLITE_CORRUPT`)
- **#19 — on-disk round-trip:** writes a span to a real on-disk SQLite store, releases the wrapper, reopens a fresh wrapper on the same file, and asserts the record survives — the durable persistence path, never exercised in-memory.
- **#20 — concurrent stress:** hammers the shared background context with 200 interleaved concurrent `upsertSpan` / `count` / `cleanUpSpans` operations; asserts no crash/deadlock and a consistent final count. (Ran 10× locally for stability.)
- **#17 — schema migration:** seeds a *pre-v7* on-disk store (current `Session` schema minus the 7 nullable user-session columns), then opens it with the current model and asserts lightweight migration succeeds and the row survives with the new columns nil/default. Guards against a future **non-additive** `SessionRecord` change that would crash on upgrade.

### Build change
- `Package.swift`: added `EmbraceCoreDataInternal` to the `EmbraceStorageInternalTests` target deps (test-only) so the on-disk tests can construct `CoreDataWrapper` directly with `isTesting: false`. That target already operates on `storage.coreData`, so the dependency is honest.
