### PR TITLE
Fix stale doc comments in EmbraceIO public API

### DIFF
--- a/Sources/EmbraceIO/EmbraceIO.swift
+++ b/Sources/EmbraceIO/EmbraceIO.swift
@@ -20,7 +20,7 @@ import Foundation
 /// ```swift
 /// import EmbraceIO
 ///
-/// let options = EmbraceIO.Options(appId: "appId")
+/// let options = EmbraceIO.Options.withAppId("appId")
 /// try EmbraceIO.setup(options: options)
 /// ```
 public class EmbraceIO {

--- a/Sources/EmbraceIO/Public/EmbraceIO+StartupInstrumentation.swift
+++ b/Sources/EmbraceIO/Public/EmbraceIO+StartupInstrumentation.swift
@@ -16,6 +16,7 @@ extension EmbraceIO {
     /// - Parameters:
     ///    - name: The name of the span.
     ///    - startTime: The start time of the span.
+    ///    - endTime: The end time of the span, if already known. Defaults to `nil`.
     ///    - attributes: A dictionary of attributes to set on the span.
     /// - Returns: An `EmbraceSpan` or nil if the root span was not found.
     public func createStartupChildSpan(


### PR DESCRIPTION
## Summary

Two stale doc-comment fixes surfaced while reviewing the 7.0 Public API reference. Both are comment-only — no code behavior changes.

- **`EmbraceIO.swift`** — the class-level usage example showed `EmbraceIO.Options(appId:)`, which is not a public initializer. Updated it to the real factory `EmbraceIO.Options.withAppId(_:)` so copy-pasted code compiles.
- **`EmbraceIO+StartupInstrumentation.swift`** — `createStartupChildSpan(...)`'s doc comment omitted its `endTime` parameter. Added the missing `- endTime:` line.

## Test plan

- [x] Comment-only changes; no behavior affected.