### PR TITLE
[EMBR-12829] Fix: Poll for heartbeat advance in SessionControllerTests/test_heartbeat

### DIFF
--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -515,11 +515,14 @@ final class SessionControllerTests: XCTestCase {
         let session = controller.startSession(state: .foreground)
         var lastDate = session!.lastHeartbeatTime
 
-        // then the heartbeat time is updated
+        // The heartbeat advances on a timer that CI load can delay, so poll for
+        // the timestamp to actually change instead of assuming it happens within
+        // a fixed window.
         for _ in 1...3 {
-            wait(delay: 0.3)
-            XCTAssertNotEqual(lastDate, controller.currentSession!.lastHeartbeatTime)
-            lastDate = controller.currentSession!.lastHeartbeatTime
+            wait(timeout: .longTimeout, interval: .shortInterval) {
+                controller.currentSession?.lastHeartbeatTime != lastDate
+            }
+            lastDate = try XCTUnwrap(controller.currentSession?.lastHeartbeatTime)
         }
     }
 


### PR DESCRIPTION
## What

`SessionControllerTests/test_heartbeat` waited a fixed `0.3s` (`wait(delay: 0.3)`) and then asserted `lastHeartbeatTime` had changed via `XCTAssertNotEqual`. That assumes the `0.1s` heartbeat timer fires inside the sleep window; under CI load the timer can be starved, leaving the timestamp unchanged and failing the assertion (false negative).

This replaces the blind sleep + single `NotEqual` with `wait(timeout:interval:until:)` polling for the timestamp to actually advance, the same post-condition-polling idiom already used by `test_endSession_uploadsSession*` in this suite. Bounded by `.longTimeout` (5s), so a genuine regression still fails loudly rather than hanging.

Test-only change.

## Validation

`test_heartbeat` run 10× with `-run-tests-until-failure` on macOS → 10/10 pass, ~0.31s each (poll returns as soon as each heartbeat fires; no added wall-clock).

## Notes

The flake was observed on iOS `sanitizer none` on PR #684 (base `7.0`). The test is identical on `main` and `7.0` (7.0 only adds `controller.otel = otel`), so this is fixed on `main` and will carry into `7.0` on the next merge.