### PR TITLE
Make HangCaptureService convenience constructor public

### DIFF
--- a/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
+++ b/Sources/EmbraceIO/Capture/CaptureService+Helpers.swift
@@ -67,7 +67,7 @@ import Foundation
         /// - Note: Available on iOS and tvOS only. Hang detection relies on
         ///   `CADisplayLink`, which has no standalone initializer on macOS and
         ///   is not available on watchOS.
-        static func hangWatchdog() -> HangCaptureService {
+        public static func hangs() -> HangCaptureService {
             return HangCaptureService()
         }
     #endif

--- a/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServiceBuilderTests.swift
@@ -229,7 +229,7 @@ class CaptureServiceBuilderTests: XCTestCase {
             let builder = CaptureServiceBuilder()
 
             // when adding a HangCaptureService
-            builder.add(.hangWatchdog())
+            builder.add(.hangs())
 
             // then the list contains the capture service
             let list = builder.build()


### PR DESCRIPTION
The constructor for HangCaptureService to use in `CaptureServiceBuilder().add(...).build()` is Internal by mistake. This PR makes it public like the rest of the other convenience constructors for capture services on the list.