### PR TITLE
Skip performance tests under sanitizer instrumentation

### DIFF
--- a/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewPerfTests.swift
+++ b/Tests/EmbraceCoreTests/SwiftUI/EmbraceTraceViewPerfTests.swift
@@ -67,7 +67,9 @@
         }
 
         @MainActor
-        func testEmbraceTraceViewEnabledPerformance() async {
+        func testEmbraceTraceViewEnabledPerformance() async throws {
+            // Perf measurements are meaningless under sanitizer instrumentation.
+            try XCTSkipIfSanitizing()
             mockConfig.isSwiftUiViewInstrumentationEnabled = true
             measure {
                 runLayout()
@@ -75,7 +77,9 @@
         }
 
         @MainActor
-        func testEmbraceTraceViewDisabledPerformance() async {
+        func testEmbraceTraceViewDisabledPerformance() async throws {
+            // Perf measurements are meaningless under sanitizer instrumentation.
+            try XCTSkipIfSanitizing()
             mockConfig.isSwiftUiViewInstrumentationEnabled = false
             measure {
                 runLayout()

--- a/Tests/EmbraceIOTests/PerformanceTests.swift
+++ b/Tests/EmbraceIOTests/PerformanceTests.swift
@@ -116,11 +116,7 @@ class PerformanceBacktraceTests: XCTestCase {
     func test_embraceBacktraceAndSymbolicate() throws {
         // ksbic_init (KSCrash binary-image cache) is not safe under sanitizer instrumentation:
         // TSan aborts; ASan deadlocks until the 30-minute job cap fires.
-        let env = ProcessInfo.processInfo.environment
-        try XCTSkipIf(
-            env["TSAN_OPTIONS"] != nil || env["ASAN_OPTIONS"] != nil,
-            "KSCrash symbolication is incompatible with sanitizer instrumentation"
-        )
+        try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
         _ = EmbraceBacktrace.backtrace().threads.compactMap { thread in
             thread.callstack.frames(symbolicated: true)
         }
@@ -140,7 +136,10 @@ class PerformanceLogicalWritesTests: XCTestCase {
         return String((0..<length).compactMap { _ in characters.randomElement() })
     }
 
-    func test_measureLogicalWrites() {
+    func test_measureLogicalWrites() throws {
+        // XCTStorageMetric teardown BUS-faults in objc_release under TSan, and perf
+        // measurements are meaningless under sanitizer instrumentation regardless.
+        try XCTSkipIfSanitizing("XCTStorageMetric is incompatible with sanitizer instrumentation")
 
         let storage: EmbraceStorage! = try? EmbraceStorage.createInDiskDb(fileName: UUID().uuidString, journalMode: .wal)
 

--- a/Tests/TestSupport/XCTSkip+Helpers.swift
+++ b/Tests/TestSupport/XCTSkip+Helpers.swift
@@ -16,6 +16,26 @@ extension XCTestCase {
 }
 
 extension XCTestCase {
+    /// Skips the test when it runs under ThreadSanitizer or AddressSanitizer.
+    ///
+    /// Xcode injects `TSAN_OPTIONS` / `ASAN_OPTIONS` into the test process when the
+    /// corresponding sanitizer is enabled, so their presence is a reliable signal.
+    ///
+    /// Use this for tests that are fundamentally incompatible with sanitizer runs:
+    /// - Performance tests (`measure(...)`): the instrumentation dominates timing and
+    ///   I/O, so the numbers are meaningless, and some `XCTMetric` teardown paths crash
+    ///   (e.g. `XCTStorageMetric` BUS-faults in `objc_release` under TSan).
+    /// - Code paths the sanitizers can't handle, such as KSCrash's binary-image cache
+    ///   (TSan aborts; ASan deadlocks until the job timeout fires).
+    public func XCTSkipIfSanitizing(_ message: String? = nil) throws {
+        let env = ProcessInfo.processInfo.environment
+        guard env["TSAN_OPTIONS"] == nil, env["ASAN_OPTIONS"] == nil else {
+            throw XCTSkip(message ?? "Skipping test under sanitizer instrumentation")
+        }
+    }
+}
+
+extension XCTestCase {
     // this makes it easy to guard against watchOS without warnings
     public static func isWatchOS() -> Bool {
         #if os(watchOS)


### PR DESCRIPTION
## What

Guards all XCTest performance tests so they skip under ThreadSanitizer / AddressSanitizer, and centralizes the detection in a reusable `XCTSkipIfSanitizing` helper.

## Why

The thread-sanitizer CI job was failing on `PerformanceLogicalWritesTests.test_measureLogicalWrites` ([run 28533804253](https://github.com/embrace-io/embrace-apple-sdk/actions/runs/28533804253/job/84589915918)). The raw xcodebuild log shows the crash is a BUS fault inside `objc_release`, called from **Apple's** XCTest performance machinery as it tears down `XCTStorageMetric` — not in Embrace code:

```
ThreadSanitizer: BUS ... in objc_release_x8+0x8
  #1 -[XCTestCase(XCTPerformanceAnalysis) measureWithMetrics:options:block:]  (XCTestCore)
  #3 PerformanceLogicalWritesTests.test_measureLogicalWrites()
```

More broadly, a performance measurement under a sanitizer is meaningless: the instrumentation dominates timing and I/O (the trace-view perf test on that same run reported 238% relative standard deviation). So the right move is to skip perf tests under TSan/ASan entirely — this isn't suppressing a real signal, the signal is invalid by construction.

## Changes

- **New `XCTSkipIfSanitizing(_:)` helper** in `Tests/TestSupport/XCTSkip+Helpers.swift`. Detects the `TSAN_OPTIONS`/`ASAN_OPTIONS` env vars Xcode injects under `-enableThreadSanitizer`/`-enableAddressSanitizer` (the same check the symbolication test already used inline).
- `PerformanceLogicalWritesTests.test_measureLogicalWrites` — guarded (fixes the failure).
- `EmbraceTraceViewPerfTests` (both `measure {}` tests) — guarded for consistency; they pass under TSan today but produce noise and cost ~26s of job time.
- `PerformanceBacktraceTests.test_embraceBacktraceAndSymbolicate` — migrated from its inline env-var check to the helper (no behavior change).

## Testing

`xcodebuild build-for-testing` (EmbraceIO-Package, iOS Simulator) succeeds. These tests continue to run and measure normally in the non-sanitizer jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)