### PR TITLE
[EMBR-12885] Fix: Bump remaining fetchUnsentCrashReports test waits to .veryLongTimeout

### DIFF
--- a/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
+++ b/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
@@ -97,7 +97,7 @@
                 expectation.fulfill()
             }
 
-            wait(for: [expectation], timeout: .defaultTimeout)
+            wait(for: [expectation], timeout: .veryLongTimeout)
         }
 
         func test_fetchCrashReports_count() throws {
@@ -224,7 +224,7 @@
                 expectation.fulfill()
             }
 
-            wait(for: [expectation], timeout: .defaultTimeout)
+            wait(for: [expectation], timeout: .veryLongTimeout)
         }
 
         func testOnHavingEmptySignalBlockList_fetchUnsentCrashReports_SIGTERMshouldBeReported() throws {
@@ -248,7 +248,7 @@
                 expectation.fulfill()
             }
 
-            wait(for: [expectation], timeout: .defaultTimeout)
+            wait(for: [expectation], timeout: .veryLongTimeout)
         }
 
         func testOnModifyingSignalBlockList_fetchUnsentCrashReports_shouldAvoidReportingBlockedSignals() throws {
@@ -273,7 +273,7 @@
                 expectation.fulfill()
             }
 
-            wait(for: [expectation], timeout: .defaultTimeout)
+            wait(for: [expectation], timeout: .veryLongTimeout)
         }
     }
 


### PR DESCRIPTION
`EmbraceCrashReporterTests/testOnModifyingSignalBlockList_fetchUnsentCrashReports_shouldAvoidReportingBlockedSignals` flaked on PR #675's `Test iOS … sanitizer none` job ([run 28801930803](https://github.com/embrace-io/embrace-apple-sdk/actions/runs/28801930803/job/85407444668)) with `Asynchronous wait failed: Exceeded timeout of 3 seconds` at `EmbraceCrashReporterTests.swift:276`.

This is a recurrence of EMBR-12774 / #662: a fixed 3 s (`.defaultTimeout`) `XCTestExpectation` wait on `fetchUnsentCrashReports`'s async completion handler, which starves when the callback is delayed past the timeout under CI runner contention. The fetch itself is ~tens of ms; the timeout is the only defect. This occurrence was on `sanitizer none`, confirming the starvation is plain runner contention, not ASan overhead.

#662 bumped only one of five sibling `fetchUnsentCrashReports` tests to `.veryLongTimeout` and its spec called for sweeping the rest once a second occurrence landed. This PR does that sweep — bumping the four remaining `.defaultTimeout` waits to `.veryLongTimeout`:

- `test_fetchCrashReports`
- `testOnHavingDefaultSignalBlockList_fetchUnsentCrashReports_SIGTERMshouldntBeReported`
- `testOnHavingEmptySignalBlockList_fetchUnsentCrashReports_SIGTERMshouldBeReported`
- `testOnModifyingSignalBlockList_fetchUnsentCrashReports_shouldAvoidReportingBlockedSignals`
