### PR TITLE
[EMBR-12830] Fix: Deterministic upload dispatch in endSession upload tests to fix CI starvation flake

### DIFF
--- a/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/SessionControllerTests.swift
@@ -245,8 +245,11 @@ final class SessionControllerTests: XCTestCase {
         // mock successful requests
         EmbraceHTTPMock.mock(url: testSessionsUrl())
 
-        // given a started session
-        let controller = SessionController(storage: storage, upload: upload, config: nil)
+        // given a started session. A synchronous upload queue keeps the end-session
+        // upload dispatch on the calling thread instead of hopping through the shared
+        // GCD pool, which can be starved under CI load and leave the request unsent.
+        let controller = SessionController(
+            storage: storage, upload: upload, config: nil, queue: MockQueue())
         controller.sdkStateProvider = sdkStateProvider
         controller.startSession(state: .foreground)
 
@@ -278,8 +281,11 @@ final class SessionControllerTests: XCTestCase {
         // mock error requests
         EmbraceHTTPMock.mock(url: testSessionsUrl(), errorCode: 500)
 
-        // given a started session
-        let controller = SessionController(storage: storage, upload: upload, config: nil)
+        // given a started session. A synchronous upload queue keeps the end-session
+        // upload dispatch on the calling thread instead of hopping through the shared
+        // GCD pool, which can be starved under CI load and leave the request unsent.
+        let controller = SessionController(
+            storage: storage, upload: upload, config: nil, queue: MockQueue())
         controller.sdkStateProvider = sdkStateProvider
         controller.startSession(state: .foreground)
 


### PR DESCRIPTION
## What

`SessionControllerTests/test_endSession_uploadsSession[_error]` end a session and poll `EmbraceHTTPMock` for the resulting request. `endSession()` dispatches the upload through `SessionController`'s own serial queue (`com.embrace.session_controller_upload`, `SessionController.swift:320`) — a plain GCD-pool-backed `DispatchQueue` that `EmbraceUpload`'s own upload tests don't have. Under CI load that hop can be starved, so **no request reaches the mock within the poll window** and the test fails with `totalRequestCount() == 0` (recurred 2026-06-30 on run 28481406258, iOS sanitizer none, despite the earlier polling fix in #659).

Inject the existing `MockQueue` (runs blocks inline) as the controller's upload queue so the dispatch is deterministic instead of depending on the shared pool. `SessionController.init(queue:)` is already injectable — **test-only change, no production code touched**. Same "don't depend on the shared GCD pool" family as #674.

The real network path stays exercised: `EmbraceUpload`'s own `.utility` upload `OperationQueue` and the `URLSession` → `EmbraceHTTPMock` round-trip are still asynchronous and real; only the logic-free controller dispatch hop becomes inline.

## Validation

- `test_endSession_uploadsSession[_error]` ×30 with `-run-tests-until-failure` on macOS → 60/60 pass.
- Full `SessionControllerTests` suite green (29 tests).
- Per-test runtime drops ~0.2–0.4s → ~0.03s (upload fires inline instead of waiting on scheduling).