### PR TITLE
[EMBR-13038] Fix: Make hang FrameRateMonitor injectable to fix span over-count test flake

### DIFF
--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -24,11 +24,22 @@ import OpenTelemetryApi
     @objc(EMBHangCaptureService)
     public final class HangCaptureService: CaptureService {
 
-        public init(
+        public convenience init(
             limits: HangLimits = HangLimits()
+        ) {
+            self.init(limits: limits, makeMonitor: { FrameRateMonitor(threshold: $0) })
+        }
+
+        /// Designated initializer. `makeMonitor` builds the frame-rate monitor for a
+        /// threshold and is substitutable, so tests can pass a factory that returns
+        /// `nil` to run without a live `CADisplayLink`.
+        init(
+            limits: HangLimits,
+            makeMonitor: @escaping (_ threshold: TimeInterval) -> FrameRateMonitor?
         ) {
             dispatchPrecondition(condition: .onQueue(.main))
             self.mainThread = pthread_self()
+            self.makeMonitor = makeMonitor
             self.limitData = EmbraceMutex(MutableLimitData(limits: limits))
             super.init()
         }
@@ -48,7 +59,7 @@ import OpenTelemetryApi
             let currentLimits = limits
             let monitor: FrameRateMonitor? =
                 currentLimits.hangPerSession > 0
-                ? FrameRateMonitor(threshold: currentLimits.hangThreshold)
+                ? makeMonitor(currentLimits.hangThreshold)
                 : nil
             monitor?.hangObserver = self
             monitor?.logger = logger
@@ -76,7 +87,7 @@ import OpenTelemetryApi
             if monitorNeedsUpdate {
                 let monitor: FrameRateMonitor? =
                     newLimits.hangPerSession > 0
-                    ? FrameRateMonitor(threshold: newLimits.hangThreshold)
+                    ? makeMonitor(newLimits.hangThreshold)
                     : nil
                 monitor?.hangObserver = self
                 monitor?.logger = logger
@@ -85,6 +96,9 @@ import OpenTelemetryApi
         }
 
         private var mainThread: pthread_t
+
+        /// Builds the frame-rate monitor; substitutable so tests can avoid a live `CADisplayLink`.
+        private let makeMonitor: (TimeInterval) -> FrameRateMonitor?
 
         struct MutableLimitData {
             var limits: HangLimits = HangLimits()

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -31,8 +31,16 @@
             super.tearDown()
         }
 
+        /// Builds a service whose monitor factory returns `nil`, so no live
+        /// `CADisplayLink` runs and only explicitly-driven hangs reach the span logic —
+        /// keeping span-count assertions deterministic. Detection is covered by
+        /// `FrameRateMonitorTests`.
+        private func makeService(limits: HangLimits = HangLimits()) -> HangCaptureService {
+            HangCaptureService(limits: limits, makeMonitor: { _ in nil })
+        }
+
         private func makeInstalledService(limits: HangLimits = HangLimits()) -> HangCaptureService {
-            let service = HangCaptureService(limits: limits)
+            let service = makeService(limits: limits)
             service.install(otel: otel)
             service.start()
             return service
@@ -41,13 +49,56 @@
         // MARK: - Config
 
         func test_onConfigUpdated_updatesHangThreshold() {
-            let service = HangCaptureService(limits: HangLimits(hangThreshold: 0.249))
+            let service = makeService(limits: HangLimits(hangThreshold: 0.249))
 
             let newLimits = HangLimits(hangThreshold: 0.5)
             let mockConfig = MockEmbraceConfigurable(hangLimits: newLimits)
             service.onConfigUpdated(mockConfig)
 
             XCTAssertEqual(service.limits.hangThreshold, 0.5)
+        }
+
+        // MARK: - Monitor wiring
+
+        func test_onInstall_wiresMonitorAsObserver_whenHangsEnabled() {
+            // The debugger-attached guard in `onInstall` would otherwise skip
+            // monitor creation when running under Xcode's debugger; this env var is
+            // the SDK's own escape hatch and makes the wiring deterministic.
+            setenv("EMBAllowWatchdogInDebugger", "1", 1)
+            defer { unsetenv("EMBAllowWatchdogInDebugger") }
+
+            var capturedThreshold: TimeInterval?
+            weak var capturedMonitor: FrameRateMonitor?
+            let service = HangCaptureService(limits: HangLimits(hangThreshold: 0.3)) { threshold in
+                capturedThreshold = threshold
+                let monitor = FrameRateMonitor(threshold: threshold)
+                capturedMonitor = monitor
+                return monitor
+            }
+
+            service.install(otel: otel)
+
+            // onInstall built a monitor with the configured threshold and wired
+            // the service as its observer.
+            XCTAssertEqual(capturedThreshold, 0.3)
+            XCTAssertNotNil(capturedMonitor)
+            XCTAssertTrue(capturedMonitor?.hangObserver === service)
+        }
+
+        func test_onInstall_skipsMonitor_whenHangsDisabled() {
+            setenv("EMBAllowWatchdogInDebugger", "1", 1)
+            defer { unsetenv("EMBAllowWatchdogInDebugger") }
+
+            var factoryCalled = false
+            let service = HangCaptureService(limits: HangLimits(hangPerSession: 0)) { threshold in
+                factoryCalled = true
+                return FrameRateMonitor(threshold: threshold)
+            }
+
+            service.install(otel: otel)
+
+            // hangPerSession == 0 gates the monitor off — the factory is never invoked.
+            XCTAssertFalse(factoryCalled)
         }
 
         // MARK: - Span lifecycle
@@ -91,7 +142,7 @@
 
         func test_hangStarted_withoutOTel_doesNotCrash() {
             // Service never installed — buildSpan returns nil, should not crash
-            let service = HangCaptureService()
+            let service = makeService()
             service.hangStarted(at: Date(), duration: 0.5)
             wait(delay: 0.2)
         }


### PR DESCRIPTION
## Problem

`HangCaptureServiceTests/test_hangStarted_createsSpan` intermittently fails in CI with `XCTAssertEqual ("2") != ("1")` (`sanitizer none`). Sightings: 2026-06-29 (run 28396508980), and 2026-07-17 on PR #652 (run 29574697849).

## Root cause

`makeInstalledService()` → `install` → `onInstall` builds a real, **live** `FrameRateMonitor` — a `CADisplayLink` on the main runloop. CI has no debugger, so the `isDebuggerAttached()` early-return in `onInstall` never fires, which is why it only reproduces in CI and never locally under Xcode.

The test drives `hangStarted` once, then `wait(...)` spins the runloop. On a loaded runner the main thread genuinely stalls >249 ms, the display link ticks and calls `hangStarted` again → a real **second** `emb-thread-blockage` span (default `hangPerSession` is 20, so it's allowed). A true over-count from a live detector, not a poll-predicate race.

## Fix

Make the monitor injectable via a new designated `init(limits:makeMonitor:)`. Production keeps the real `FrameRateMonitor` (behavior unchanged); span-lifecycle tests inject a no-op factory so no live `CADisplayLink` runs. The detection path stays covered by `FrameRateMonitorTests`.

Also adds two deterministic wiring tests:
- `test_onInstall_wiresMonitorAsObserver_whenHangsEnabled` — monitor built with the configured threshold and the service wired as its observer.
- `test_onInstall_skipsMonitor_whenHangsDisabled` — factory never invoked when `hangPerSession == 0`.

## Testing

All 16 `HangCaptureServiceTests` + `FrameRateMonitorTests` pass on iPhone 17 Pro / Xcode 26.5.