### PR TITLE
Drop EmbraceProfiling subspecs from CocoaPods podspec

### DIFF
--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -130,16 +130,10 @@ Pod::Spec.new do |spec|
     subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
   end
 
-  spec.subspec 'EmbraceProfilingSampler' do |subs|
-    subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
-    subs.public_header_files = "Sources/#{subs.module_name}/include/**/*.h"
-  end
-
-  spec.subspec 'EmbraceProfiling' do |subs|
-    subs.source_files = "Sources/#{subs.module_name}/**/*.{h,m,mm,c,cpp,swift}"
-    subs.dependency "EmbraceIO/EmbraceProfilingSampler"
-    subs.dependency "EmbraceIO/EmbraceAtomicsShim"
-  end
+  # Note: EmbraceProfiling / EmbraceProfilingSampler are intentionally omitted from CocoaPods.
+  # Profiling is a Swift Package Manager–only feature. `pod lib lint` builds every subspec into a
+  # single merged `EmbraceIO` module, where the sibling C modules can't be imported as their own
+  # modules. Since CocoaPods is frozen for new features, profiling ships via SPM only.
 
   # External
   spec.subspec 'EmbraceKSCrash' do |subs|


### PR DESCRIPTION
## What

Removes the `EmbraceProfilingSampler` and `EmbraceProfiling` subspecs from `EmbraceIO.podspec`, making profiling a Swift Package Manager–only feature.

## Why

`pod lib lint` builds every subspec into a single merged `EmbraceIO` module. In that build, EmbraceProfiling's sibling C modules (`EmbraceProfilingSampler`, `EmbraceAtomicsShim`) can't be imported as their own modules, producing:

```
Sources/EmbraceProfiling/ProfilingEngine.swift:7:12: error: Unable to resolve module dependency: 'EmbraceAtomicsShim'
Sources/EmbraceProfiling/ProfilingEngine.swift:8:12: error: Unable to resolve module dependency: 'EmbraceProfilingSampler'
[!] EmbraceIO did not pass validation, due to 5 errors.
```

Rather than wire profiling into CocoaPods, we make it SPM-only: CocoaPods is being deprecated and we're winding down releases there, so new features like profiling won't be added to it.

Profiling has no consumers in the shipped pod today, so this is a clean removal. SPM targets are unchanged.

## Notes

- Base is `karl/profiling-engine-api` (stack root, where the subspecs were introduced) so the fix propagates to the branches stacked on it.