### PR TITLE
Add concurrency group to Build Example Apps workflow

### DIFF
--- a/.github/workflows/build-example-apps.yml
+++ b/.github/workflows/build-example-apps.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-brandgame-app:
     name: Build BrandGame App


### PR DESCRIPTION
## What

Adds a `concurrency` group to `build-example-apps.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

## Why

Build Example Apps was the **only** workflow of the seven missing a concurrency group. Every other workflow (Build Platforms, Run Swift Tests, Cocoapod, Format, Dependency Review, UI Tests, Device Benchmarks) already declares this exact block and auto-cancels superseded runs.

Without it, each push to a PR spawned a fresh Build Example Apps run and left the older in-flight/queued ones alive. On the scarce macOS-26 runners these stale runs just accumulate in the queue — e.g. the 7.0 release PR showed three queued "Build Example Apps" runs for three different commits, while every other workflow showed only the latest.

This brings the workflow in line with the rest and stops the pileup.