### PR TITLE
[EMBR-13023] Chore: Gate iOS TSan/ASan on PRs behind ci:sanitizers label

### DIFF
--- a/.github/matrices/builds.json
+++ b/.github/matrices/builds.json
@@ -66,5 +66,45 @@
         "sanitizer": "thread"
       }
     ]
+  },
+  "pr-sanitizers": {
+    "include": [
+      {
+        "platform": "iOS",
+        "xcode_version": "26.5",
+        "macos-version": "26",
+        "sanitizer": "none"
+      },
+      {
+        "platform": "tvOS",
+        "xcode_version": "26.5",
+        "macos-version": "26",
+        "sanitizer": "none"
+      },
+      {
+        "platform": "macOS",
+        "xcode_version": "26.5",
+        "macos-version": "26",
+        "sanitizer": "none"
+      },
+      {
+        "platform": "watchOS",
+        "xcode_version": "26.5",
+        "macos-version": "26",
+        "sanitizer": "none"
+      },
+      {
+        "platform": "iOS",
+        "xcode_version": "26.5",
+        "macos-version": "26",
+        "sanitizer": "address"
+      },
+      {
+        "platform": "iOS",
+        "xcode_version": "26.5",
+        "macos-version": "26",
+        "sanitizer": "thread"
+      }
+    ]
   }
 }

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,7 @@ on:
         required: true
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
@@ -29,9 +30,17 @@ jobs:
           persist-credentials: false
 
       - id: set
+        # SANITIZERS_REQUESTED is read from the event payload (no API call) and
+        # passed via env so the untrusted label text never lands in the script
+        # body. Adding the `ci:sanitizers` label to a PR opts it into the iOS
+        # TSan + ASan jobs; only users with write/triage access can add labels.
+        env:
+          SANITIZERS_REQUESTED: ${{ contains(github.event.pull_request.labels.*.name, 'ci:sanitizers') }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
             MATRIX=$(jq -c .main .github/matrices/builds.json)
+          elif [[ "${SANITIZERS_REQUESTED}" == "true" ]]; then
+            MATRIX=$(jq -c '."pr-sanitizers"' .github/matrices/builds.json)
           else
             MATRIX=$(jq -c .pr .github/matrices/builds.json)
           fi


### PR DESCRIPTION
## What

Adds an opt-in way to run the iOS Thread + Address Sanitizer jobs against a PR, without paying their cost on every PR. Applying the `ci:sanitizers` label to a PR selects a matrix that includes iOS TSan + ASan; every subsequent push while the label is present keeps running them.

Today the sanitizer jobs run **only on `push: main`**, so a race or memory bug in a PR isn't caught until it merges. This lets an author (or reviewer) opt a risky PR in before merge.

## Changes

- **`.github/workflows/run-tests.yml`**
  - `pull_request` now triggers on `labeled` (in addition to the defaults) so applying the label starts a run.
  - `prepare` reads the label from the event payload via a `SANITIZERS_REQUESTED` env var and selects the new matrix when present. Passed through `env:` (not inlined) so the untrusted label text is never spliced into the script body.
- **`.github/matrices/builds.json`**
  - New `pr-sanitizers` key: the 4 standard PR platforms (`sanitizer: none`) + iOS `address` + iOS `thread`.

## Notes

- **No new permissions / no token** — labels arrive in the event payload; default `contents: read` is enough.
- **Access gating is inherent** — only users with write/triage access can add labels to a PR, so this can't be triggered by outside contributors.
- **iOS-only is intentional** — the shared core is compiled identically across platforms and the sanitizers catch logic-level races/UAF, so iOS covers ~99%; other targets are mostly simulated clones or feature-stripped (watchOS).
- **Concurrency**: labeling mid-run cancels and restarts with the larger matrix (existing `cancel-in-progress` behavior) — expected.

## Test plan

- [ ] Open/label a throwaway PR with `ci:sanitizers` and confirm the iOS `address` + `thread` jobs appear.
- [ ] Confirm an unlabeled PR still runs only the standard 4-platform matrix.