### PR TITLE
Guard ProfilingEngine test-only extension behind #if !os(watchOS)

### DIFF
--- a/Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift
+++ b/Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift
@@ -3,23 +3,20 @@
 //
 
 #if !os(watchOS)
+
     @testable import EmbraceProfiling
     import EmbraceProfilingSampler
     import EmbraceProfilingTestSupport
-#endif
 
-extension ProfilingEngine {
+    extension ProfilingEngine {
 
-    /// TEST-ONLY: Allocate the ring buffer without starting the sampler.
-    /// Allows writing synthetic data via ``writeSampleForTesting(timestamp:frames:)``
-    /// then reading via ``retrieveSamples(from:through:)``.
-    /// Acquires the gate. Returns false on allocation failure, invalid config, or gate contention.
-    func allocateBufferForTesting(
-        configuration: ProfilingConfiguration = ProfilingConfiguration()
-    ) -> Bool {
-        #if os(watchOS)
-            return false
-        #else
+        /// TEST-ONLY: Allocate the ring buffer without starting the sampler.
+        /// Allows writing synthetic data via ``writeSampleForTesting(timestamp:frames:)``
+        /// then reading via ``retrieveSamples(from:through:)``.
+        /// Acquires the gate. Returns false on allocation failure, invalid config, or gate contention.
+        func allocateBufferForTesting(
+            configuration: ProfilingConfiguration = ProfilingConfiguration()
+        ) -> Bool {
             guard configuration.isValid else { return false }
             guard acquireGate() else { return false }
             defer { releaseGate() }
@@ -59,16 +56,12 @@ extension ProfilingEngine {
 
             activeConfiguration = configuration
             return true
-        #endif
-    }
+        }
 
-    /// TEST-ONLY: Write a synthetic sample directly to the ring buffer.
-    /// Buffer must have been allocated (via ``allocateBufferForTesting(configuration:)`` or ``start(configuration:)``).
-    /// Does NOT acquire the gate. Caller must ensure no concurrent access.
-    func writeSampleForTesting(timestamp: UInt64, frames: [UInt]) -> Bool {
-        #if os(watchOS)
-            return false
-        #else
+        /// TEST-ONLY: Write a synthetic sample directly to the ring buffer.
+        /// Buffer must have been allocated (via ``allocateBufferForTesting(configuration:)`` or ``start(configuration:)``).
+        /// Does NOT acquire the gate. Caller must ensure no concurrent access.
+        func writeSampleForTesting(timestamp: UInt64, frames: [UInt]) -> Bool {
             guard let ringBuffer else { return false }
 
             return frames.withUnsafeBufferPointer { buf in
@@ -77,15 +70,13 @@ extension ProfilingEngine {
                     emb_ring_buffer_write(ringBuffer, timestamp, ptr, frames.count) == EMB_RING_WRITE_OK
                 }
             }
-        #endif
-    }
+        }
 
-    /// TEST-ONLY: Reset the engine to a clean initial state.
-    /// Stops sampler if active (with polling wait), destroys ring buffer,
-    /// deallocates read buffer, resets C sampler state.
-    /// Acquires the gate.
-    func resetForTesting() {
-        #if !os(watchOS)
+        /// TEST-ONLY: Reset the engine to a clean initial state.
+        /// Stops sampler if active (with polling wait), destroys ring buffer,
+        /// deallocates read buffer, resets C sampler state.
+        /// Acquires the gate.
+        func resetForTesting() {
             emb_sampler_stop()
 
             let deadline = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) + 5_000_000_000
@@ -118,6 +109,7 @@ extension ProfilingEngine {
             if gateAcquired {
                 releaseGate()
             }
-        #endif
+        }
     }
-}
+
+#endif


### PR DESCRIPTION
## What

`Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift` guarded its imports (`EmbraceProfiling`, `EmbraceProfilingSampler`, `EmbraceProfilingTestSupport`) behind `#if !os(watchOS)`, but left `extension ProfilingEngine { … }` outside the guard. On watchOS the module isn't imported, so the type is out of scope and `EmbraceProfilingTests` failed to compile:

```
Tests/EmbraceProfilingTests/ProfilingEngine+Testing.swift:11:11: error: cannot find type 'ProfilingEngine' in scope
```

This turned the **watchOS test** job red (e.g. PR #652's CI, which is stacked on this branch).

## Fix

Wrap the whole file — imports **and** the extension — in a single `#if !os(watchOS)`, matching every sibling test file in the target (`ProfilingEngineTests.swift`, `ProfilingEnginePauseTests.swift`, `FallbackBenchmarks.swift`). The per-method `#if os(watchOS) return false` stubs became dead once the extension can't exist on watchOS, so they're removed.

## Verification

`xcodebuild build-for-testing -scheme EmbraceIO-Package -only-testing:EmbraceProfilingTests` against a watchOS Simulator → **TEST BUILD SUCCEEDED**. Non-watchOS behavior is unchanged (the extension body is identical to before).