### PR TITLE
[EMBR-12835] Feature: Removing `resetUploadCache`

### DIFF
--- a/Sources/EmbraceCore/Embrace.swift
+++ b/Sources/EmbraceCore/Embrace.swift
@@ -430,11 +430,6 @@ package class Embrace {
         }
     }
 
-    /// Call this if you want the Embrace SDK to clear the upload cache data on the next launch.
-    package func resetUploadCache() {
-        Embrace.resetUploadCache = true
-    }
-
     /// Waits synchronously for all queued SDK work to drain.
     ///
     /// Drains the internal processing queue and the OTel bridge's span pipeline so the SDK

--- a/Sources/EmbraceCore/Internal/Embrace+Setup.swift
+++ b/Sources/EmbraceCore/Internal/Embrace+Setup.swift
@@ -80,8 +80,7 @@ extension Embrace {
             journalMode: configuration.isWalModeEnabled ? .wal : .delete
         )
 
-        let cache = EmbraceUpload.CacheOptions(storageMechanism: storageMechanism, resetCache: resetUploadCache)
-        resetUploadCache = false
+        let cache = EmbraceUpload.CacheOptions(storageMechanism: storageMechanism)
 
         // metadata
         let metadata = EmbraceUpload.MetadataOptions(
@@ -109,12 +108,6 @@ extension Embrace {
             ManualSessionLifecycle(controller: controller)
         }
     #endif
-
-    static let resetUploadCacheKey = "emb.reset-upload-cache"
-    static var resetUploadCache: Bool {
-        get { UserDefaults.standard.bool(forKey: Embrace.resetUploadCacheKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Embrace.resetUploadCacheKey) }
-    }
 }
 
 /// Extension to handle observability of SDK startup

--- a/Sources/EmbraceIO/EmbraceIO.swift
+++ b/Sources/EmbraceIO/EmbraceIO.swift
@@ -119,11 +119,6 @@ public class EmbraceIO {
         Embrace.client?.endUserSession()
     }
 
-    /// Call this if you want the Embrace SDK to clear the upload cache data on the next launch.
-    public func resetUploadCache() {
-        Embrace.client?.resetUploadCache()
-    }
-
     /// Waits synchronously for all queued SDK work to drain.
     ///
     /// SPI for benchmarks and tests — not part of the public SDK surface.

--- a/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
+++ b/Sources/EmbraceUploadInternal/Cache/EmbraceUploadCache.swift
@@ -26,13 +26,6 @@ class EmbraceUploadCache {
             try? FileManager.default.removeItem(at: url)
         }
 
-        // remove active cache if needed
-        if options.resetCache,
-            let cacheUrl = options.storageMechanism.fileURL
-        {
-            try? FileManager.default.removeItem(at: cacheUrl)
-        }
-
         // create core data stack
         let coreDataOptions = CoreDataWrapper.Options(
             storageMechanism: options.storageMechanism,

--- a/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
+++ b/Sources/EmbraceUploadInternal/Options/EmbraceUpload+CacheOptions.swift
@@ -23,21 +23,16 @@ extension EmbraceUpload {
         /// Determines the maximum amount of days a request will be cached. Use 0 to disable.
         public let cacheDaysLimit: UInt
 
-        /// If enabled, the cache will be emptied when created
-        public let resetCache: Bool
-
         public init(
             storageMechanism: StorageMechanism,
             enableBackgroundTasks: Bool = true,
             cacheLimit: UInt = 0,
-            cacheDaysLimit: UInt = 7,
-            resetCache: Bool = false
+            cacheDaysLimit: UInt = 7
         ) {
             self.storageMechanism = storageMechanism
             self.enableBackgroundTasks = enableBackgroundTasks
             self.cacheLimit = cacheLimit
             self.cacheDaysLimit = cacheDaysLimit
-            self.resetCache = resetCache
         }
     }
 }

--- a/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests.swift
+++ b/Tests/EmbraceUploadInternalTests/EmbraceUploadCacheTests.swift
@@ -20,27 +20,6 @@ class EmbraceUploadCacheTests: XCTestCase {
 
     }
 
-    func test_resetCache() throws {
-
-        // create the base folder as sometimes it might not exist
-        try FileManager.default.createDirectory(at: fileProvider.tmpDirectory, withIntermediateDirectories: true)
-
-        // given an existing db file
-        let storageMechanism: StorageMechanism = .onDisk(
-            name: "test_resetCache", baseURL: fileProvider.tmpDirectory, journalMode: .delete)
-        let fileUrl = storageMechanism.fileURL!
-        try "test".write(to: fileUrl, atomically: true, encoding: .utf8)
-        XCTAssert(FileManager.default.fileExists(atPath: fileUrl.path))
-
-        // when creating the cache with the reset flag enabled
-        let options = EmbraceUpload.CacheOptions(
-            storageMechanism: storageMechanism, enableBackgroundTasks: false, resetCache: true)
-        _ = try EmbraceUploadCache(options: options, logger: logger)
-
-        // then the old cache file is deleted
-        XCTAssertFalse(FileManager.default.fileExists(atPath: fileUrl.path))
-    }
-
     func test_fetchUploadData() throws {
         let options = EmbraceUpload.CacheOptions(
             storageMechanism: .inMemory(name: testName), enableBackgroundTasks: false)


### PR DESCRIPTION
I don't think this method is needed anymore with the "recent" changes and fixes we've done on the upload module.
I'd rather release 7.0 without this and add it later, than the other way around.