### PR TITLE
[EMBR-13022] Feature: New Stacktrace Sampler for Hang Capture Service

### DIFF
--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -41,6 +41,7 @@ Pod::Spec.new do |spec|
     subs.dependency "EmbraceIO/EmbraceStorageInternal"
     subs.dependency "EmbraceIO/EmbraceUploadInternal"
     subs.dependency "EmbraceIO/EmbraceObjCUtilsInternal"
+    subs.dependency "EmbraceIO/EmbraceKSCrashBacktraceSupport"
     subs.dependency "EmbraceIO/EmbraceSemantics"
     subs.dependency "EmbraceIO/EmbraceConfiguration"
   end

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,8 @@ let package = Package(
             dependencies: [
                 "EmbraceIO",
                 "EmbraceCore",
-                "TestSupport"
+                "TestSupport",
+                "TestSupportObjc"
             ]
         ),
 

--- a/Package.swift
+++ b/Package.swift
@@ -92,6 +92,7 @@ let package = Package(
                 "EmbraceStorageInternal",
                 "EmbraceUploadInternal",
                 "EmbraceObjCUtilsInternal",
+                "EmbraceKSCrashBacktraceSupport",
                 "EmbraceSemantics"
             ],
             resources: [

--- a/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
+++ b/Sources/EmbraceCommonInternal/CrashReporter/CrashReporter.swift
@@ -115,6 +115,29 @@ public typealias FrameAddress = UInt
     ///   Implementations commonly transform the raw PC to a canonical call instruction (e.g., `returnAddress - 1` on ARM).
     ///   See `SymbolicatedFrame.callInstruction`.
     @objc func backtrace(of thread: pthread_t) -> [FrameAddress]
+
+    /// Fills `buffer` (which has room for `capacity` addresses) with the frame addresses of `thread`,
+    /// returning the number of addresses written. Ordered from the top frame to the bottom.
+    ///
+    /// Unlike ``backtrace(of:)``, this returns nothing heap-allocated: the caller owns `buffer`. It
+    /// exists so the walk can run while `thread` is **suspended** without the walker touching the
+    /// heap — a `malloc` here can deadlock the whole process if the suspended thread holds the
+    /// allocator lock.
+    ///
+    /// - Important: The implementation MUST be allocation-free and async-signal-safe: no `malloc`,
+    ///   no Obj-C/Swift runtime work, no lock acquisition. It is called between `thread_suspend` and
+    ///   `thread_resume` of a thread that is not the caller.
+    /// - Parameters:
+    ///   - thread: The target `pthread_t`. Must not be the calling thread (it is expected to be
+    ///     suspended by the caller for the duration of the call).
+    ///   - buffer: Caller-owned storage for at least `capacity` `FrameAddress` values.
+    ///   - capacity: The capacity of `buffer`, in elements.
+    /// - Returns: The number of frame addresses written to `buffer` (`0...capacity`).
+    @objc func backtrace(
+        of thread: pthread_t,
+        into buffer: UnsafeMutablePointer<FrameAddress>,
+        capacity: Int
+    ) -> Int
 }
 
 // MARK: - Symbolication

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -98,7 +98,9 @@ extension RemoteConfig: EmbraceConfigurable {
         HangLimits(
             hangThreshold: payload.hangLimitsHangThreshold,
             hangPerSession: payload.hangLimitsHangPerSession,
-            reportsWatchdogEvents: payload.hangLimitsReportsWatchdogEvents
+            reportsWatchdogEvents: payload.hangLimitsReportsWatchdogEvents,
+            sampleTriggerThreshold: payload.hangLimitsSampleTriggerThreshold,
+            samplePollInterval: payload.hangLimitsSamplePollInterval
         )
     }
 

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -70,9 +70,9 @@ public class RemoteConfig {
 
         do {
             let data = try Data(contentsOf: url)
-            try _payload.withLock {
-                $0 = try JSONDecoder().decode(RemoteConfigPayload.self, from: data)
-            }
+            let decoded = try JSONDecoder().decode(RemoteConfigPayload.self, from: data)
+            _payload.withLock { $0 = decoded }
+            logHangLimitCorrections(for: decoded)
         } catch {
             logger.error("Error loading cached remote config!")
         }
@@ -187,6 +187,9 @@ extension RemoteConfig: EmbraceConfigurable {
                 $0 = newPayload
                 return changed
             }
+            if didUpdate {
+                strongSelf.logHangLimitCorrections(for: newPayload)
+            }
             strongSelf.saveToCache(data)
 
             completion(didUpdate, nil)
@@ -195,6 +198,48 @@ extension RemoteConfig: EmbraceConfigurable {
 }
 
 extension RemoteConfig {
+
+    /// Descriptions of any hang-limit payload values that `HangLimits` had to correct — an
+    /// out-of-range clamp, a non-finite/non-positive fallback, or the
+    /// `sampleTriggerThreshold >= hangThreshold` re-derivation. Empty when the payload is already
+    /// valid. `HangLimits` corrects these silently (by design — it can't reach a logger and must not
+    /// trap), so this surfaces them one layer up where a bad remote-config push can be diagnosed.
+    /// Pure, so it can be unit-tested without the fetch/logging plumbing.
+    static func hangLimitCorrections(for payload: RemoteConfigPayload) -> [String] {
+        let limits = HangLimits(
+            hangThreshold: payload.hangLimitsHangThreshold,
+            hangPerSession: payload.hangLimitsHangPerSession,
+            reportsWatchdogEvents: payload.hangLimitsReportsWatchdogEvents,
+            sampleTriggerThreshold: payload.hangLimitsSampleTriggerThreshold,
+            samplePollInterval: payload.hangLimitsSamplePollInterval
+        )
+
+        var corrections: [String] = []
+        if limits.hangThreshold != payload.hangLimitsHangThreshold {
+            corrections.append(
+                "hang_threshold \(payload.hangLimitsHangThreshold) → \(limits.hangThreshold) (must be finite and > 0)")
+        }
+        if limits.sampleTriggerThreshold != payload.hangLimitsSampleTriggerThreshold {
+            corrections.append(
+                "sample_trigger_threshold \(payload.hangLimitsSampleTriggerThreshold) → \(limits.sampleTriggerThreshold) "
+                    + "(clamped into [\(HangLimits.minSampleTriggerThreshold), \(HangLimits.maxSampleTriggerThreshold)] "
+                    + "and kept below hang_threshold)")
+        }
+        if limits.samplePollInterval != payload.hangLimitsSamplePollInterval {
+            corrections.append(
+                "sample_poll_interval \(payload.hangLimitsSamplePollInterval) → \(limits.samplePollInterval) "
+                    + "(clamped into [\(HangLimits.minSamplePollInterval), \(HangLimits.maxSamplePollInterval)])")
+        }
+        return corrections
+    }
+
+    /// Logs a warning for each hang-limit value the incoming payload had to have corrected.
+    func logHangLimitCorrections(for payload: RemoteConfigPayload) {
+        for correction in Self.hangLimitCorrections(for: payload) {
+            logger.warning("[Hang] remote config value out of range, corrected: \(correction)")
+        }
+    }
+
     func isEnabled(threshold: Float) -> Bool {
         return Self.isEnabled(hexValue: deviceIdHexValue, digits: Self.deviceIdUsedDigits, threshold: threshold)
     }

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -199,12 +199,14 @@ extension RemoteConfig: EmbraceConfigurable {
 
 extension RemoteConfig {
 
-    /// Descriptions of any hang-limit payload values that `HangLimits` had to correct — an
-    /// out-of-range clamp, a non-finite/non-positive fallback, or the
-    /// `sampleTriggerThreshold >= hangThreshold` re-derivation. Empty when the payload is already
-    /// valid. `HangLimits` corrects these silently (by design — it can't reach a logger and must not
-    /// trap), so this surfaces them one layer up where a bad remote-config push can be diagnosed.
-    /// Pure, so it can be unit-tested without the fetch/logging plumbing.
+    /// Descriptions of any hang-limit payload values that were *invalid* and had to be corrected — a
+    /// non-finite/non-positive fallback, an out-of-range clamp, or a `sampleTriggerThreshold` at or
+    /// above `hangThreshold`. Empty when the payload is valid. The routine cap that keeps the trigger
+    /// a margin below `hangThreshold` is expected policy, not a misconfiguration, so a valid in-range
+    /// request the cap merely trims is deliberately *not* reported. `HangLimits` applies all of this
+    /// silently (by design — it can't reach a logger and must not trap), so this surfaces the genuine
+    /// misconfigurations one layer up where a bad remote-config push can be diagnosed. Pure, so it can
+    /// be unit-tested without the fetch/logging plumbing.
     static func hangLimitCorrections(for payload: RemoteConfigPayload) -> [String] {
         let limits = HangLimits(
             hangThreshold: payload.hangLimitsHangThreshold,
@@ -232,7 +234,7 @@ extension RemoteConfig {
         } else if rawTrigger < HangLimits.minSampleTriggerThreshold {
             triggerReason = "below the floor of \(HangLimits.minSampleTriggerThreshold); clamped up"
         } else if rawTrigger > HangLimits.maxSampleTriggerThreshold {
-            triggerReason = "above the max of \(HangLimits.maxSampleTriggerThreshold); clamped down"
+            triggerReason = "above the max of \(HangLimits.maxSampleTriggerThreshold) (a seconds/ms mixup?); capped"
         } else if rawTrigger >= limits.hangThreshold {
             triggerReason = "at or above hang_threshold (\(limits.hangThreshold)); capped"
         } else {

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -215,21 +215,39 @@ extension RemoteConfig {
         )
 
         var corrections: [String] = []
+
         if limits.hangThreshold != payload.hangLimitsHangThreshold {
             corrections.append(
-                "hang_threshold \(payload.hangLimitsHangThreshold) → \(limits.hangThreshold) (must be finite and > 0)")
+                "hang_threshold \(payload.hangLimitsHangThreshold) → \(limits.hangThreshold) "
+                    + "(not finite or <= 0; reset to default)")
         }
+
         if limits.sampleTriggerThreshold != payload.hangLimitsSampleTriggerThreshold {
-            corrections.append(
-                "sample_trigger_threshold \(payload.hangLimitsSampleTriggerThreshold) → \(limits.sampleTriggerThreshold) "
-                    + "(clamped into [\(HangLimits.minSampleTriggerThreshold), \(HangLimits.maxSampleTriggerThreshold)] "
-                    + "and kept below hang_threshold)")
+            let raw = payload.hangLimitsSampleTriggerThreshold
+            let reason: String
+            if !raw.isFinite {
+                reason = "not finite; reset to default"
+            } else {
+                // Mirror HangLimits.init: clamp first, then re-derive if still >= hang_threshold.
+                let clamped = Swift.min(
+                    Swift.max(raw, HangLimits.minSampleTriggerThreshold), HangLimits.maxSampleTriggerThreshold)
+                reason =
+                    clamped >= limits.hangThreshold
+                    ? "must stay below hang_threshold (\(limits.hangThreshold)); re-derived"
+                    : "out of [\(HangLimits.minSampleTriggerThreshold), \(HangLimits.maxSampleTriggerThreshold)]; clamped"
+            }
+            corrections.append("sample_trigger_threshold \(raw) → \(limits.sampleTriggerThreshold) (\(reason))")
         }
+
         if limits.samplePollInterval != payload.hangLimitsSamplePollInterval {
-            corrections.append(
-                "sample_poll_interval \(payload.hangLimitsSamplePollInterval) → \(limits.samplePollInterval) "
-                    + "(clamped into [\(HangLimits.minSamplePollInterval), \(HangLimits.maxSamplePollInterval)])")
+            let raw = payload.hangLimitsSamplePollInterval
+            let reason =
+                raw.isFinite
+                ? "out of [\(HangLimits.minSamplePollInterval), \(HangLimits.maxSamplePollInterval)]; clamped"
+                : "not finite; reset to default"
+            corrections.append("sample_poll_interval \(raw) → \(limits.samplePollInterval) (\(reason))")
         }
+
         return corrections
     }
 

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig.swift
@@ -222,21 +222,24 @@ extension RemoteConfig {
                     + "(not finite or <= 0; reset to default)")
         }
 
-        if limits.sampleTriggerThreshold != payload.hangLimitsSampleTriggerThreshold {
-            let raw = payload.hangLimitsSampleTriggerThreshold
-            let reason: String
-            if !raw.isFinite {
-                reason = "not finite; reset to default"
-            } else {
-                // Mirror HangLimits.init: clamp first, then re-derive if still >= hang_threshold.
-                let clamped = Swift.min(
-                    Swift.max(raw, HangLimits.minSampleTriggerThreshold), HangLimits.maxSampleTriggerThreshold)
-                reason =
-                    clamped >= limits.hangThreshold
-                    ? "must stay below hang_threshold (\(limits.hangThreshold)); re-derived"
-                    : "out of [\(HangLimits.minSampleTriggerThreshold), \(HangLimits.maxSampleTriggerThreshold)]; clamped"
-            }
-            corrections.append("sample_trigger_threshold \(raw) → \(limits.sampleTriggerThreshold) (\(reason))")
+        // The trigger is routinely capped at a fraction of hang_threshold; that's expected policy, not
+        // a misconfiguration — so a valid request (`[floor, hang_threshold)`) is never reported even
+        // when the cap trims it. Only genuinely invalid values warn.
+        let rawTrigger = payload.hangLimitsSampleTriggerThreshold
+        let triggerReason: String?
+        if !rawTrigger.isFinite {
+            triggerReason = "not finite; reset to default"
+        } else if rawTrigger < HangLimits.minSampleTriggerThreshold {
+            triggerReason = "below the floor of \(HangLimits.minSampleTriggerThreshold); clamped up"
+        } else if rawTrigger > HangLimits.maxSampleTriggerThreshold {
+            triggerReason = "above the max of \(HangLimits.maxSampleTriggerThreshold); clamped down"
+        } else if rawTrigger >= limits.hangThreshold {
+            triggerReason = "at or above hang_threshold (\(limits.hangThreshold)); capped"
+        } else {
+            triggerReason = nil
+        }
+        if let triggerReason {
+            corrections.append("sample_trigger_threshold \(rawTrigger) → \(limits.sampleTriggerThreshold) (\(triggerReason))")
         }
 
         if limits.samplePollInterval != payload.hangLimitsSamplePollInterval {

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -45,6 +45,8 @@ public struct RemoteConfigPayload: Decodable, Equatable {
     var hangLimitsHangThreshold: TimeInterval
     var hangLimitsHangPerSession: UInt
     var hangLimitsReportsWatchdogEvents: Bool
+    var hangLimitsSampleTriggerThreshold: TimeInterval
+    var hangLimitsSamplePollInterval: TimeInterval
 
     var networkPayloadCaptureRules: [NetworkPayloadCaptureRule]
 
@@ -101,6 +103,8 @@ public struct RemoteConfigPayload: Decodable, Equatable {
             case hangThreshold = "hang_threshold"
             case hangPerSession = "hang_per_session"
             case reportsWatchdogEvents = "reports_watchdog_events"
+            case sampleTriggerThreshold = "sample_trigger_threshold"
+            case samplePollInterval = "sample_poll_interval"
         }
 
         case networkPayLoadCapture = "network_capture"
@@ -254,10 +258,24 @@ public struct RemoteConfigPayload: Decodable, Equatable {
                     Bool.self,
                     forKey: CodingKeys.HangLimitsCodingKeys.reportsWatchdogEvents
                 ) ?? defaultPayload.hangLimitsReportsWatchdogEvents
+
+            hangLimitsSampleTriggerThreshold =
+                try hangLimitsContainer.decodeIfPresent(
+                    TimeInterval.self,
+                    forKey: CodingKeys.HangLimitsCodingKeys.sampleTriggerThreshold
+                ) ?? defaultPayload.hangLimitsSampleTriggerThreshold
+
+            hangLimitsSamplePollInterval =
+                try hangLimitsContainer.decodeIfPresent(
+                    TimeInterval.self,
+                    forKey: CodingKeys.HangLimitsCodingKeys.samplePollInterval
+                ) ?? defaultPayload.hangLimitsSamplePollInterval
         } else {
             hangLimitsHangThreshold = defaultPayload.hangLimitsHangThreshold
             hangLimitsHangPerSession = defaultPayload.hangLimitsHangPerSession
             hangLimitsReportsWatchdogEvents = defaultPayload.hangLimitsReportsWatchdogEvents
+            hangLimitsSampleTriggerThreshold = defaultPayload.hangLimitsSampleTriggerThreshold
+            hangLimitsSamplePollInterval = defaultPayload.hangLimitsSamplePollInterval
         }
 
         // internal logs limit
@@ -395,6 +413,8 @@ public struct RemoteConfigPayload: Decodable, Equatable {
         hangLimitsHangThreshold = 0.249
         hangLimitsHangPerSession = 20
         hangLimitsReportsWatchdogEvents = false
+        hangLimitsSampleTriggerThreshold = 0.15
+        hangLimitsSamplePollInterval = 0.05
 
         networkPayloadCaptureRules = []
         useLegacyUrlSessionProxy = false

--- a/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
+++ b/Sources/EmbraceConfigInternal/EmbraceConfigurable/RemoteConfig/RemoteConfigPayload.swift
@@ -410,11 +410,11 @@ public struct RemoteConfigPayload: Decodable, Equatable {
         internalLogsWarningLimit = 0
         internalLogsErrorLimit = 3
 
-        hangLimitsHangThreshold = 0.249
-        hangLimitsHangPerSession = 20
-        hangLimitsReportsWatchdogEvents = false
-        hangLimitsSampleTriggerThreshold = 0.15
-        hangLimitsSamplePollInterval = 0.05
+        hangLimitsHangThreshold = HangLimits.defaultHangThreshold
+        hangLimitsHangPerSession = HangLimits.defaultHangPerSession
+        hangLimitsReportsWatchdogEvents = HangLimits.defaultReportsWatchdogEvents
+        hangLimitsSampleTriggerThreshold = HangLimits.defaultSampleTriggerThreshold
+        hangLimitsSamplePollInterval = HangLimits.defaultSamplePollInterval
 
         networkPayloadCaptureRules = []
         useLegacyUrlSessionProxy = false

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -16,14 +16,27 @@ import Foundation
     /// Collects crash reports for Hangs that do not recover.
     public let reportsWatchdogEvents: Bool
 
+    /// How long (in seconds) the main thread must be continuously busy before the during-block
+    /// sampler snapshots it. Sits below `hangThreshold` so the snapshot lands inside the hang the
+    /// detector later confirms. The SDK clamps this up to a compiled-in minimum before use.
+    public let sampleTriggerThreshold: TimeInterval
+
+    /// How often (in seconds) the background sampler checks main-thread liveness. The SDK clamps
+    /// this up to a compiled-in minimum before use.
+    public let samplePollInterval: TimeInterval
+
     public init(
         hangThreshold: TimeInterval = 0.249,
         hangPerSession: UInt = 20,
-        reportsWatchdogEvents: Bool = false
+        reportsWatchdogEvents: Bool = false,
+        sampleTriggerThreshold: TimeInterval = 0.15,
+        samplePollInterval: TimeInterval = 0.05
     ) {
         self.hangThreshold = hangThreshold
         self.hangPerSession = hangPerSession
         self.reportsWatchdogEvents = reportsWatchdogEvents
+        self.sampleTriggerThreshold = sampleTriggerThreshold
+        self.samplePollInterval = samplePollInterval
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -33,5 +46,7 @@ import Foundation
         return hangThreshold == other.hangThreshold
             && hangPerSession == other.hangPerSession
             && reportsWatchdogEvents == other.reportsWatchdogEvents
+            && sampleTriggerThreshold == other.sampleTriggerThreshold
+            && samplePollInterval == other.samplePollInterval
     }
 }

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -93,6 +93,16 @@ import Foundation
         return Swift.min(Swift.max(value, minimum), maximum)
     }
 
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(hangThreshold)
+        hasher.combine(hangPerSession)
+        hasher.combine(reportsWatchdogEvents)
+        hasher.combine(sampleTriggerThreshold)
+        hasher.combine(samplePollInterval)
+        return hasher.finalize()
+    }
+
     public override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? Self else {
             return false

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -7,6 +7,34 @@ import Foundation
 /// HangLimits manages limits for the app hangs generated through the SDK
 @objc public class HangLimits: NSObject {
 
+    // MARK: - Defaults
+
+    /// Default minimum frame delay reported as a hang (≈ Apple's own definition of a hang).
+    public static let defaultHangThreshold: TimeInterval = 0.249
+    /// Default maximum number of captured hangs per session.
+    public static let defaultHangPerSession: UInt = 20
+    /// Default for collecting watchdog reports for hangs that do not recover.
+    public static let defaultReportsWatchdogEvents = false
+    /// Default trigger for the during-block sampler.
+    public static let defaultSampleTriggerThreshold: TimeInterval = 0.15
+    /// Default poll cadence for the during-block sampler.
+    public static let defaultSamplePollInterval: TimeInterval = 0.05
+
+    // MARK: - Bounds
+    //
+    // Bounds for the remote-config-driven sampler values. The low bounds keep a bad/hostile remote
+    // value from driving overly aggressive main-thread suspension. The high bounds are a safety rail
+    // against the sampler's downstream `useconds_t` (UInt32 µs) and `UInt64` (ns) conversions, which
+    // would trap on an out-of-range value. Clamping in `init` means every consumer of `HangLimits`
+    // inherits the guarantee.
+
+    public static let minSampleTriggerThreshold: TimeInterval = 0.05  // 50 ms
+    public static let maxSampleTriggerThreshold: TimeInterval = 3600  // 1 h
+    public static let minSamplePollInterval: TimeInterval = 0.01  // 10 ms
+    public static let maxSamplePollInterval: TimeInterval = 60  // 60 s
+
+    // MARK: - Values
+
     /// Minimum duration (in seconds) a frame delay must exceed to be reported as a hang.
     public let hangThreshold: TimeInterval
 
@@ -18,25 +46,51 @@ import Foundation
 
     /// How long (in seconds) the main thread must be continuously busy before the during-block
     /// sampler snapshots it. Sits below `hangThreshold` so the snapshot lands inside the hang the
-    /// detector later confirms. The SDK clamps this up to a compiled-in minimum before use.
+    /// detector later confirms. Clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`.
     public let sampleTriggerThreshold: TimeInterval
 
-    /// How often (in seconds) the background sampler checks main-thread liveness. The SDK clamps
-    /// this up to a compiled-in minimum before use.
+    /// How often (in seconds) the background sampler checks main-thread liveness. Clamped into
+    /// `[minSamplePollInterval, maxSamplePollInterval]`.
     public let samplePollInterval: TimeInterval
 
     public init(
-        hangThreshold: TimeInterval = 0.249,
-        hangPerSession: UInt = 20,
-        reportsWatchdogEvents: Bool = false,
-        sampleTriggerThreshold: TimeInterval = 0.15,
-        samplePollInterval: TimeInterval = 0.05
+        hangThreshold: TimeInterval = HangLimits.defaultHangThreshold,
+        hangPerSession: UInt = HangLimits.defaultHangPerSession,
+        reportsWatchdogEvents: Bool = HangLimits.defaultReportsWatchdogEvents,
+        sampleTriggerThreshold: TimeInterval = HangLimits.defaultSampleTriggerThreshold,
+        samplePollInterval: TimeInterval = HangLimits.defaultSamplePollInterval
     ) {
-        self.hangThreshold = hangThreshold
+        self.hangThreshold = HangLimits.sanitized(hangThreshold, fallback: HangLimits.defaultHangThreshold)
         self.hangPerSession = hangPerSession
         self.reportsWatchdogEvents = reportsWatchdogEvents
-        self.sampleTriggerThreshold = sampleTriggerThreshold
-        self.samplePollInterval = samplePollInterval
+        self.sampleTriggerThreshold = HangLimits.clamped(
+            sampleTriggerThreshold,
+            fallback: HangLimits.defaultSampleTriggerThreshold,
+            min: HangLimits.minSampleTriggerThreshold,
+            max: HangLimits.maxSampleTriggerThreshold
+        )
+        self.samplePollInterval = HangLimits.clamped(
+            samplePollInterval,
+            fallback: HangLimits.defaultSamplePollInterval,
+            min: HangLimits.minSamplePollInterval,
+            max: HangLimits.maxSamplePollInterval
+        )
+    }
+
+    /// A finite, positive value passes through unchanged; anything else falls back to `fallback`.
+    private static func sanitized(_ value: TimeInterval, fallback: TimeInterval) -> TimeInterval {
+        value.isFinite && value > 0 ? value : fallback
+    }
+
+    /// A finite value clamped into `[minimum, maximum]`; a non-finite value falls back to `fallback`.
+    private static func clamped(
+        _ value: TimeInterval,
+        fallback: TimeInterval,
+        min minimum: TimeInterval,
+        max maximum: TimeInterval
+    ) -> TimeInterval {
+        guard value.isFinite else { return fallback }
+        return Swift.min(Swift.max(value, minimum), maximum)
     }
 
     public override func isEqual(_ object: Any?) -> Bool {

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -33,6 +33,12 @@ import Foundation
     public static let minSamplePollInterval: TimeInterval = 0.01  // 10 ms
     public static let maxSamplePollInterval: TimeInterval = 60  // 60 s
 
+    /// Fraction of `hangThreshold` used to re-derive `sampleTriggerThreshold` when a remote config is
+    /// internally inconsistent (`sampleTriggerThreshold >= hangThreshold`). Matches the ratio the
+    /// SDK's own defaults use (0.15 / 0.249 ≈ 0.6), so the during-block snapshot lands well inside the
+    /// confirmed hang window.
+    public static let sampleTriggerFraction: TimeInterval = 0.6
+
     // MARK: - Values
 
     /// Minimum duration (in seconds) a frame delay must exceed to be reported as a hang.
@@ -45,8 +51,9 @@ import Foundation
     public let reportsWatchdogEvents: Bool
 
     /// How long (in seconds) the main thread must be continuously busy before the during-block
-    /// sampler snapshots it. Sits below `hangThreshold` so the snapshot lands inside the hang the
-    /// detector later confirms. Clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`.
+    /// sampler snapshots it. Clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`
+    /// and additionally kept below `hangThreshold` — re-derived via ``sampleTriggerFraction`` if an
+    /// inconsistent config sets it at/above — so the snapshot lands inside the confirmed hang window.
     public let sampleTriggerThreshold: TimeInterval
 
     /// How often (in seconds) the background sampler checks main-thread liveness. Clamped into
@@ -60,15 +67,27 @@ import Foundation
         sampleTriggerThreshold: TimeInterval = HangLimits.defaultSampleTriggerThreshold,
         samplePollInterval: TimeInterval = HangLimits.defaultSamplePollInterval
     ) {
-        self.hangThreshold = HangLimits.sanitized(hangThreshold, fallback: HangLimits.defaultHangThreshold)
-        self.hangPerSession = hangPerSession
-        self.reportsWatchdogEvents = reportsWatchdogEvents
-        self.sampleTriggerThreshold = HangLimits.clamped(
+        let resolvedHangThreshold = HangLimits.sanitized(
+            hangThreshold, fallback: HangLimits.defaultHangThreshold)
+        var resolvedSampleTrigger = HangLimits.clamped(
             sampleTriggerThreshold,
             fallback: HangLimits.defaultSampleTriggerThreshold,
             min: HangLimits.minSampleTriggerThreshold,
             max: HangLimits.maxSampleTriggerThreshold
         )
+        // Keep the trigger below the reported-hang threshold so the during-block snapshot lands inside
+        // the window the detector confirms. Only an inconsistent config (trigger >= hangThreshold) is
+        // adjusted; valid configs — including the default — pass through untouched. This branch fires
+        // only when `hangThreshold <= resolvedSampleTrigger <= maxSampleTriggerThreshold`, so the
+        // derived value stays bounded — an unbounded `hangThreshold` can't reintroduce the ns overflow.
+        if resolvedSampleTrigger >= resolvedHangThreshold {
+            resolvedSampleTrigger = resolvedHangThreshold * HangLimits.sampleTriggerFraction
+        }
+
+        self.hangThreshold = resolvedHangThreshold
+        self.hangPerSession = hangPerSession
+        self.reportsWatchdogEvents = reportsWatchdogEvents
+        self.sampleTriggerThreshold = resolvedSampleTrigger
         self.samplePollInterval = HangLimits.clamped(
             samplePollInterval,
             fallback: HangLimits.defaultSamplePollInterval,

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// HangLimits manages limits for the app hangs generated through the SDK
-@objc public class HangLimits: NSObject {
+@objc public final class HangLimits: NSObject {
 
     // MARK: - Defaults
 
@@ -37,7 +37,7 @@ import Foundation
     /// internally inconsistent (`sampleTriggerThreshold >= hangThreshold`). Matches the ratio the
     /// SDK's own defaults use (0.15 / 0.249 ≈ 0.6), so the during-block snapshot lands well inside the
     /// confirmed hang window.
-    public static let sampleTriggerFraction: TimeInterval = 0.6
+    static let sampleTriggerFraction: TimeInterval = 0.6
 
     // MARK: - Values
 

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -53,8 +53,8 @@ import Foundation
     /// How long (in seconds) the main thread must be continuously busy before the during-block
     /// sampler snapshots it. Capped at ``sampleTriggerFraction`` of `hangThreshold` — a fixed headroom
     /// below the reported-hang threshold so the snapshot lands inside the confirmed window — and
-    /// clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`. A requested value at or
-    /// below the cap is used as-is. For a degenerately small `hangThreshold` (below
+    /// clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`. A requested value in
+    /// `[minSampleTriggerThreshold, cap]` is used as-is. For a degenerately small `hangThreshold` (below
     /// `minSampleTriggerThreshold / sampleTriggerFraction`) the floor takes precedence over the cap.
     public let sampleTriggerThreshold: TimeInterval
 

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -23,10 +23,10 @@ import Foundation
     // MARK: - Bounds
     //
     // Bounds for the remote-config-driven sampler values. The low bounds keep a bad/hostile remote
-    // value from driving overly aggressive main-thread suspension. The high bounds are a safety rail
-    // against the sampler's downstream `useconds_t` (UInt32 µs) and `UInt64` (ns) conversions, which
-    // would trap on an out-of-range value. Clamping in `init` means every consumer of `HangLimits`
-    // inherits the guarantee.
+    // value from driving overly aggressive main-thread suspension. The high bounds are product
+    // ceilings that double as a safety rail: the sampler converts these to nanoseconds via
+    // `UInt64(seconds * 1_000_000_000)`, which would trap on an out-of-range value. Clamping in
+    // `init` means every consumer of `HangLimits` inherits the guarantee.
 
     public static let minSampleTriggerThreshold: TimeInterval = 0.05  // 50 ms
     public static let maxSampleTriggerThreshold: TimeInterval = 3600  // 1 h

--- a/Sources/EmbraceConfiguration/HangLimits.swift
+++ b/Sources/EmbraceConfiguration/HangLimits.swift
@@ -51,9 +51,11 @@ import Foundation
     public let reportsWatchdogEvents: Bool
 
     /// How long (in seconds) the main thread must be continuously busy before the during-block
-    /// sampler snapshots it. Clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`
-    /// and additionally kept below `hangThreshold` — re-derived via ``sampleTriggerFraction`` if an
-    /// inconsistent config sets it at/above — so the snapshot lands inside the confirmed hang window.
+    /// sampler snapshots it. Capped at ``sampleTriggerFraction`` of `hangThreshold` — a fixed headroom
+    /// below the reported-hang threshold so the snapshot lands inside the confirmed window — and
+    /// clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`. A requested value at or
+    /// below the cap is used as-is. For a degenerately small `hangThreshold` (below
+    /// `minSampleTriggerThreshold / sampleTriggerFraction`) the floor takes precedence over the cap.
     public let sampleTriggerThreshold: TimeInterval
 
     /// How often (in seconds) the background sampler checks main-thread liveness. Clamped into
@@ -69,31 +71,35 @@ import Foundation
     ) {
         let resolvedHangThreshold = HangLimits.sanitized(
             hangThreshold, fallback: HangLimits.defaultHangThreshold)
-        var resolvedSampleTrigger = HangLimits.clamped(
-            sampleTriggerThreshold,
-            fallback: HangLimits.defaultSampleTriggerThreshold,
-            min: HangLimits.minSampleTriggerThreshold,
-            max: HangLimits.maxSampleTriggerThreshold
-        )
-        // Keep the trigger below the reported-hang threshold so the during-block snapshot lands inside
-        // the window the detector confirms. Only an inconsistent config (trigger >= hangThreshold) is
-        // adjusted; valid configs — including the default — pass through untouched. This branch fires
-        // only when `hangThreshold <= resolvedSampleTrigger <= maxSampleTriggerThreshold`, so the
-        // derived value stays bounded — an unbounded `hangThreshold` can't reintroduce the ns overflow.
-        if resolvedSampleTrigger >= resolvedHangThreshold {
-            resolvedSampleTrigger = resolvedHangThreshold * HangLimits.sampleTriggerFraction
-        }
 
         self.hangThreshold = resolvedHangThreshold
         self.hangPerSession = hangPerSession
         self.reportsWatchdogEvents = reportsWatchdogEvents
-        self.sampleTriggerThreshold = resolvedSampleTrigger
+        self.sampleTriggerThreshold = HangLimits.resolvedSampleTrigger(
+            sampleTriggerThreshold, hangThreshold: resolvedHangThreshold)
         self.samplePollInterval = HangLimits.clamped(
             samplePollInterval,
             fallback: HangLimits.defaultSamplePollInterval,
             min: HangLimits.minSamplePollInterval,
             max: HangLimits.maxSamplePollInterval
         )
+    }
+
+    /// Effective during-block trigger for a `requested` value and an already-sanitized `hangThreshold`.
+    /// Always capped at ``sampleTriggerFraction`` of `hangThreshold` (a fixed headroom below the
+    /// reported-hang threshold), then clamped into `[minSampleTriggerThreshold, maxSampleTriggerThreshold]`.
+    /// A non-finite request falls back to the default (itself subject to the cap). `max(…, min…)` on
+    /// the ceiling keeps it from dropping below the floor for a degenerately small `hangThreshold`, so
+    /// the floor wins there; it also keeps the value bounded, so an unbounded `hangThreshold` can't
+    /// reintroduce the ns-conversion overflow downstream.
+    private static func resolvedSampleTrigger(
+        _ requested: TimeInterval, hangThreshold: TimeInterval
+    ) -> TimeInterval {
+        let base = requested.isFinite ? requested : defaultSampleTriggerThreshold
+        let ceiling = Swift.max(
+            Swift.min(hangThreshold * sampleTriggerFraction, maxSampleTriggerThreshold),
+            minSampleTriggerThreshold)
+        return Swift.min(Swift.max(base, minSampleTriggerThreshold), ceiling)
     }
 
     /// A finite, positive value passes through unchanged; anything else falls back to `fallback`.

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
@@ -207,11 +207,41 @@ extension EmbraceBacktrace {
 
 extension EmbraceBacktrace {
 
+    /// Number of Embrace capture-plumbing frames sitting on top of a stack that was walked on the
+    /// *current* thread (self-capture, i.e. `canSuspend == false`).
+    ///
+    /// When we walk our own thread the raw addresses begin inside the SDK: the
+    /// `Thread.callStackReturnAddresses` read site, the `Backtracer` call, and the internal
+    /// `_takeSnapshot` / `takeSnapshot` / `backtrace(of:threadIndex:)` wrappers — all above the code
+    /// that actually asked for the backtrace. Dropping exactly these lands frame 0 on the caller.
+    ///
+    /// This is deliberately *not* applied when suspending and walking a **different** thread: that
+    /// thread's genuine top frame is the code we want, with none of our wrappers above it (skip 0).
+    ///
+    /// - Important: This is wrapper *depth*, not a semantic constant — it only stays correct while
+    ///   the call chain above is unchanged. The wrappers (`backtrace(of:threadIndex:)`,
+    ///   `takeSnapshot`, `_takeSnapshot`) are marked `@inline(never)` precisely so this depth is
+    ///   **identical at every optimization level**; that is what lets the Debug-only
+    ///   `BacktraceFrameSkipTests` authoritatively pin it for Release too (the repo can't currently
+    ///   run that suite in Release). If an internal refactor changes the chain, that test fails and
+    ///   points here — update the constant and keep the `@inline(never)` wrappers intact.
+    static let selfCaptureFrameSkip = 5
+
+    /// Wrapper depth for the Apple/`Thread.callStackReturnAddresses` self-capture path
+    /// (`_takeSnapshotApple`). Smaller than ``selfCaptureFrameSkip`` because that path has no
+    /// `Backtracer` indirection on top. Pinned by the same test; see it for the drift caveat.
+    static let appleSelfCaptureFrameSkip = 3
+
+    // `@inline(never)` here (and on `backtrace(of:threadIndex:)`) is load-bearing: it pins the
+    // self-capture wrapper depth so `selfCaptureFrameSkip` is identical at every optimization level.
+    // Without it the optimizer could collapse this forwarder in Release, shifting the skip by one.
+    @inline(never)
     static func takeSnapshot(of thread: pthread_t, threadIndex: Int = 0) -> [EmbraceBacktraceThread] {
         let snap = _takeSnapshot(of: thread, threadIndex: threadIndex)
         return snap
     }
 
+    @inline(never)
     static func _takeSnapshot(of thread: pthread_t, threadIndex: Int = 0) -> [EmbraceBacktraceThread] {
 
         guard let backtracer = Embrace.client?.options.backtracer else {
@@ -222,31 +252,49 @@ extension EmbraceBacktrace {
         let machThread = pthread_mach_thread_np(thread)
         let canSuspend = pthread_self() != thread
 
-        // suspend thread if not the current thread.
+        // Drop the SDK's own capture frames (present only on self-capture; see `selfCaptureFrameSkip`).
+        let sdkFrameSkip = canSuspend ? 0 : Self.selfCaptureFrameSkip
+        let entries = 512
+
+        let addresses: [UInt]
         if canSuspend {
+            // Suspending another thread to walk it is a #423-class deadlock hazard: if that thread
+            // holds the allocator lock, any `malloc` inside the suspend window hangs the process. So
+            // the buffer is allocated BEFORE the suspend and everything that touches the heap
+            // (copy/slice) happens AFTER the resume; only the alloc-free `backtrace(of:into:capacity:)`
+            // runs in the window.
+            let buffer = UnsafeMutablePointer<FrameAddress>.allocate(capacity: entries)
+            defer { buffer.deallocate() }
+
             guard emb_thread_suspend(machThread) == KERN_SUCCESS else {
                 Embrace.logger.warning("[EmbraceBacktrace] error suspending thread")
                 return []
             }
-        }
-
-        // Get the actual snapshot,
-        let backtraceAddresses = backtracer.backtrace(of: thread)
-
-        // resume thread
-        if canSuspend {
+            // ───── SUSPEND WINDOW: allocation-free / async-signal-safe only ─────
+            #if DEBUG
+                EmbraceBacktraceSuspendWindowProbe.willEnter?()
+            #endif
+            let count = backtracer.backtrace(of: thread, into: buffer, capacity: entries)
+            #if DEBUG
+                EmbraceBacktraceSuspendWindowProbe.didExit?()
+            #endif
+            // ───── END SUSPEND WINDOW ─────
             emb_thread_resume(machThread)
-        }
 
-        // remove the entries that are part of the SDK,
-        // get only the first N entries to not overload the system,
-        // clean 'em up.
-        let entries = 512
-        let addresses =
-            backtraceAddresses
-            .dropFirst(5)
-            .prefix(entries)
-            .compactMap { $0 as UInt }
+            addresses =
+                Array(UnsafeBufferPointer(start: buffer, count: max(0, count)))
+                .dropFirst(sdkFrameSkip)
+                .prefix(entries)
+                .compactMap { $0 as UInt }
+        } else {
+            // Self-capture: nothing is suspended, so the allocating array API is safe (and required
+            // for the on-main `pthread_self()` path, which KSCrash handles specially).
+            addresses =
+                backtracer.backtrace(of: thread)
+                .dropFirst(sdkFrameSkip)
+                .prefix(entries)
+                .compactMap { $0 as UInt }
+        }
 
         return [
             EmbraceBacktraceThread(
@@ -262,11 +310,15 @@ extension EmbraceBacktrace {
 
 extension EmbraceBacktrace {
 
+    // `@inline(never)` pins the Apple self-capture wrapper depth for `appleSelfCaptureFrameSkip`,
+    // same rationale as `takeSnapshot`.
+    @inline(never)
     static func takeSnapshotApple() -> [EmbraceBacktraceThread] {
         let snap = _takeSnapshotApple()
         return snap
     }
 
+    @inline(never)
     static func _takeSnapshotApple() -> [EmbraceBacktraceThread] {
 
         // Get the actual snapshot,
@@ -276,7 +328,7 @@ extension EmbraceBacktrace {
         let entries = 512
         let addresses =
             Thread.callStackReturnAddresses
-            .dropFirst(3)
+            .dropFirst(Self.appleSelfCaptureFrameSkip)
             .prefix(entries)
             .compactMap { $0 as? UInt }
 
@@ -318,3 +370,15 @@ extension EmbraceBacktraceFrame {
         ]
     }
 }
+
+#if DEBUG
+    /// Test-only seam bracketing the `_takeSnapshot` thread-suspend window. Both hooks are `nil` in
+    /// normal use (a `nil`-check is the only cost, and they are stripped entirely from Release), so
+    /// they add nothing to production. The suspend-window sentinel test sets them to mark exactly
+    /// when the target thread is suspended, so it can prove the walk allocates nothing in-window.
+    /// The hooks themselves MUST be allocation-free — they run inside the window.
+    enum EmbraceBacktraceSuspendWindowProbe {
+        static var willEnter: (() -> Void)?
+        static var didExit: (() -> Void)?
+    }
+#endif

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
@@ -222,11 +222,6 @@ extension EmbraceBacktrace {
     ///   Release too. If a refactor changes the chain, that test fails and points here.
     static let selfCaptureFrameSkip = 5
 
-    /// Wrapper depth for the Apple/`Thread.callStackReturnAddresses` self-capture path
-    /// (`_takeSnapshotApple`). Smaller than ``selfCaptureFrameSkip`` because that path has no
-    /// `Backtracer` indirection on top. Pinned by the same test; see it for the drift caveat.
-    static let appleSelfCaptureFrameSkip = 3
-
     /// Upper bound on frames captured per snapshot: deep enough for real call stacks, capped so a
     /// runaway/recursive stack can't blow up capture cost or payload size.
     static let maxCapturedFrames = 512
@@ -297,42 +292,6 @@ extension EmbraceBacktrace {
         return [
             EmbraceBacktraceThread(
                 index: threadIndex,
-                callstack: EmbraceBacktraceThread.Callstack(
-                    addresses: addresses,
-                    count: addresses.count
-                )
-            )
-        ]
-    }
-}
-
-extension EmbraceBacktrace {
-
-    // `@inline(never)` pins the Apple self-capture wrapper depth for `appleSelfCaptureFrameSkip`,
-    // same rationale as `takeSnapshot`.
-    @inline(never)
-    static func takeSnapshotApple() -> [EmbraceBacktraceThread] {
-        let snap = _takeSnapshotApple()
-        return snap
-    }
-
-    @inline(never)
-    static func _takeSnapshotApple() -> [EmbraceBacktraceThread] {
-
-        // Get the actual snapshot,
-        // remove the entries that are part of the SDK,
-        // get only the first N entries to not overload the system,
-        // clean 'em up.
-        let entries = Self.maxCapturedFrames
-        let addresses =
-            Thread.callStackReturnAddresses
-            .dropFirst(Self.appleSelfCaptureFrameSkip)
-            .prefix(entries)
-            .compactMap { $0 as? UInt }
-
-        return [
-            EmbraceBacktraceThread(
-                index: 0,
                 callstack: EmbraceBacktraceThread.Callstack(
                     addresses: addresses,
                     count: addresses.count

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
@@ -172,10 +172,6 @@ extension EmbraceBacktraceFrame {
             ),
             image: result.imageName != nil
                 ? Image(
-                    // `result.imageUUID` is already the full Mach-O UUID string (built via
-                    // `NSUUID(uuidBytes:).uuidString` in the symbolicator). Passing that String back
-                    // through `NSUUID(uuidBytes:)` reinterprets its first 16 UTF-8 bytes as a raw
-                    // `uuid_t`, truncating the UUID to its first 16 characters. Use it directly.
                     uuid: result.imageUUID ?? "",
                     name: result.imageName.flatMap { $0 as NSString }?.lastPathComponent ?? "",
                     address: result.imageAddress,

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
@@ -207,24 +207,19 @@ extension EmbraceBacktrace {
 
 extension EmbraceBacktrace {
 
-    /// Number of Embrace capture-plumbing frames sitting on top of a stack that was walked on the
-    /// *current* thread (self-capture, i.e. `canSuspend == false`).
+    /// Number of Embrace capture-plumbing frames on top of a stack walked on the *current* thread
+    /// (self-capture, `canSuspend == false`): the `Backtracer` call and the `_takeSnapshot` /
+    /// `takeSnapshot` / `backtrace(of:threadIndex:)` wrappers above the caller. Dropping exactly
+    /// these lands frame 0 on the code that asked for the backtrace.
     ///
-    /// When we walk our own thread the raw addresses begin inside the SDK: the
-    /// `Thread.callStackReturnAddresses` read site, the `Backtracer` call, and the internal
-    /// `_takeSnapshot` / `takeSnapshot` / `backtrace(of:threadIndex:)` wrappers — all above the code
-    /// that actually asked for the backtrace. Dropping exactly these lands frame 0 on the caller.
+    /// Self-capture is a live path: `LogController` walks the current thread for warn/error log
+    /// stack traces (`backtrace(of: pthread_self())`). The skip is *not* applied when suspending a
+    /// different thread, whose genuine top frame is already the code we want (skip 0).
     ///
-    /// This is deliberately *not* applied when suspending and walking a **different** thread: that
-    /// thread's genuine top frame is the code we want, with none of our wrappers above it (skip 0).
-    ///
-    /// - Important: This is wrapper *depth*, not a semantic constant — it only stays correct while
-    ///   the call chain above is unchanged. The wrappers (`backtrace(of:threadIndex:)`,
-    ///   `takeSnapshot`, `_takeSnapshot`) are marked `@inline(never)` precisely so this depth is
-    ///   **identical at every optimization level**; that is what lets the Debug-only
-    ///   `BacktraceFrameSkipTests` authoritatively pin it for Release too (the repo can't currently
-    ///   run that suite in Release). If an internal refactor changes the chain, that test fails and
-    ///   points here — update the constant and keep the `@inline(never)` wrappers intact.
+    /// - Important: this is wrapper *depth*, not a semantic constant — correct only while the call
+    ///   chain above is unchanged. Those wrappers are `@inline(never)` so the depth is identical at
+    ///   every optimization level, which lets the Debug-only `BacktraceFrameSkipTests` pin it for
+    ///   Release too. If a refactor changes the chain, that test fails and points here.
     static let selfCaptureFrameSkip = 5
 
     /// Wrapper depth for the Apple/`Thread.callStackReturnAddresses` self-capture path
@@ -232,9 +227,13 @@ extension EmbraceBacktrace {
     /// `Backtracer` indirection on top. Pinned by the same test; see it for the drift caveat.
     static let appleSelfCaptureFrameSkip = 3
 
-    // `@inline(never)` here (and on `backtrace(of:threadIndex:)`) is load-bearing: it pins the
-    // self-capture wrapper depth so `selfCaptureFrameSkip` is identical at every optimization level.
-    // Without it the optimizer could collapse this forwarder in Release, shifting the skip by one.
+    /// Upper bound on frames captured per snapshot: deep enough for real call stacks, capped so a
+    /// runaway/recursive stack can't blow up capture cost or payload size.
+    static let maxCapturedFrames = 512
+
+    // `@inline(never)` here (and on `backtrace(of:threadIndex:)`) pins the self-capture wrapper depth
+    // so `selfCaptureFrameSkip` holds at every optimization level; without it the optimizer could
+    // collapse this forwarder in Release and shift the skip by one.
     @inline(never)
     static func takeSnapshot(of thread: pthread_t, threadIndex: Int = 0) -> [EmbraceBacktraceThread] {
         let snap = _takeSnapshot(of: thread, threadIndex: threadIndex)
@@ -254,15 +253,14 @@ extension EmbraceBacktrace {
 
         // Drop the SDK's own capture frames (present only on self-capture; see `selfCaptureFrameSkip`).
         let sdkFrameSkip = canSuspend ? 0 : Self.selfCaptureFrameSkip
-        let entries = 512
+        let entries = Self.maxCapturedFrames
 
         let addresses: [UInt]
         if canSuspend {
-            // Suspending another thread to walk it is a #423-class deadlock hazard: if that thread
-            // holds the allocator lock, any `malloc` inside the suspend window hangs the process. So
-            // the buffer is allocated BEFORE the suspend and everything that touches the heap
-            // (copy/slice) happens AFTER the resume; only the alloc-free `backtrace(of:into:capacity:)`
-            // runs in the window.
+            // Deadlock hazard: if the suspended thread holds the allocator lock, any `malloc` in the
+            // suspend window hangs the process. So allocate the buffer before the suspend and do all
+            // heap work (copy/slice) after the resume — only the alloc-free
+            // `backtrace(of:into:capacity:)` runs in the window.
             let buffer = UnsafeMutablePointer<FrameAddress>.allocate(capacity: entries)
             defer { buffer.deallocate() }
 
@@ -325,7 +323,7 @@ extension EmbraceBacktrace {
         // remove the entries that are part of the SDK,
         // get only the first N entries to not overload the system,
         // clean 'em up.
-        let entries = 512
+        let entries = Self.maxCapturedFrames
         let addresses =
             Thread.callStackReturnAddresses
             .dropFirst(Self.appleSelfCaptureFrameSkip)

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace+Internal.swift
@@ -172,7 +172,11 @@ extension EmbraceBacktraceFrame {
             ),
             image: result.imageName != nil
                 ? Image(
-                    uuid: NSUUID(uuidBytes: result.imageUUID).uuidString,
+                    // `result.imageUUID` is already the full Mach-O UUID string (built via
+                    // `NSUUID(uuidBytes:).uuidString` in the symbolicator). Passing that String back
+                    // through `NSUUID(uuidBytes:)` reinterprets its first 16 UTF-8 bytes as a raw
+                    // `uuid_t`, truncating the UUID to its first 16 characters. Use it directly.
+                    uuid: result.imageUUID ?? "",
                     name: result.imageName.flatMap { $0 as NSString }?.lastPathComponent ?? "",
                     address: result.imageAddress,
                     size: result.imageSize

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace.swift
@@ -136,6 +136,9 @@ public struct EmbraceBacktrace: Codable {
     ///
     /// - Note: The `timestamp` is sourced from `CLOCK_MONOTONIC_RAW` via
     ///   `clock_gettime_nsec_np`, which is suitable for measuring intervals.
+    // `@inline(never)`: keeps this a stable frame in self-capture stacks so `selfCaptureFrameSkip`
+    // is optimization-independent. See that constant.
+    @inline(never)
     static func backtrace(of thread: pthread_t, threadIndex: Int = 0) -> EmbraceBacktrace {
         EmbraceBacktrace(
             timestampUnits: .nanoseconds,
@@ -154,6 +157,8 @@ public struct EmbraceBacktrace: Codable {
     ///
     /// - Note: The `timestamp` is sourced from `CLOCK_MONOTONIC_RAW` via
     ///   `clock_gettime_nsec_np`, which is suitable for measuring intervals.
+    // `@inline(never)`: stable frame for the Apple self-capture path; see `appleSelfCaptureFrameSkip`.
+    @inline(never)
     static func backtrace() -> EmbraceBacktrace {
         EmbraceBacktrace(
             timestampUnits: .nanoseconds,

--- a/Sources/EmbraceCore/Backtrace/EmbraceBacktrace.swift
+++ b/Sources/EmbraceCore/Backtrace/EmbraceBacktrace.swift
@@ -147,25 +147,6 @@ public struct EmbraceBacktrace: Codable {
         )
     }
 
-    /// Captures a backtrace of the current thread using `Thread.callStackReturnAddresses`.
-    ///
-    /// This is the simplest capture path and does not require suspending any threads.
-    /// It’s useful for lightweight diagnostics or when called on the thread of interest.
-    ///
-    /// - Returns: A backtrace snapshot containing one `EmbraceBacktraceThread`
-    ///   derived from `Thread.callStackReturnAddresses`.
-    ///
-    /// - Note: The `timestamp` is sourced from `CLOCK_MONOTONIC_RAW` via
-    ///   `clock_gettime_nsec_np`, which is suitable for measuring intervals.
-    // `@inline(never)`: stable frame for the Apple self-capture path; see `appleSelfCaptureFrameSkip`.
-    @inline(never)
-    static func backtrace() -> EmbraceBacktrace {
-        EmbraceBacktrace(
-            timestampUnits: .nanoseconds,
-            timestamp: clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW),
-            threads: takeSnapshotApple()
-        )
-    }
 }
 extension EmbraceBacktrace: Sendable {}
 

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -46,13 +46,30 @@ import OpenTelemetryApi
             // we need to wait until the remote config is actually loaded from disk
             // which happens just before this call.
             let currentLimits = limits
-            let monitor: FrameRateMonitor? =
-                currentLimits.hangPerSession > 0
-                ? FrameRateMonitor(threshold: currentLimits.hangThreshold)
-                : nil
-            monitor?.hangObserver = self
-            monitor?.logger = logger
-            limitData.withLock { $0.watchdog = monitor }
+            let (monitor, sampler) = makeMonitorAndSampler(for: currentLimits)
+            sampler?.start()
+            limitData.withLock {
+                $0.watchdog = monitor
+                $0.sampler = sampler
+            }
+        }
+
+        /// Builds the detector + during-block sampler pair for `limits`, or `(nil, nil)` when hangs
+        /// are disabled. The sampler is returned un-started; callers own `start()`/`stop()`.
+        private func makeMonitorAndSampler(
+            for limits: HangLimits
+        ) -> (FrameRateMonitor?, MainThreadStackSampler?) {
+            guard limits.hangPerSession > 0 else { return (nil, nil) }
+            let monitor = FrameRateMonitor(threshold: limits.hangThreshold)
+            monitor.hangObserver = self
+            monitor.logger = logger
+            let sampler = StallTriggeredSampler(
+                mainThread: mainThread,
+                triggerThreshold: limits.sampleTriggerThreshold,
+                pollInterval: limits.samplePollInterval,
+                logger: logger
+            )
+            return (monitor, sampler)
         }
 
         public override func onSessionStart(_ session: any EmbraceSession) {
@@ -70,17 +87,21 @@ import OpenTelemetryApi
                 let changed =
                     $0.limits.hangThreshold != newLimits.hangThreshold
                     || ($0.limits.hangPerSession == 0) != (newLimits.hangPerSession == 0)
+                    || $0.limits.sampleTriggerThreshold != newLimits.sampleTriggerThreshold
+                    || $0.limits.samplePollInterval != newLimits.samplePollInterval
                 $0.limits = newLimits
                 return changed
             }
             if monitorNeedsUpdate {
-                let monitor: FrameRateMonitor? =
-                    newLimits.hangPerSession > 0
-                    ? FrameRateMonitor(threshold: newLimits.hangThreshold)
-                    : nil
-                monitor?.hangObserver = self
-                monitor?.logger = logger
-                limitData.withLock { $0.watchdog = monitor }
+                let (monitor, sampler) = makeMonitorAndSampler(for: newLimits)
+                let oldSampler = limitData.withLock { data -> MainThreadStackSampler? in
+                    let previous = data.sampler
+                    data.watchdog = monitor
+                    data.sampler = sampler
+                    return previous
+                }
+                oldSampler?.stop()
+                sampler?.start()
             }
         }
 
@@ -90,6 +111,7 @@ import OpenTelemetryApi
             var limits: HangLimits = HangLimits()
             var hangsInSessionCount: UInt = 0
             var watchdog: FrameRateMonitor?
+            var sampler: MainThreadStackSampler?
         }
         let limitData: EmbraceMutex<MutableLimitData>
 
@@ -153,21 +175,15 @@ import OpenTelemetryApi
                 return
             }
 
-            // Capture a single retroactive backtrace of the main thread.
-            let pre = Date()
-            let backtrace = EmbraceBacktrace.backtrace(of: mainThread, threadIndex: 0)
-            let post = Date()
-
+            // No stack is captured here. The hang stack is attached at `hangEnded` from the
+            // during-block sampler; a retroactive on-main capture at this point would walk the
+            // display-link servicing path (CADisplayLink only fires after main unblocks), not the
+            // code that actually hung.
             spanQueue.async { [self] in
                 span =
                     builder
                     .setStartTime(time: at)
                     .startSpan()
-                addSamplingSpanEvent(
-                    time: at,
-                    backtrace: backtrace,
-                    overhead: Int(post.timeIntervalSince(pre) * 1_000_000_000)
-                )
             }
         }
 
@@ -181,7 +197,27 @@ import OpenTelemetryApi
                 )
             }
 
+            // Reconcile the CADisplayLink-confirmed hang with the sampler's during-block snapshots.
+            // `duration` is a clock-agnostic interval, so subtracting it from a fresh
+            // CLOCK_MONOTONIC_RAW reading (taken here on main, ≈ real hang end) yields the window in
+            // the sampler's own clock. The during-block sample was taken at ≈ start + trigger, so it
+            // lands inside; a small tolerance absorbs callback latency.
+            let tolerance: UInt64 = 20_000_000  // 20 ms
+            let endMono = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+            let durationNanos = UInt64((duration * 1_000_000_000).rounded())
+            let startMono = endMono > durationNanos + tolerance ? endMono &- durationNanos &- tolerance : 0
+            let sample = limitData.withLock { $0.sampler }?.samples(in: startMono...endMono).last
+            let sampleTime = at.addingTimeInterval(-duration)
+
             spanQueue.async { [self] in
+                if let sample {
+                    addSamplingSpanEvent(
+                        time: sampleTime,
+                        backtrace: sample.backtrace,
+                        overhead: Int(sample.overhead)
+                    )
+                }
+                // else: emit the span with no stack — an honest "no trace" beats the old misleading one.
                 span?.end(time: at)
                 span = nil
             }

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -28,12 +28,15 @@ import OpenTelemetryApi
             limits: HangLimits = HangLimits()
         ) {
             dispatchPrecondition(condition: .onQueue(.main))
+            // Capture main's `pthread_t` here, on the main thread. The sampler is (re)built later —
+            // `onConfigUpdated` runs off the main thread — so it can't derive main via `pthread_self()`
+            // itself; we capture it once and inject it.
             self.mainThread = pthread_self()
             self.limitData = EmbraceMutex(MutableLimitData(limits: limits))
             super.init()
         }
 
-        public override func onInstall() {
+        public override func onStart() {
 
             // No monitor when debugger is attached.
             if isDebuggerAttached() && ProcessInfo.processInfo.environment["EMBAllowWatchdogInDebugger"] != "1" {
@@ -42,20 +45,41 @@ import OpenTelemetryApi
                 return
             }
 
-            // Since we use `limits.hangPerSession` as a gate for the monitor,
-            // we need to wait until the remote config is actually loaded from disk
-            // which happens just before this call.
-            let currentLimits = limits
-            let (monitor, sampler) = makeMonitorAndSampler(for: currentLimits)
-            sampler?.start()
-            limitData.withLock {
-                $0.watchdog = monitor
-                $0.sampler = sampler
+            // `limits.hangPerSession` gates the monitor, and the remote config is loaded from disk
+            // before the service is installed and started, so `limits` is authoritative here.
+            activate(with: limits)
+        }
+
+        public override func onStop() {
+            // Tear down the detector and sampler so no poll thread or CADisplayLink outlives an SDK
+            // stop. Releasing the monitor invalidates its CADisplayLink via `FrameRateMonitor.deinit`.
+            let sampler = limitData.withLock { data -> MainThreadStackSampler? in
+                let previous = data.sampler
+                data.watchdog = nil
+                data.sampler = nil
+                return previous
             }
+            sampler?.stop()
+        }
+
+        /// Builds a fresh detector + sampler for `limits`, starts the sampler, and swaps them in for
+        /// the previous pair (which is stopped and released).
+        private func activate(with limits: HangLimits) {
+            let (monitor, sampler) = makeMonitorAndSampler(for: limits)
+            sampler?.start()
+            let oldSampler = limitData.withLock { data -> MainThreadStackSampler? in
+                let previous = data.sampler
+                data.watchdog = monitor
+                data.sampler = sampler
+                return previous
+            }
+            oldSampler?.stop()
         }
 
         /// Builds the detector + during-block sampler pair for `limits`, or `(nil, nil)` when hangs
-        /// are disabled. The sampler is returned un-started; callers own `start()`/`stop()`.
+        /// are disabled. The sampler is returned un-started (the caller owns `start()`/`stop()`); the
+        /// monitor begins observing as soon as it is constructed — `FrameRateMonitor.init` adds its
+        /// `CADisplayLink` to the main run loop — and stops when it is released.
         private func makeMonitorAndSampler(
             for limits: HangLimits
         ) -> (FrameRateMonitor?, MainThreadStackSampler?) {
@@ -92,17 +116,11 @@ import OpenTelemetryApi
                 $0.limits = newLimits
                 return changed
             }
-            if monitorNeedsUpdate {
-                let (monitor, sampler) = makeMonitorAndSampler(for: newLimits)
-                let oldSampler = limitData.withLock { data -> MainThreadStackSampler? in
-                    let previous = data.sampler
-                    data.watchdog = monitor
-                    data.sampler = sampler
-                    return previous
-                }
-                oldSampler?.stop()
-                sampler?.start()
-            }
+            // Only rebuild the live detector/sampler while active. If the service isn't running the
+            // new limits are stored above and applied the next time `onStart()` runs — a config
+            // update must never spin up a poll thread on a stopped service.
+            guard monitorNeedsUpdate, state.load(order: .acquire) == .active else { return }
+            activate(with: newLimits)
         }
 
         private var mainThread: pthread_t
@@ -206,7 +224,8 @@ import OpenTelemetryApi
             let endMono = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
             let durationNanos = UInt64((duration * 1_000_000_000).rounded())
             let startMono = endMono > durationNanos + tolerance ? endMono &- durationNanos &- tolerance : 0
-            let sample = limitData.withLock { $0.sampler }?.samples(in: startMono...endMono).last
+            // Take the earliest during-block sample in the window — closest to where the block began.
+            let sample = limitData.withLock { $0.sampler }?.samples(in: startMono...endMono).first
             let sampleTime = at.addingTimeInterval(-duration)
 
             spanQueue.async { [self] in

--- a/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Hang/HangCaptureService.swift
@@ -27,11 +27,6 @@ import OpenTelemetryApi
         public init(
             limits: HangLimits = HangLimits()
         ) {
-            dispatchPrecondition(condition: .onQueue(.main))
-            // Capture main's `pthread_t` here, on the main thread. The sampler is (re)built later —
-            // `onConfigUpdated` runs off the main thread — so it can't derive main via `pthread_self()`
-            // itself; we capture it once and inject it.
-            self.mainThread = pthread_self()
             self.limitData = EmbraceMutex(MutableLimitData(limits: limits))
             super.init()
         }
@@ -63,17 +58,24 @@ import OpenTelemetryApi
         }
 
         /// Builds a fresh detector + sampler for `limits`, starts the sampler, and swaps them in for
-        /// the previous pair (which is stopped and released).
+        /// the previous pair (which is stopped and released). The swap is committed under the lock
+        /// only if the service is still active; if a concurrent `onStop()` raced in between building
+        /// and storing, the freshly built pair is torn down instead — so no poll thread or
+        /// CADisplayLink outlives the stop.
         private func activate(with limits: HangLimits) {
             let (monitor, sampler) = makeMonitorAndSampler(for: limits)
             sampler?.start()
-            let oldSampler = limitData.withLock { data -> MainThreadStackSampler? in
+            let (oldSampler, stored) = limitData.withLock { data -> (MainThreadStackSampler?, Bool) in
+                guard state.load(order: .acquire) == .active else { return (nil, false) }
                 let previous = data.sampler
                 data.watchdog = monitor
                 data.sampler = sampler
-                return previous
+                return (previous, true)
             }
             oldSampler?.stop()
+            if !stored {
+                sampler?.stop()  // service stopped mid-build; release the pair we just started
+            }
         }
 
         /// Builds the detector + during-block sampler pair for `limits`, or `(nil, nil)` when hangs
@@ -88,7 +90,6 @@ import OpenTelemetryApi
             monitor.hangObserver = self
             monitor.logger = logger
             let sampler = StallTriggeredSampler(
-                mainThread: mainThread,
                 triggerThreshold: limits.sampleTriggerThreshold,
                 pollInterval: limits.samplePollInterval,
                 logger: logger
@@ -122,8 +123,6 @@ import OpenTelemetryApi
             guard monitorNeedsUpdate, state.load(order: .acquire) == .active else { return }
             activate(with: newLimits)
         }
-
-        private var mainThread: pthread_t
 
         struct MutableLimitData {
             var limits: HangLimits = HangLimits()
@@ -225,7 +224,10 @@ import OpenTelemetryApi
             let durationNanos = UInt64((duration * 1_000_000_000).rounded())
             let startMono = endMono > durationNanos + tolerance ? endMono &- durationNanos &- tolerance : 0
             // Take the earliest during-block sample in the window — closest to where the block began.
-            let sample = limitData.withLock { $0.sampler }?.samples(in: startMono...endMono).first
+            let (hasSampler, sample) = limitData.withLock { data -> (Bool, MainThreadStackSample?) in
+                let sampler = data.sampler
+                return (sampler != nil, sampler?.samples(in: startMono...endMono).first)
+            }
             let sampleTime = at.addingTimeInterval(-duration)
 
             spanQueue.async { [self] in
@@ -235,8 +237,13 @@ import OpenTelemetryApi
                         backtrace: sample.backtrace,
                         overhead: Int(sample.overhead)
                     )
+                } else {
+                    // Emit the span with no stack — an honest "no trace" beats the old misleading one —
+                    // but log why, so an empty stack is distinguishable from missing hang data.
+                    logger?.debug(
+                        "[Hang] confirmed hang emitted with no during-block stack "
+                            + "(\(hasSampler ? "sampler active, no sample landed in the window" : "no active sampler")).")
                 }
-                // else: emit the span with no stack — an honest "no trace" beats the old misleading one.
                 span?.end(time: at)
                 span = nil
             }
@@ -253,6 +260,9 @@ import OpenTelemetryApi
 
             let stack = processBacktrace(backtrace)
             guard stack.frameCount > 0 else {
+                logger?.warning(
+                    "[Hang] captured a during-block backtrace but all frames were dropped "
+                        + "(frameCount = 0) — no Symbolicator configured?")
                 return
             }
 

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/MainThreadStackSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/MainThreadStackSampler.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+
+    /// A single backtrace of the main thread captured *while the main thread was blocked*.
+    struct MainThreadStackSample {
+
+        /// Capture time in `CLOCK_MONOTONIC_RAW` nanoseconds — identical to `backtrace.timestamp`.
+        ///
+        /// Used to reconcile the sample against the CADisplayLink-confirmed hang window: the window
+        /// is derived from the same clock (see `HangCaptureService.hangEnded`), so a sample is
+        /// "in window" iff its `timestamp` falls inside it.
+        let timestamp: UInt64
+
+        /// Measured cost of the suspend + walk, in nanoseconds. Reported as `sample_overhead`.
+        let overhead: UInt64
+
+        /// The captured main-thread stack.
+        let backtrace: EmbraceBacktrace
+    }
+
+    /// Supplies main-thread stacks captured *while the main thread was blocked*.
+    ///
+    /// This is the seam that decouples `HangCaptureService` from *how* the during-block stack is
+    /// obtained. `FrameRateMonitor` (CADisplayLink) remains the sole authority on whether a hang is
+    /// reported and its boundaries; a conforming sampler's only job is to have a during-block stack
+    /// ready to hand back once the hang is confirmed.
+    ///
+    /// The current implementation is `StallTriggeredSampler`. Because the contract is just
+    /// "give me buffered during-block samples in this time range", a later step can drop in an
+    /// adapter over the shared profiling engine's sample store with **no change** to
+    /// `HangCaptureService`.
+    ///
+    /// - Note: A sampler must be **free-running** — CADisplayLink only confirms a hang *after* the
+    ///   main thread unblocks, so the stack has to have been captured already. It cannot be started
+    ///   in response to the detector.
+    protocol MainThreadStackSampler: AnyObject {
+
+        /// Begins sampling. Called once the feature is enabled (same gate as the monitor).
+        func start()
+
+        /// Stops sampling and releases resources. Called on teardown / config disable.
+        func stop()
+
+        /// Pauses sampling without tearing down (e.g. app backgrounded).
+        func pause()
+
+        /// Resumes sampling after a `pause()` (e.g. app foregrounded).
+        func resume()
+
+        /// Buffered during-block samples whose capture `timestamp` falls within `range`
+        /// (`CLOCK_MONOTONIC_RAW` ns), ordered oldest to newest.
+        func samples(in range: ClosedRange<UInt64>) -> [MainThreadStackSample]
+    }
+
+#endif

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/MainThreadStackSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/MainThreadStackSampler.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
 #if !os(watchOS) && !os(macOS)

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -51,9 +51,15 @@
 
         private let buffer = EmbraceMutex<[MainThreadStackSample]>([])
 
-        private var observer: CFRunLoopObserver?
-        private var thread: Thread?
-        private var lifecycleTokens: [NSObjectProtocol] = []
+        /// Lifecycle-owned resources. Guarded by a mutex so `start()`/`stop()` are mutually exclusive
+        /// and these fields are never touched unlocked — the poll thread and the beacon never read
+        /// them, so this lock is only ever contended by concurrent `start`/`stop`/`deinit` callers.
+        private struct LifecycleState {
+            var observer: CFRunLoopObserver?
+            var thread: Thread?
+            var tokens: [NSObjectProtocol] = []
+        }
+        private let lifecycle = EmbraceMutex(LifecycleState())
 
         /// - Parameters:
         ///   - mainThread: the `pthread_t` of the thread to sample (the main thread).
@@ -97,25 +103,41 @@
         // MARK: - MainThreadStackSampler
 
         func start() {
-            guard !running.exchange(true, order: .acquireAndRelease) else { return }
-            installObserver()
-            registerLifecycleNotifications()
+            lifecycle.withLock { state in
+                guard !running.load(order: .acquire) else { return }
+                running.store(true, order: .release)
 
-            let thread = Thread { [weak self] in self?.run() }
-            thread.name = "io.embrace.hang.sampler"
-            thread.qualityOfService = .userInitiated
-            self.thread = thread
-            thread.start()
+                if let observer = makeObserver() {
+                    state.observer = observer
+                    CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
+                }
+                state.tokens = makeLifecycleTokens()
+
+                let thread = Thread { [weak self] in self?.run() }
+                thread.name = "io.embrace.hang.sampler"
+                thread.qualityOfService = .userInitiated
+                state.thread = thread
+                thread.start()
+            }
         }
 
         func stop() {
-            guard running.exchange(false, order: .acquireAndRelease) else { return }
-            removeObserver()
-            let nc = NotificationCenter.default
-            lifecycleTokens.forEach { nc.removeObserver($0) }
-            lifecycleTokens = []
-            thread = nil
-            busySince.store(0, order: .release)
+            lifecycle.withLock { state in
+                guard running.load(order: .acquire) else { return }
+                running.store(false, order: .release)
+
+                if let observer = state.observer {
+                    CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes)
+                }
+                state.observer = nil
+
+                let nc = NotificationCenter.default
+                state.tokens.forEach { nc.removeObserver($0) }
+                state.tokens = []
+
+                state.thread = nil
+                busySince.store(0, order: .release)
+            }
         }
 
         func pause() {
@@ -134,9 +156,9 @@
 
         // MARK: - Main-thread liveness beacon
 
-        private func installObserver() {
+        private func makeObserver() -> CFRunLoopObserver? {
             let activities = CFRunLoopActivity([.afterWaiting, .beforeWaiting]).rawValue
-            let observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, activities, true, 0) {
+            return CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, activities, true, 0) {
                 [weak self] _, activity in
                 guard let self else { return }
                 if activity == .beforeWaiting {
@@ -146,15 +168,6 @@
                     self.busySince.store(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW), order: .release)
                 }
             }
-            self.observer = observer
-            CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
-        }
-
-        private func removeObserver() {
-            if let observer {
-                CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes)
-            }
-            observer = nil
         }
 
         // MARK: - Background sampling loop
@@ -201,20 +214,18 @@
 
         // MARK: - App lifecycle (raw names to avoid a UIKit dependency)
 
-        private func registerLifecycleNotifications() {
+        private func makeLifecycleTokens() -> [NSObjectProtocol] {
             let nc = NotificationCenter.default
-            lifecycleTokens.append(
+            return [
                 nc.addObserver(
                     forName: Notification.Name("UIApplicationDidEnterBackgroundNotification"),
                     object: nil, queue: nil
-                ) { [weak self] _ in self?.pause() }
-            )
-            lifecycleTokens.append(
+                ) { [weak self] _ in self?.pause() },
                 nc.addObserver(
                     forName: Notification.Name("UIApplicationWillEnterForegroundNotification"),
                     object: nil, queue: nil
                 ) { [weak self] _ in self?.resume() }
-            )
+            ]
         }
     }
 

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -1,0 +1,221 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+
+    #if !EMBRACE_COCOAPOD_BUILDING_SDK
+        import EmbraceCommonInternal
+    #endif
+
+    /// Detects that the main thread *looks* stalled and captures a single during-block backtrace of
+    /// it from a background thread. It does **not** decide whether a hang is reported —
+    /// `FrameRateMonitor` (CADisplayLink) remains the authority. This only supplies the stack;
+    /// stalls that CADisplayLink never confirms simply produce a buffered sample nobody queries.
+    ///
+    /// Detection is a lock-free liveness beacon plus a polling background thread:
+    ///
+    /// - A `CFRunLoopObserver` on the main run loop records, in the atomic `busySince`, the time the
+    ///   current busy epoch began (`.afterWaiting`) and clears it when the loop goes idle
+    ///   (`.beforeWaiting`). The handler runs on the main thread, so it does the absolute minimum —
+    ///   one atomic store, no lock — to avoid burdening the thread we're trying to measure.
+    /// - The background thread polls `busySince`. If the main thread has been continuously busy past
+    ///   `triggerThreshold`, it takes **one** suspended snapshot of main and buffers it. The
+    ///   `busySince` timestamp doubles as the epoch id: while main is blocked the run loop can't fire
+    ///   the observer again, so the value is stable and we sample the episode exactly once.
+    ///
+    /// The trigger sits below the reported-hang threshold so the snapshot lands *inside* the hang
+    /// window that CADisplayLink later confirms.
+    final class StallTriggeredSampler: MainThreadStackSampler {
+
+        /// Lower bound on the trigger. Prevents a bad/hostile remote value from driving overly
+        /// aggressive main-thread suspension.
+        static let minTriggerThreshold: TimeInterval = 0.05  // 50 ms
+
+        /// Lower bound on the poll cadence, for the same reason.
+        static let minPollInterval: TimeInterval = 0.01  // 10 ms
+
+        private let mainThread: pthread_t
+        private let triggerNanos: UInt64
+        private let pollMicros: useconds_t
+        private let bufferCap: Int
+        private weak var logger: InternalLogger?
+
+        /// `CLOCK_MONOTONIC_RAW` ns when the current busy epoch began; `0` when the run loop is idle.
+        /// Written by the main-thread beacon, read by the background poller.
+        private let busySince = EmbraceAtomic<UInt64>(0)
+        private let paused = EmbraceAtomic<Bool>(false)
+        private let running = EmbraceAtomic<Bool>(false)
+
+        private let buffer = EmbraceMutex<[MainThreadStackSample]>([])
+
+        private var observer: CFRunLoopObserver?
+        private var thread: Thread?
+        private var lifecycleTokens: [NSObjectProtocol] = []
+
+        /// - Parameters:
+        ///   - mainThread: the `pthread_t` of the thread to sample (the main thread).
+        ///   - triggerThreshold: how long main must be continuously busy before we snapshot it.
+        ///     Clamped up to ``minTriggerThreshold``.
+        ///   - pollInterval: how often the background thread checks liveness. Clamped up to
+        ///     ``minPollInterval``.
+        ///   - bufferCap: max buffered samples (small ring; one per stall episode).
+        init(
+            mainThread: pthread_t,
+            triggerThreshold: TimeInterval,
+            pollInterval: TimeInterval = 0.05,
+            bufferCap: Int = 8,
+            logger: InternalLogger?
+        ) {
+            self.mainThread = mainThread
+            self.triggerNanos = UInt64(max(Self.minTriggerThreshold, triggerThreshold) * 1_000_000_000)
+            self.pollMicros = useconds_t(max(Self.minPollInterval, pollInterval) * 1_000_000)
+            self.bufferCap = bufferCap
+            self.logger = logger
+        }
+
+        /// Convenience: derive the trigger from the reported-hang threshold (a fraction below it so
+        /// the snapshot lands in-window even for short hangs).
+        convenience init(mainThread: pthread_t, hangThreshold: TimeInterval, logger: InternalLogger?) {
+            self.init(
+                mainThread: mainThread,
+                triggerThreshold: hangThreshold * 0.6,
+                logger: logger
+            )
+        }
+
+        deinit { stop() }
+
+        /// Effective trigger after clamping, in seconds. Exposed for tests.
+        var effectiveTriggerThreshold: TimeInterval { TimeInterval(triggerNanos) / 1_000_000_000 }
+
+        /// Effective poll cadence after clamping, in seconds. Exposed for tests.
+        var effectivePollInterval: TimeInterval { TimeInterval(pollMicros) / 1_000_000 }
+
+        // MARK: - MainThreadStackSampler
+
+        func start() {
+            guard !running.exchange(true, order: .acquireAndRelease) else { return }
+            installObserver()
+            registerLifecycleNotifications()
+
+            let thread = Thread { [weak self] in self?.run() }
+            thread.name = "io.embrace.hang.sampler"
+            thread.qualityOfService = .userInitiated
+            self.thread = thread
+            thread.start()
+        }
+
+        func stop() {
+            guard running.exchange(false, order: .acquireAndRelease) else { return }
+            removeObserver()
+            let nc = NotificationCenter.default
+            lifecycleTokens.forEach { nc.removeObserver($0) }
+            lifecycleTokens = []
+            thread = nil
+            busySince.store(0, order: .release)
+        }
+
+        func pause() {
+            paused.store(true, order: .release)
+            busySince.store(0, order: .release)  // forget the current epoch across background
+        }
+
+        func resume() {
+            busySince.store(0, order: .release)  // fresh start; the beacon repopulates it
+            paused.store(false, order: .release)
+        }
+
+        func samples(in range: ClosedRange<UInt64>) -> [MainThreadStackSample] {
+            buffer.withLock { $0.filter { range.contains($0.timestamp) } }
+        }
+
+        // MARK: - Main-thread liveness beacon
+
+        private func installObserver() {
+            let activities = CFRunLoopActivity([.afterWaiting, .beforeWaiting]).rawValue
+            let observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, activities, true, 0) {
+                [weak self] _, activity in
+                guard let self else { return }
+                if activity == .beforeWaiting {
+                    self.busySince.store(0, order: .release)  // going idle → not a hang
+                } else {
+                    // .afterWaiting → a busy epoch begins. One atomic store, nothing else.
+                    self.busySince.store(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW), order: .release)
+                }
+            }
+            self.observer = observer
+            CFRunLoopAddObserver(CFRunLoopGetMain(), observer, .commonModes)
+        }
+
+        private func removeObserver() {
+            if let observer {
+                CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes)
+            }
+            observer = nil
+        }
+
+        // MARK: - Background sampling loop
+
+        private func run() {
+            // The `busySince` value we last captured for. Poller-local: no synchronization needed.
+            var lastSampledEpoch: UInt64 = 0
+
+            while running.load(order: .acquire) {
+                usleep(pollMicros)
+
+                guard !paused.load(order: .acquire) else { continue }
+
+                let since = busySince.load(order: .acquire)
+                guard since != 0, since != lastSampledEpoch else { continue }
+
+                let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+                guard now &- since >= triggerNanos else { continue }
+
+                lastSampledEpoch = since  // one snapshot per stall episode
+                captureSample()
+            }
+        }
+
+        private func captureSample() {
+            guard EmbraceBacktrace.isAvailable else { return }
+
+            let pre = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+            let backtrace = EmbraceBacktrace.backtrace(of: mainThread, threadIndex: 0)  // suspends main; alloc-free
+            let post = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
+
+            let sample = MainThreadStackSample(
+                timestamp: backtrace.timestamp,
+                overhead: post &- pre,
+                backtrace: backtrace
+            )
+            buffer.withLock {
+                $0.append(sample)
+                if $0.count > bufferCap {
+                    $0.removeFirst($0.count - bufferCap)
+                }
+            }
+        }
+
+        // MARK: - App lifecycle (raw names to avoid a UIKit dependency)
+
+        private func registerLifecycleNotifications() {
+            let nc = NotificationCenter.default
+            lifecycleTokens.append(
+                nc.addObserver(
+                    forName: Notification.Name("UIApplicationDidEnterBackgroundNotification"),
+                    object: nil, queue: nil
+                ) { [weak self] _ in self?.pause() }
+            )
+            lifecycleTokens.append(
+                nc.addObserver(
+                    forName: Notification.Name("UIApplicationWillEnterForegroundNotification"),
+                    object: nil, queue: nil
+                ) { [weak self] _ in self?.resume() }
+            )
+        }
+    }
+
+#endif

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -98,7 +98,8 @@
                     min: HangLimits.minSamplePollInterval,
                     max: HangLimits.maxSamplePollInterval
                 ),
-                bufferCap: Swift.max(1, bufferCap)  // a non-positive cap would trap the ring-buffer trim
+                // a cap < 1 would defeat buffering: 0 clears the ring every append, negative traps the trim.
+                bufferCap: Swift.max(1, bufferCap)
             )
             self.logger = logger
         }

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -9,6 +9,7 @@
     #if !EMBRACE_COCOAPOD_BUILDING_SDK
         import EmbraceCommonInternal
         import EmbraceConfiguration
+        import EmbraceObjCUtilsInternal
     #endif
 
     /// Detects that the main thread *looks* stalled and captures a single during-block backtrace of
@@ -56,14 +57,16 @@
         private let lifecycle = EmbraceMutex(LifecycleState())
 
         /// - Parameters:
-        ///   - mainThread: the `pthread_t` of the thread to sample (the main thread).
+        ///   - mainThread: the `pthread_t` of the thread to sample. Defaults to the main thread,
+        ///     resolved via `EmbraceGetMainThread()` (captured at load), so callers built off the main
+        ///     thread — e.g. during a config-update rebuild — still target main correctly.
         ///   - triggerThreshold: how long main must be continuously busy before we snapshot it.
         ///     Clamped into `HangLimits.min/maxSampleTriggerThreshold`.
         ///   - pollInterval: how often the background thread checks liveness. Clamped into
         ///     `HangLimits.min/maxSamplePollInterval`.
         ///   - bufferCap: max buffered samples (small ring; one per stall episode).
         init(
-            mainThread: pthread_t,
+            mainThread: pthread_t = EmbraceGetMainThread(),
             triggerThreshold: TimeInterval,
             pollInterval: TimeInterval = HangLimits.defaultSamplePollInterval,
             bufferCap: Int = 8,
@@ -113,6 +116,12 @@
             lifecycle.withLock { state in
                 guard !running.load(order: .acquire) else { return }
                 running.store(true, order: .release)
+
+                if !EmbraceBacktrace.isAvailable {
+                    logger?.warning(
+                        "[Hang] during-block sampler started with no Backtracer configured; hang spans "
+                            + "will have no stack. Wire a Backtracer via EmbraceCore options, or use EmbraceIO.")
+                }
 
                 if let observer = makeObserver() {
                     state.observer = observer

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -8,6 +8,7 @@
 
     #if !EMBRACE_COCOAPOD_BUILDING_SDK
         import EmbraceCommonInternal
+        import EmbraceConfiguration
     #endif
 
     /// Detects that the main thread *looks* stalled and captures a single during-block backtrace of
@@ -30,16 +31,9 @@
     /// window that CADisplayLink later confirms.
     final class StallTriggeredSampler: MainThreadStackSampler {
 
-        /// Lower bound on the trigger. Prevents a bad/hostile remote value from driving overly
-        /// aggressive main-thread suspension.
-        static let minTriggerThreshold: TimeInterval = 0.05  // 50 ms
-
-        /// Lower bound on the poll cadence, for the same reason.
-        static let minPollInterval: TimeInterval = 0.01  // 10 ms
-
         private let mainThread: pthread_t
         private let triggerNanos: UInt64
-        private let pollMicros: useconds_t
+        private let pollNanos: UInt64
         private let bufferCap: Int
         private weak var logger: InternalLogger?
 
@@ -64,32 +58,32 @@
         /// - Parameters:
         ///   - mainThread: the `pthread_t` of the thread to sample (the main thread).
         ///   - triggerThreshold: how long main must be continuously busy before we snapshot it.
-        ///     Clamped up to ``minTriggerThreshold``.
-        ///   - pollInterval: how often the background thread checks liveness. Clamped up to
-        ///     ``minPollInterval``.
+        ///     Clamped into `HangLimits.min/maxSampleTriggerThreshold`.
+        ///   - pollInterval: how often the background thread checks liveness. Clamped into
+        ///     `HangLimits.min/maxSamplePollInterval`.
         ///   - bufferCap: max buffered samples (small ring; one per stall episode).
         init(
             mainThread: pthread_t,
             triggerThreshold: TimeInterval,
-            pollInterval: TimeInterval = 0.05,
+            pollInterval: TimeInterval = HangLimits.defaultSamplePollInterval,
             bufferCap: Int = 8,
             logger: InternalLogger?
         ) {
             self.mainThread = mainThread
-            self.triggerNanos = UInt64(max(Self.minTriggerThreshold, triggerThreshold) * 1_000_000_000)
-            self.pollMicros = useconds_t(max(Self.minPollInterval, pollInterval) * 1_000_000)
+            self.triggerNanos = Self.clampedNanos(
+                triggerThreshold,
+                fallback: HangLimits.defaultSampleTriggerThreshold,
+                min: HangLimits.minSampleTriggerThreshold,
+                max: HangLimits.maxSampleTriggerThreshold
+            )
+            self.pollNanos = Self.clampedNanos(
+                pollInterval,
+                fallback: HangLimits.defaultSamplePollInterval,
+                min: HangLimits.minSamplePollInterval,
+                max: HangLimits.maxSamplePollInterval
+            )
             self.bufferCap = bufferCap
             self.logger = logger
-        }
-
-        /// Convenience: derive the trigger from the reported-hang threshold (a fraction below it so
-        /// the snapshot lands in-window even for short hangs).
-        convenience init(mainThread: pthread_t, hangThreshold: TimeInterval, logger: InternalLogger?) {
-            self.init(
-                mainThread: mainThread,
-                triggerThreshold: hangThreshold * 0.6,
-                logger: logger
-            )
         }
 
         deinit { stop() }
@@ -98,7 +92,20 @@
         var effectiveTriggerThreshold: TimeInterval { TimeInterval(triggerNanos) / 1_000_000_000 }
 
         /// Effective poll cadence after clamping, in seconds. Exposed for tests.
-        var effectivePollInterval: TimeInterval { TimeInterval(pollMicros) / 1_000_000 }
+        var effectivePollInterval: TimeInterval { TimeInterval(pollNanos) / 1_000_000_000 }
+
+        /// Values reaching `HangLimits` are already clamped; this is the defense-in-depth for direct
+        /// callers. A non-finite value falls back to `fallback`; otherwise it is clamped into
+        /// `[minimum, maximum]` (whose upper bound keeps the ns conversion from overflowing).
+        private static func clampedNanos(
+            _ value: TimeInterval,
+            fallback: TimeInterval,
+            min minimum: TimeInterval,
+            max maximum: TimeInterval
+        ) -> UInt64 {
+            let base = value.isFinite ? value : fallback
+            return UInt64(Swift.min(Swift.max(base, minimum), maximum) * 1_000_000_000)
+        }
 
         // MARK: - MainThreadStackSampler
 
@@ -113,7 +120,19 @@
                 }
                 state.tokens = makeLifecycleTokens()
 
-                let thread = Thread { [weak self] in self?.run() }
+                // The worker shares this sampler's lock-free state but not `self`, so the poll thread
+                // never retains the sampler; that keeps `deinit { stop() }` a real backstop.
+                let worker = PollWorker(
+                    running: running,
+                    paused: paused,
+                    busySince: busySince,
+                    buffer: buffer,
+                    mainThread: mainThread,
+                    triggerNanos: triggerNanos,
+                    pollNanos: pollNanos,
+                    bufferCap: bufferCap
+                )
+                let thread = Thread { worker.run() }
                 thread.name = "io.embrace.hang.sampler"
                 thread.qualityOfService = .userInitiated
                 state.thread = thread
@@ -170,14 +189,62 @@
             }
         }
 
-        // MARK: - Background sampling loop
+        // MARK: - App lifecycle (raw names to avoid a UIKit dependency)
 
-        private func run() {
-            // The `busySince` value we last captured for. Poller-local: no synchronization needed.
+        private func makeLifecycleTokens() -> [NSObjectProtocol] {
+            let nc = NotificationCenter.default
+            return [
+                nc.addObserver(
+                    forName: Notification.Name("UIApplicationDidEnterBackgroundNotification"),
+                    object: nil, queue: nil
+                ) { [weak self] _ in self?.pause() },
+                nc.addObserver(
+                    forName: Notification.Name("UIApplicationWillEnterForegroundNotification"),
+                    object: nil, queue: nil
+                ) { [weak self] _ in self?.resume() }
+            ]
+        }
+    }
+
+    /// The background poll loop. Holds only the shared lock-free state, never the sampler, so the
+    /// sampler's lifetime is not pinned to the loop's — the thread closure retains this worker
+    /// instead. The shared atomics/buffer stay alive as long as the loop runs.
+    private final class PollWorker {
+        private let running: EmbraceAtomic<Bool>
+        private let paused: EmbraceAtomic<Bool>
+        private let busySince: EmbraceAtomic<UInt64>
+        private let buffer: EmbraceMutex<[MainThreadStackSample]>
+        private let mainThread: pthread_t
+        private let triggerNanos: UInt64
+        private let pollNanos: UInt64
+        private let bufferCap: Int
+
+        init(
+            running: EmbraceAtomic<Bool>,
+            paused: EmbraceAtomic<Bool>,
+            busySince: EmbraceAtomic<UInt64>,
+            buffer: EmbraceMutex<[MainThreadStackSample]>,
+            mainThread: pthread_t,
+            triggerNanos: UInt64,
+            pollNanos: UInt64,
+            bufferCap: Int
+        ) {
+            self.running = running
+            self.paused = paused
+            self.busySince = busySince
+            self.buffer = buffer
+            self.mainThread = mainThread
+            self.triggerNanos = triggerNanos
+            self.pollNanos = pollNanos
+            self.bufferCap = bufferCap
+        }
+
+        func run() {
+            // The `busySince` value we last captured for. Loop-local: no synchronization needed.
             var lastSampledEpoch: UInt64 = 0
 
             while running.load(order: .acquire) {
-                usleep(pollMicros)
+                Self.sleep(nanos: pollNanos)
 
                 guard !paused.load(order: .acquire) else { continue }
 
@@ -212,20 +279,12 @@
             }
         }
 
-        // MARK: - App lifecycle (raw names to avoid a UIKit dependency)
-
-        private func makeLifecycleTokens() -> [NSObjectProtocol] {
-            let nc = NotificationCenter.default
-            return [
-                nc.addObserver(
-                    forName: Notification.Name("UIApplicationDidEnterBackgroundNotification"),
-                    object: nil, queue: nil
-                ) { [weak self] _ in self?.pause() },
-                nc.addObserver(
-                    forName: Notification.Name("UIApplicationWillEnterForegroundNotification"),
-                    object: nil, queue: nil
-                ) { [weak self] _ in self?.resume() }
-            ]
+        private static func sleep(nanos: UInt64) {
+            var ts = timespec(
+                tv_sec: Int(nanos / 1_000_000_000),
+                tv_nsec: Int(nanos % 1_000_000_000)
+            )
+            nanosleep(&ts, nil)
         }
     }
 

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -98,7 +98,7 @@
                     min: HangLimits.minSamplePollInterval,
                     max: HangLimits.maxSamplePollInterval
                 ),
-                bufferCap: bufferCap
+                bufferCap: Swift.max(1, bufferCap)  // a non-positive cap would trap the ring-buffer trim
             )
             self.logger = logger
         }

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/StallTriggeredSampler.swift
@@ -12,6 +12,28 @@
         import EmbraceObjCUtilsInternal
     #endif
 
+    /// Lock-free state shared between the sampler and its background poll loop. Both hold the **same**
+    /// instance (it's a reference type), so the main-thread beacon's writes, the public lifecycle
+    /// calls, and the loop all observe one source of truth. Bundling it into a single object is what
+    /// lets the loop share exactly this state and nothing else — the worker is handed this, never the
+    /// sampler — so there's no way to accidentally wire the loop to atomics nobody writes to.
+    private final class SharedPollState {
+        /// `CLOCK_MONOTONIC_RAW` ns when the current busy epoch began; `0` when the run loop is idle.
+        /// Written by the main-thread beacon, read by the background poller.
+        let busySince = EmbraceAtomic<UInt64>(0)
+        let paused = EmbraceAtomic<Bool>(false)
+        let running = EmbraceAtomic<Bool>(false)
+        let buffer = EmbraceMutex<[MainThreadStackSample]>([])
+    }
+
+    /// Immutable poll-loop configuration. All value types, safe to copy into the worker.
+    private struct PollConfig {
+        let mainThread: pthread_t
+        let triggerNanos: UInt64
+        let pollNanos: UInt64
+        let bufferCap: Int
+    }
+
     /// Detects that the main thread *looks* stalled and captures a single during-block backtrace of
     /// it from a background thread. It does **not** decide whether a hang is reported —
     /// `FrameRateMonitor` (CADisplayLink) remains the authority. This only supplies the stack;
@@ -32,19 +54,9 @@
     /// window that CADisplayLink later confirms.
     final class StallTriggeredSampler: MainThreadStackSampler {
 
-        private let mainThread: pthread_t
-        private let triggerNanos: UInt64
-        private let pollNanos: UInt64
-        private let bufferCap: Int
+        private let shared = SharedPollState()
+        private let config: PollConfig
         private weak var logger: InternalLogger?
-
-        /// `CLOCK_MONOTONIC_RAW` ns when the current busy epoch began; `0` when the run loop is idle.
-        /// Written by the main-thread beacon, read by the background poller.
-        private let busySince = EmbraceAtomic<UInt64>(0)
-        private let paused = EmbraceAtomic<Bool>(false)
-        private let running = EmbraceAtomic<Bool>(false)
-
-        private let buffer = EmbraceMutex<[MainThreadStackSample]>([])
 
         /// Lifecycle-owned resources. Guarded by a mutex so `start()`/`stop()` are mutually exclusive
         /// and these fields are never touched unlocked — the poll thread and the beacon never read
@@ -72,30 +84,32 @@
             bufferCap: Int = 8,
             logger: InternalLogger?
         ) {
-            self.mainThread = mainThread
-            self.triggerNanos = Self.clampedNanos(
-                triggerThreshold,
-                fallback: HangLimits.defaultSampleTriggerThreshold,
-                min: HangLimits.minSampleTriggerThreshold,
-                max: HangLimits.maxSampleTriggerThreshold
+            self.config = PollConfig(
+                mainThread: mainThread,
+                triggerNanos: Self.clampedNanos(
+                    triggerThreshold,
+                    fallback: HangLimits.defaultSampleTriggerThreshold,
+                    min: HangLimits.minSampleTriggerThreshold,
+                    max: HangLimits.maxSampleTriggerThreshold
+                ),
+                pollNanos: Self.clampedNanos(
+                    pollInterval,
+                    fallback: HangLimits.defaultSamplePollInterval,
+                    min: HangLimits.minSamplePollInterval,
+                    max: HangLimits.maxSamplePollInterval
+                ),
+                bufferCap: bufferCap
             )
-            self.pollNanos = Self.clampedNanos(
-                pollInterval,
-                fallback: HangLimits.defaultSamplePollInterval,
-                min: HangLimits.minSamplePollInterval,
-                max: HangLimits.maxSamplePollInterval
-            )
-            self.bufferCap = bufferCap
             self.logger = logger
         }
 
         deinit { stop() }
 
         /// Effective trigger after clamping, in seconds. Exposed for tests.
-        var effectiveTriggerThreshold: TimeInterval { TimeInterval(triggerNanos) / 1_000_000_000 }
+        var effectiveTriggerThreshold: TimeInterval { TimeInterval(config.triggerNanos) / 1_000_000_000 }
 
         /// Effective poll cadence after clamping, in seconds. Exposed for tests.
-        var effectivePollInterval: TimeInterval { TimeInterval(pollNanos) / 1_000_000_000 }
+        var effectivePollInterval: TimeInterval { TimeInterval(config.pollNanos) / 1_000_000_000 }
 
         /// Values reaching `HangLimits` are already clamped; this is the defense-in-depth for direct
         /// callers. A non-finite value falls back to `fallback`; otherwise it is clamped into
@@ -114,8 +128,8 @@
 
         func start() {
             lifecycle.withLock { state in
-                guard !running.load(order: .acquire) else { return }
-                running.store(true, order: .release)
+                guard !shared.running.load(order: .acquire) else { return }
+                shared.running.store(true, order: .release)
 
                 if !EmbraceBacktrace.isAvailable {
                     logger?.warning(
@@ -129,18 +143,9 @@
                 }
                 state.tokens = makeLifecycleTokens()
 
-                // The worker shares this sampler's lock-free state but not `self`, so the poll thread
+                // The worker is handed the shared state and config but never `self`, so the poll thread
                 // never retains the sampler; that keeps `deinit { stop() }` a real backstop.
-                let worker = PollWorker(
-                    running: running,
-                    paused: paused,
-                    busySince: busySince,
-                    buffer: buffer,
-                    mainThread: mainThread,
-                    triggerNanos: triggerNanos,
-                    pollNanos: pollNanos,
-                    bufferCap: bufferCap
-                )
+                let worker = PollWorker(shared: shared, config: config)
                 let thread = Thread { worker.run() }
                 thread.name = "io.embrace.hang.sampler"
                 thread.qualityOfService = .userInitiated
@@ -151,8 +156,8 @@
 
         func stop() {
             lifecycle.withLock { state in
-                guard running.load(order: .acquire) else { return }
-                running.store(false, order: .release)
+                guard shared.running.load(order: .acquire) else { return }
+                shared.running.store(false, order: .release)
 
                 if let observer = state.observer {
                     CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes)
@@ -164,22 +169,22 @@
                 state.tokens = []
 
                 state.thread = nil
-                busySince.store(0, order: .release)
+                shared.busySince.store(0, order: .release)
             }
         }
 
         func pause() {
-            paused.store(true, order: .release)
-            busySince.store(0, order: .release)  // forget the current epoch across background
+            shared.paused.store(true, order: .release)
+            shared.busySince.store(0, order: .release)  // forget the current epoch across background
         }
 
         func resume() {
-            busySince.store(0, order: .release)  // fresh start; the beacon repopulates it
-            paused.store(false, order: .release)
+            shared.busySince.store(0, order: .release)  // fresh start; the beacon repopulates it
+            shared.paused.store(false, order: .release)
         }
 
         func samples(in range: ClosedRange<UInt64>) -> [MainThreadStackSample] {
-            buffer.withLock { $0.filter { range.contains($0.timestamp) } }
+            shared.buffer.withLock { $0.filter { range.contains($0.timestamp) } }
         }
 
         // MARK: - Main-thread liveness beacon
@@ -190,10 +195,10 @@
                 [weak self] _, activity in
                 guard let self else { return }
                 if activity == .beforeWaiting {
-                    self.busySince.store(0, order: .release)  // going idle → not a hang
+                    self.shared.busySince.store(0, order: .release)  // going idle → not a hang
                 } else {
                     // .afterWaiting → a busy epoch begins. One atomic store, nothing else.
-                    self.busySince.store(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW), order: .release)
+                    self.shared.busySince.store(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW), order: .release)
                 }
             }
         }
@@ -215,53 +220,32 @@
         }
     }
 
-    /// The background poll loop. Holds only the shared lock-free state, never the sampler, so the
-    /// sampler's lifetime is not pinned to the loop's — the thread closure retains this worker
-    /// instead. The shared atomics/buffer stay alive as long as the loop runs.
+    /// The background poll loop. Holds only the shared lock-free state and the immutable config,
+    /// never the sampler, so the sampler's lifetime is not pinned to the loop's — the thread closure
+    /// retains this worker instead. The shared state stays alive as long as the loop runs.
     private final class PollWorker {
-        private let running: EmbraceAtomic<Bool>
-        private let paused: EmbraceAtomic<Bool>
-        private let busySince: EmbraceAtomic<UInt64>
-        private let buffer: EmbraceMutex<[MainThreadStackSample]>
-        private let mainThread: pthread_t
-        private let triggerNanos: UInt64
-        private let pollNanos: UInt64
-        private let bufferCap: Int
+        private let shared: SharedPollState
+        private let config: PollConfig
 
-        init(
-            running: EmbraceAtomic<Bool>,
-            paused: EmbraceAtomic<Bool>,
-            busySince: EmbraceAtomic<UInt64>,
-            buffer: EmbraceMutex<[MainThreadStackSample]>,
-            mainThread: pthread_t,
-            triggerNanos: UInt64,
-            pollNanos: UInt64,
-            bufferCap: Int
-        ) {
-            self.running = running
-            self.paused = paused
-            self.busySince = busySince
-            self.buffer = buffer
-            self.mainThread = mainThread
-            self.triggerNanos = triggerNanos
-            self.pollNanos = pollNanos
-            self.bufferCap = bufferCap
+        init(shared: SharedPollState, config: PollConfig) {
+            self.shared = shared
+            self.config = config
         }
 
         func run() {
             // The `busySince` value we last captured for. Loop-local: no synchronization needed.
             var lastSampledEpoch: UInt64 = 0
 
-            while running.load(order: .acquire) {
-                Self.sleep(nanos: pollNanos)
+            while shared.running.load(order: .acquire) {
+                Self.sleep(nanos: config.pollNanos)
 
-                guard !paused.load(order: .acquire) else { continue }
+                guard !shared.paused.load(order: .acquire) else { continue }
 
-                let since = busySince.load(order: .acquire)
+                let since = shared.busySince.load(order: .acquire)
                 guard since != 0, since != lastSampledEpoch else { continue }
 
                 let now = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
-                guard now &- since >= triggerNanos else { continue }
+                guard now &- since >= config.triggerNanos else { continue }
 
                 lastSampledEpoch = since  // one snapshot per stall episode
                 captureSample()
@@ -272,7 +256,7 @@
             guard EmbraceBacktrace.isAvailable else { return }
 
             let pre = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
-            let backtrace = EmbraceBacktrace.backtrace(of: mainThread, threadIndex: 0)  // suspends main; alloc-free
+            let backtrace = EmbraceBacktrace.backtrace(of: config.mainThread, threadIndex: 0)  // suspends main; alloc-free
             let post = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
 
             let sample = MainThreadStackSample(
@@ -280,10 +264,10 @@
                 overhead: post &- pre,
                 backtrace: backtrace
             )
-            buffer.withLock {
+            shared.buffer.withLock {
                 $0.append(sample)
-                if $0.count > bufferCap {
-                    $0.removeFirst($0.count - bufferCap)
+                if $0.count > config.bufferCap {
+                    $0.removeFirst($0.count - config.bufferCap)
                 }
             }
         }

--- a/Sources/EmbraceCore/Options/Embrace+Options.swift
+++ b/Sources/EmbraceCore/Options/Embrace+Options.swift
@@ -45,10 +45,11 @@ extension Embrace {
         ///   - logLevel: The `LogLevel` to use for console logs.
         ///   - export: `OpenTelemetryExport` object to export telemetry using OpenTelemetry protocols
         ///   - processors: `OpenTelemetryProcessor` objects to do extra processing
-        ///   - backtracer: Optional `Backtracer` to capture stack traces. Defaults to the
-        ///     built-in mechanism, which is sufficient for most apps.
-        ///   - symbolicator: Optional `Symbolicator` to resolve frames into symbols;
-        ///     without it, only raw addresses are shown.
+        ///   - backtracer: Optional `Backtracer` used to capture stack traces. Defaults to `nil`;
+        ///     when `nil`, custom stack-trace capture is disabled. `EmbraceIO`'s convenience options
+        ///     wire in a built-in `Backtracer` for you.
+        ///   - symbolicator: Optional `Symbolicator` used to resolve frames into symbols. Defaults to
+        ///     `nil`; when `nil`, unresolved frames are dropped rather than emitted as raw addresses.
         @objc public init(
             appId: String,
             appGroupId: String? = nil,

--- a/Sources/EmbraceCore/Options/Embrace+Options.swift
+++ b/Sources/EmbraceCore/Options/Embrace+Options.swift
@@ -10,6 +10,7 @@ import Foundation
     import EmbraceOTelInternal
     import EmbraceConfigInternal
     import EmbraceConfiguration
+    import EmbraceKSCrashBacktraceSupport
 #endif
 
 extension Embrace {
@@ -45,11 +46,11 @@ extension Embrace {
         ///   - logLevel: The `LogLevel` to use for console logs.
         ///   - export: `OpenTelemetryExport` object to export telemetry using OpenTelemetry protocols
         ///   - processors: `OpenTelemetryProcessor` objects to do extra processing
-        ///   - backtracer: Optional `Backtracer` used to capture stack traces. Defaults to `nil`;
-        ///     when `nil`, custom stack-trace capture is disabled. `EmbraceIO`'s convenience options
-        ///     wire in a built-in `Backtracer` for you.
+        ///   - backtracer: Optional `Backtracer` used to capture stack traces. Defaults to the
+        ///     built-in `KSCrashBacktracing`; pass `nil` to disable custom stack-trace capture.
         ///   - symbolicator: Optional `Symbolicator` used to resolve frames into symbols. Defaults to
-        ///     `nil`; when `nil`, unresolved frames are dropped rather than emitted as raw addresses.
+        ///     the built-in `KSCrashBacktracing`; pass `nil` to disable symbolication (unresolved
+        ///     frames are then dropped rather than emitted as raw addresses).
         @objc public init(
             appId: String,
             appGroupId: String? = nil,
@@ -60,8 +61,8 @@ extension Embrace {
             logLevel: LogLevel = .default,
             export: OpenTelemetryExport? = nil,
             processors: [OpenTelemetryProcessor]? = nil,
-            backtracer: Backtracer? = nil,
-            symbolicator: Symbolicator? = nil
+            backtracer: Backtracer? = KSCrashBacktracing(),
+            symbolicator: Symbolicator? = KSCrashBacktracing()
         ) {
             self.appId = appId
             self.appGroupId = appGroupId
@@ -97,8 +98,8 @@ extension Embrace {
             crashReporter: CrashReporter?,
             logLevel: LogLevel = .default,
             runtimeConfiguration: EmbraceConfigurable = .default,
-            backtracer: Backtracer? = nil,
-            symbolicator: Symbolicator? = nil
+            backtracer: Backtracer? = KSCrashBacktracing(),
+            symbolicator: Symbolicator? = KSCrashBacktracing()
         ) {
             self.appId = nil
             self.appGroupId = nil

--- a/Sources/ThirdParty/EmbraceKSCrashBacktraceSupport/EmbraceKSCrashBacktraceSupport.swift
+++ b/Sources/ThirdParty/EmbraceKSCrashBacktraceSupport/EmbraceKSCrashBacktraceSupport.swift
@@ -37,6 +37,19 @@ public class KSCrashBacktracing: Backtracer, Symbolicator {
         return addresses
     }
 
+    public func backtrace(
+        of thread: pthread_t,
+        into buffer: UnsafeMutablePointer<FrameAddress>,
+        capacity: Int
+    ) -> Int {
+        // Alloc-free / async-signal-safe: `ksbt_captureBacktrace` fills the caller's buffer in place
+        // using stack-allocated machine context + stack cursor (no malloc, no runtime calls), so it
+        // is safe to run while `thread` is suspended. The `pthread_self()` workaround in
+        // `backtrace(of:)` is intentionally NOT replicated here: this entry point is only used to walk
+        // a *suspended* thread, which is never the caller.
+        return Int(captureBacktrace(thread: thread, addresses: buffer, count: Int32(capacity)))
+    }
+
     public func resolve(address: UInt) -> SymbolicatedFrame? {
 
         var result = SymbolInformation()

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfig/RemoteConfigPayloadTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfig/RemoteConfigPayloadTests.swift
@@ -43,6 +43,8 @@ class RemoteConfigPayloadTests: XCTestCase {
         XCTAssertEqual(payload.internalLogsErrorLimit, 3)
         XCTAssertEqual(payload.networkPayloadCaptureRules.count, 0)
         XCTAssertEqual(payload.hangLimitsHangThreshold, 0.249)
+        XCTAssertEqual(payload.hangLimitsSampleTriggerThreshold, 0.15)
+        XCTAssertEqual(payload.hangLimitsSamplePollInterval, 0.05)
     }
 
     func testOnHavingValidRemoteConfig_RemoteConfigPayload_shouldOverridedDefaultValuesWithProvidedOnes() throws {
@@ -94,6 +96,8 @@ class RemoteConfigPayloadTests: XCTestCase {
         XCTAssertEqual(payload.hangLimitsHangThreshold, 0.5)
         XCTAssertEqual(payload.hangLimitsHangPerSession, 100)
         XCTAssertEqual(payload.hangLimitsReportsWatchdogEvents, true)
+        XCTAssertEqual(payload.hangLimitsSampleTriggerThreshold, 0.2)
+        XCTAssertEqual(payload.hangLimitsSamplePollInterval, 0.03)
     }
 
     func test_onHavingOldAndInvalidRemoteConfigPayload_RemoteConfigPayload_shouldBeCreatedWithDefaults() throws {
@@ -128,6 +132,8 @@ class RemoteConfigPayloadTests: XCTestCase {
         XCTAssertEqual(payload.internalLogsErrorLimit, 3)
         XCTAssertEqual(payload.networkPayloadCaptureRules.count, 0)
         XCTAssertEqual(payload.hangLimitsHangThreshold, 0.249)
+        XCTAssertEqual(payload.hangLimitsSampleTriggerThreshold, 0.15)
+        XCTAssertEqual(payload.hangLimitsSamplePollInterval, 0.05)
     }
 
     func getRemoteConfigData(forResource resource: String) throws -> Data {

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
@@ -179,4 +179,41 @@ final class RemoteConfigTests: XCTestCase {
         config.payload.networkPayloadCaptureRules = [rule1, rule2]
         XCTAssertEqual(config.networkPayloadCaptureRules, [rule1, rule2])
     }
+
+    // MARK: - Hang limit corrections
+
+    func test_hangLimitCorrections_emptyForValidPayload() {
+        // Default payload values are all in range.
+        XCTAssertTrue(RemoteConfig.hangLimitCorrections(for: RemoteConfigPayload()).isEmpty)
+    }
+
+    func test_hangLimitCorrections_flagsOutOfRangeSampleTrigger() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsSampleTriggerThreshold = 5000  // would overflow the ns conversion → clamped
+        let corrections = RemoteConfig.hangLimitCorrections(for: payload)
+        XCTAssertEqual(corrections.count, 1)
+        XCTAssertTrue(corrections.first?.contains("sample_trigger_threshold") ?? false)
+    }
+
+    func test_hangLimitCorrections_flagsOutOfRangeSamplePollInterval() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsSamplePollInterval = 5000
+        let corrections = RemoteConfig.hangLimitCorrections(for: payload)
+        XCTAssertEqual(corrections.count, 1)
+        XCTAssertTrue(corrections.first?.contains("sample_poll_interval") ?? false)
+    }
+
+    func test_hangLimitCorrections_flagsNonPositiveHangThreshold() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsHangThreshold = -1
+        XCTAssertTrue(RemoteConfig.hangLimitCorrections(for: payload).contains { $0.contains("hang_threshold") })
+    }
+
+    func test_hangLimitCorrections_flagsTriggerNotBelowHangThreshold() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsHangThreshold = 0.1
+        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → re-derived below it
+        XCTAssertTrue(
+            RemoteConfig.hangLimitCorrections(for: payload).contains { $0.contains("sample_trigger_threshold") })
+    }
 }

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
@@ -200,9 +200,16 @@ final class RemoteConfigTests: XCTestCase {
     func test_hangLimitCorrections_reportsCapWhenTriggerAtOrAboveHangThreshold() {
         var payload = RemoteConfigPayload()
         payload.hangLimitsHangThreshold = 0.1
-        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → inconsistent, capped
+        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → capped below it
         let msg = RemoteConfig.hangLimitCorrections(for: payload).first { $0.contains("sample_trigger_threshold") } ?? ""
         XCTAssertTrue(msg.contains("capped"), "a trigger >= hang_threshold should be reported as capped: \(msg)")
+    }
+
+    func test_hangLimitCorrections_reportsAboveMaxForOversizedSampleTrigger() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsSampleTriggerThreshold = 5000  // > max → likely a seconds/ms mixup
+        let msg = RemoteConfig.hangLimitCorrections(for: payload).first { $0.contains("sample_trigger_threshold") } ?? ""
+        XCTAssertTrue(msg.contains("above the max"), "an oversized trigger should be reported as above the max: \(msg)")
     }
 
     func test_hangLimitCorrections_silentForInRangeTriggerTrimmedByCap() {

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
@@ -197,12 +197,23 @@ final class RemoteConfigTests: XCTestCase {
         XCTAssertTrue(msg.contains("clamped"), "an out-of-range trigger should be reported as a clamp: \(msg)")
     }
 
-    func test_hangLimitCorrections_reportsReDerivationWhenTriggerNotBelowHangThreshold() {
+    func test_hangLimitCorrections_reportsCapWhenTriggerAtOrAboveHangThreshold() {
         var payload = RemoteConfigPayload()
         payload.hangLimitsHangThreshold = 0.1
-        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → re-derived below it
+        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → inconsistent, capped
         let msg = RemoteConfig.hangLimitCorrections(for: payload).first { $0.contains("sample_trigger_threshold") } ?? ""
-        XCTAssertTrue(msg.contains("re-derived"), "a trigger >= hang_threshold should be reported as re-derived: \(msg)")
+        XCTAssertTrue(msg.contains("capped"), "a trigger >= hang_threshold should be reported as capped: \(msg)")
+    }
+
+    func test_hangLimitCorrections_silentForInRangeTriggerTrimmedByCap() {
+        // 0.2 is a valid request (< hangThreshold) that the routine 60% cap trims to ~0.149. That's
+        // expected policy, not a misconfiguration, so it must NOT be reported.
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsHangThreshold = 0.249
+        payload.hangLimitsSampleTriggerThreshold = 0.2
+        XCTAssertFalse(
+            RemoteConfig.hangLimitCorrections(for: payload).contains { $0.contains("sample_trigger_threshold") },
+            "a valid-but-capped trigger should not be reported as a correction")
     }
 
     func test_hangLimitCorrections_reportsFallbackForNonFiniteSampleTrigger() {

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
@@ -227,4 +227,36 @@ final class RemoteConfigTests: XCTestCase {
         payload.hangLimitsHangThreshold = -1
         XCTAssertTrue(RemoteConfig.hangLimitCorrections(for: payload).contains { $0.contains("hang_threshold") })
     }
+
+    // MARK: - Hang correction logging is wired into config updates
+
+    func test_update_logsHangCorrections_onlyWhenPayloadChanges() {
+        let recording = MockLogger()
+        let fetcher = StubRemoteConfigFetcher(options: options, logger: recording)
+        let config = RemoteConfig(options: options, fetcher: fetcher, logger: recording)
+
+        var bad = RemoteConfigPayload()
+        bad.hangLimitsSampleTriggerThreshold = 5000  // out of range → HangLimits corrects it
+        fetcher.payloadToReturn = bad
+
+        func hangWarnings() -> Int {
+            recording.loggedMessages.filter { $0.message.contains("[Hang] remote config value out of range") }.count
+        }
+
+        // First fetch: payload changed from the default → the correction is logged once.
+        config.update { _, _ in }
+        XCTAssertEqual(hangWarnings(), 1, "a changed out-of-range payload should log its correction")
+
+        // Second fetch: identical payload → didUpdate is false → must not re-log.
+        config.update { _, _ in }
+        XCTAssertEqual(hangWarnings(), 1, "an unchanged payload must not re-log (didUpdate gate)")
+    }
+}
+
+/// Returns a canned payload synchronously instead of hitting the network.
+private final class StubRemoteConfigFetcher: RemoteConfigFetcher {
+    var payloadToReturn: RemoteConfigPayload?
+    override func fetch(completion: @escaping (RemoteConfigPayload?, Data?) -> Void) {
+        completion(payloadToReturn, nil)
+    }
 }

--- a/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
+++ b/Tests/EmbraceConfigInternalTests/EmbraceConfigurable/RemoteConfigTests.swift
@@ -187,33 +187,44 @@ final class RemoteConfigTests: XCTestCase {
         XCTAssertTrue(RemoteConfig.hangLimitCorrections(for: RemoteConfigPayload()).isEmpty)
     }
 
-    func test_hangLimitCorrections_flagsOutOfRangeSampleTrigger() {
+    func test_hangLimitCorrections_reportsClampForOutOfRangeSampleTrigger() {
         var payload = RemoteConfigPayload()
-        payload.hangLimitsSampleTriggerThreshold = 5000  // would overflow the ns conversion → clamped
+        payload.hangLimitsSampleTriggerThreshold = 0.0001  // below floor, still < hangThreshold → clamp
         let corrections = RemoteConfig.hangLimitCorrections(for: payload)
         XCTAssertEqual(corrections.count, 1)
-        XCTAssertTrue(corrections.first?.contains("sample_trigger_threshold") ?? false)
+        let msg = corrections.first ?? ""
+        XCTAssertTrue(msg.contains("sample_trigger_threshold"))
+        XCTAssertTrue(msg.contains("clamped"), "an out-of-range trigger should be reported as a clamp: \(msg)")
     }
 
-    func test_hangLimitCorrections_flagsOutOfRangeSamplePollInterval() {
+    func test_hangLimitCorrections_reportsReDerivationWhenTriggerNotBelowHangThreshold() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsHangThreshold = 0.1
+        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → re-derived below it
+        let msg = RemoteConfig.hangLimitCorrections(for: payload).first { $0.contains("sample_trigger_threshold") } ?? ""
+        XCTAssertTrue(msg.contains("re-derived"), "a trigger >= hang_threshold should be reported as re-derived: \(msg)")
+    }
+
+    func test_hangLimitCorrections_reportsFallbackForNonFiniteSampleTrigger() {
+        var payload = RemoteConfigPayload()
+        payload.hangLimitsSampleTriggerThreshold = .nan
+        let msg = RemoteConfig.hangLimitCorrections(for: payload).first { $0.contains("sample_trigger_threshold") } ?? ""
+        XCTAssertTrue(msg.contains("not finite"), "a non-finite trigger should be reported as a fallback: \(msg)")
+    }
+
+    func test_hangLimitCorrections_reportsClampForOutOfRangeSamplePollInterval() {
         var payload = RemoteConfigPayload()
         payload.hangLimitsSamplePollInterval = 5000
         let corrections = RemoteConfig.hangLimitCorrections(for: payload)
         XCTAssertEqual(corrections.count, 1)
-        XCTAssertTrue(corrections.first?.contains("sample_poll_interval") ?? false)
+        let msg = corrections.first ?? ""
+        XCTAssertTrue(msg.contains("sample_poll_interval"))
+        XCTAssertTrue(msg.contains("clamped"), "an out-of-range poll interval should be reported as a clamp: \(msg)")
     }
 
     func test_hangLimitCorrections_flagsNonPositiveHangThreshold() {
         var payload = RemoteConfigPayload()
         payload.hangLimitsHangThreshold = -1
         XCTAssertTrue(RemoteConfig.hangLimitCorrections(for: payload).contains { $0.contains("hang_threshold") })
-    }
-
-    func test_hangLimitCorrections_flagsTriggerNotBelowHangThreshold() {
-        var payload = RemoteConfigPayload()
-        payload.hangLimitsHangThreshold = 0.1
-        payload.hangLimitsSampleTriggerThreshold = 0.15  // >= hangThreshold → re-derived below it
-        XCTAssertTrue(
-            RemoteConfig.hangLimitCorrections(for: payload).contains { $0.contains("sample_trigger_threshold") })
     }
 }

--- a/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
+++ b/Tests/EmbraceConfigInternalTests/Fixtures/remote_config.json
@@ -52,6 +52,8 @@
     "hang_limits_v2": {
         "hang_threshold": 0.5,
         "hang_per_session": 100,
-        "reports_watchdog_events": true
+        "reports_watchdog_events": true,
+        "sample_trigger_threshold": 0.2,
+        "sample_poll_interval": 0.03
     }
 }

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -1,0 +1,68 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceConfiguration
+import XCTest
+
+final class HangLimitsTests: XCTestCase {
+
+    func test_init_hasCorrectDefaultValues() {
+        let limits = HangLimits()
+        XCTAssertEqual(limits.hangThreshold, HangLimits.defaultHangThreshold)
+        XCTAssertEqual(limits.hangPerSession, HangLimits.defaultHangPerSession)
+        XCTAssertEqual(limits.reportsWatchdogEvents, HangLimits.defaultReportsWatchdogEvents)
+        XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.defaultSampleTriggerThreshold)
+        XCTAssertEqual(limits.samplePollInterval, HangLimits.defaultSamplePollInterval)
+    }
+
+    // MARK: - Sampler value clamping (the trap-prevention fix)
+
+    func test_init_clampsSampleValuesUpToMinimum() {
+        let limits = HangLimits(sampleTriggerThreshold: 0.0001, samplePollInterval: 0.0001)
+        XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.minSampleTriggerThreshold)
+        XCTAssertEqual(limits.samplePollInterval, HangLimits.minSamplePollInterval)
+    }
+
+    func test_init_clampsSampleValuesDownToMaximum() {
+        // A seconds/ms mixup like 5000 would previously overflow the sampler's `useconds_t`/`UInt64`
+        // conversion and trap the process; the upper clamp is what prevents that.
+        let limits = HangLimits(sampleTriggerThreshold: 5000, samplePollInterval: 5000)
+        XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.maxSampleTriggerThreshold)
+        XCTAssertEqual(limits.samplePollInterval, HangLimits.maxSamplePollInterval)
+    }
+
+    func test_init_fallsBackToDefaultForNonFiniteSampleValues() {
+        for bad in [Double.nan, .infinity, -.infinity] {
+            let limits = HangLimits(sampleTriggerThreshold: bad, samplePollInterval: bad)
+            XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.defaultSampleTriggerThreshold)
+            XCTAssertEqual(limits.samplePollInterval, HangLimits.defaultSamplePollInterval)
+        }
+    }
+
+    func test_init_preservesInRangeSampleValues() {
+        let limits = HangLimits(sampleTriggerThreshold: 0.2, samplePollInterval: 0.03)
+        XCTAssertEqual(limits.sampleTriggerThreshold, 0.2, accuracy: 1e-9)
+        XCTAssertEqual(limits.samplePollInterval, 0.03, accuracy: 1e-9)
+    }
+
+    // MARK: - hangThreshold sanitization
+
+    func test_init_sanitizesNonPositiveOrNonFiniteHangThreshold() {
+        for bad in [0, -1, Double.nan, .infinity] {
+            let limits = HangLimits(hangThreshold: bad)
+            XCTAssertEqual(limits.hangThreshold, HangLimits.defaultHangThreshold)
+        }
+    }
+
+    func test_init_preservesValidHangThreshold() {
+        XCTAssertEqual(HangLimits(hangThreshold: 0.5).hangThreshold, 0.5, accuracy: 1e-9)
+    }
+
+    // MARK: - Bounds sanity
+
+    func test_bounds_areOrdered() {
+        XCTAssertLessThan(HangLimits.minSampleTriggerThreshold, HangLimits.maxSampleTriggerThreshold)
+        XCTAssertLessThan(HangLimits.minSamplePollInterval, HangLimits.maxSamplePollInterval)
+    }
+}

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -59,6 +59,22 @@ final class HangLimitsTests: XCTestCase {
         XCTAssertEqual(HangLimits(hangThreshold: 0.5).hangThreshold, 0.5, accuracy: 1e-9)
     }
 
+    // MARK: - Equality / hashing (NSObject contract)
+
+    func test_equalInstances_shareHashAndAreEqual() {
+        let a = HangLimits(hangThreshold: 0.3, hangPerSession: 5, samplePollInterval: 0.02)
+        let b = HangLimits(hangThreshold: 0.3, hangPerSession: 5, samplePollInterval: 0.02)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hash, b.hash, "equal HangLimits must return the same hash (NSObject contract)")
+        XCTAssertEqual(Set([a, b]).count, 1, "equal instances should dedupe in a Set")
+    }
+
+    func test_differingInstances_areNotEqual() {
+        let a = HangLimits(hangThreshold: 0.3)
+        let b = HangLimits(hangThreshold: 0.4)
+        XCTAssertNotEqual(a, b)
+    }
+
     // MARK: - Bounds sanity
 
     func test_bounds_areOrdered() {

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -24,12 +24,17 @@ final class HangLimitsTests: XCTestCase {
         XCTAssertEqual(limits.samplePollInterval, HangLimits.minSamplePollInterval)
     }
 
-    func test_init_clampsSampleValuesDownToMaximum() {
-        // A seconds/ms mixup like 5000 would previously overflow the sampler's `useconds_t`/`UInt64`
-        // conversion and trap the process; the upper clamp is what prevents that.
-        let limits = HangLimits(sampleTriggerThreshold: 5000, samplePollInterval: 5000)
+    func test_init_clampsSamplePollIntervalDownToMaximum() {
+        // A seconds/ms mixup like 5000 would previously overflow the sampler's `UInt64` ns conversion
+        // and trap the process; the upper clamp is what prevents that.
+        XCTAssertEqual(
+            HangLimits(samplePollInterval: 5000).samplePollInterval, HangLimits.maxSamplePollInterval)
+    }
+
+    func test_init_clampsSampleTriggerDownToMaximum() {
+        // Use a large hangThreshold so the trigger ceiling — not the below-hangThreshold rule — applies.
+        let limits = HangLimits(hangThreshold: 5000, sampleTriggerThreshold: 5000)
         XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.maxSampleTriggerThreshold)
-        XCTAssertEqual(limits.samplePollInterval, HangLimits.maxSamplePollInterval)
     }
 
     func test_init_fallsBackToDefaultForNonFiniteSampleValues() {
@@ -44,6 +49,29 @@ final class HangLimitsTests: XCTestCase {
         let limits = HangLimits(sampleTriggerThreshold: 0.2, samplePollInterval: 0.03)
         XCTAssertEqual(limits.sampleTriggerThreshold, 0.2, accuracy: 1e-9)
         XCTAssertEqual(limits.samplePollInterval, 0.03, accuracy: 1e-9)
+    }
+
+    // MARK: - Trigger kept below hangThreshold
+
+    func test_init_capsSampleTriggerBelowHangThresholdForInconsistentConfig() {
+        // trigger (0.15) >= hangThreshold (0.1) is inconsistent; re-derive below hangThreshold.
+        let limits = HangLimits(hangThreshold: 0.1, sampleTriggerThreshold: 0.15)
+        XCTAssertLessThan(limits.sampleTriggerThreshold, limits.hangThreshold)
+        XCTAssertEqual(limits.sampleTriggerThreshold, 0.1 * HangLimits.sampleTriggerFraction, accuracy: 1e-9)
+    }
+
+    func test_init_preservesSampleTriggerWhenBelowHangThreshold() {
+        // Valid config (0.15 < 0.249): trigger is left untouched.
+        XCTAssertEqual(
+            HangLimits(hangThreshold: 0.249, sampleTriggerThreshold: 0.15).sampleTriggerThreshold,
+            0.15, accuracy: 1e-9)
+    }
+
+    func test_init_orderingKeepsDerivedTriggerBounded_forHugeHangThreshold() {
+        // A huge hangThreshold must not leak into the trigger's ns conversion (overflow guard).
+        let limits = HangLimits(hangThreshold: 1e12, sampleTriggerThreshold: 5000)
+        XCTAssertLessThanOrEqual(limits.sampleTriggerThreshold, HangLimits.maxSampleTriggerThreshold)
+        XCTAssertLessThan(limits.sampleTriggerThreshold, limits.hangThreshold)
     }
 
     // MARK: - hangThreshold sanitization

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -110,4 +110,11 @@ final class HangLimitsTests: XCTestCase {
         XCTAssertLessThan(HangLimits.minSampleTriggerThreshold, HangLimits.maxSampleTriggerThreshold)
         XCTAssertLessThan(HangLimits.minSamplePollInterval, HangLimits.maxSamplePollInterval)
     }
+
+    func test_sampleTriggerFraction_isBelowOne() {
+        // The re-derivation `hangThreshold * sampleTriggerFraction` only stays below hangThreshold
+        // while the fraction is < 1. Pin it so that invariant can't silently break.
+        XCTAssertGreaterThan(HangLimits.sampleTriggerFraction, 0)
+        XCTAssertLessThan(HangLimits.sampleTriggerFraction, 1)
+    }
 }

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -2,8 +2,9 @@
 //  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
 //
 
-import EmbraceConfiguration
 import XCTest
+
+@testable import EmbraceConfiguration
 
 final class HangLimitsTests: XCTestCase {
 
@@ -77,7 +78,7 @@ final class HangLimitsTests: XCTestCase {
     // MARK: - hangThreshold sanitization
 
     func test_init_sanitizesNonPositiveOrNonFiniteHangThreshold() {
-        for bad in [0, -1, Double.nan, .infinity] {
+        for bad in [0, -1, Double.nan, .infinity, -.infinity] {
             let limits = HangLimits(hangThreshold: bad)
             XCTAssertEqual(limits.hangThreshold, HangLimits.defaultHangThreshold)
         }

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -13,7 +13,11 @@ final class HangLimitsTests: XCTestCase {
         XCTAssertEqual(limits.hangThreshold, HangLimits.defaultHangThreshold)
         XCTAssertEqual(limits.hangPerSession, HangLimits.defaultHangPerSession)
         XCTAssertEqual(limits.reportsWatchdogEvents, HangLimits.defaultReportsWatchdogEvents)
-        XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.defaultSampleTriggerThreshold)
+        // The default trigger (0.15) exceeds the cap (60% of the default hangThreshold), so it lands
+        // exactly at the cap.
+        XCTAssertEqual(
+            limits.sampleTriggerThreshold,
+            HangLimits.defaultHangThreshold * HangLimits.sampleTriggerFraction, accuracy: 1e-9)
         XCTAssertEqual(limits.samplePollInterval, HangLimits.defaultSamplePollInterval)
     }
 
@@ -33,39 +37,45 @@ final class HangLimitsTests: XCTestCase {
     }
 
     func test_init_clampsSampleTriggerDownToMaximum() {
-        // Use a large hangThreshold so the trigger ceiling — not the below-hangThreshold rule — applies.
-        let limits = HangLimits(hangThreshold: 5000, sampleTriggerThreshold: 5000)
+        // hangThreshold large enough that 60% of it exceeds the absolute max, so the max is the binding cap.
+        let limits = HangLimits(hangThreshold: 10000, sampleTriggerThreshold: 5000)
         XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.maxSampleTriggerThreshold)
     }
 
     func test_init_fallsBackToDefaultForNonFiniteSampleValues() {
+        // hangThreshold high enough that the default trigger isn't capped, isolating the fallback.
         for bad in [Double.nan, .infinity, -.infinity] {
-            let limits = HangLimits(sampleTriggerThreshold: bad, samplePollInterval: bad)
+            let limits = HangLimits(hangThreshold: 1.0, sampleTriggerThreshold: bad, samplePollInterval: bad)
             XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.defaultSampleTriggerThreshold)
             XCTAssertEqual(limits.samplePollInterval, HangLimits.defaultSamplePollInterval)
         }
     }
 
-    func test_init_preservesInRangeSampleValues() {
-        let limits = HangLimits(sampleTriggerThreshold: 0.2, samplePollInterval: 0.03)
-        XCTAssertEqual(limits.sampleTriggerThreshold, 0.2, accuracy: 1e-9)
+    // MARK: - Trigger capped at a fraction of hangThreshold
+
+    func test_init_preservesSampleTriggerBelowCap() {
+        // A trigger below the cap (0.6 × 0.249 ≈ 0.149) is used as-is; poll in range is preserved.
+        let limits = HangLimits(hangThreshold: 0.249, sampleTriggerThreshold: 0.12, samplePollInterval: 0.03)
+        XCTAssertEqual(limits.sampleTriggerThreshold, 0.12, accuracy: 1e-9)
         XCTAssertEqual(limits.samplePollInterval, 0.03, accuracy: 1e-9)
     }
 
-    // MARK: - Trigger kept below hangThreshold
-
-    func test_init_capsSampleTriggerBelowHangThresholdForInconsistentConfig() {
-        // trigger (0.15) >= hangThreshold (0.1) is inconsistent; re-derive below hangThreshold.
-        let limits = HangLimits(hangThreshold: 0.1, sampleTriggerThreshold: 0.15)
+    func test_init_capsSampleTriggerAtFractionOfHangThreshold() {
+        // 0.15 exceeds 60% of hangThreshold → capped to exactly that fraction (still below hangThreshold).
+        let limits = HangLimits(hangThreshold: 0.249, sampleTriggerThreshold: 0.15)
         XCTAssertLessThan(limits.sampleTriggerThreshold, limits.hangThreshold)
-        XCTAssertEqual(limits.sampleTriggerThreshold, 0.1 * HangLimits.sampleTriggerFraction, accuracy: 1e-9)
+        XCTAssertEqual(
+            limits.sampleTriggerThreshold,
+            limits.hangThreshold * HangLimits.sampleTriggerFraction, accuracy: 1e-9)
     }
 
-    func test_init_preservesSampleTriggerWhenBelowHangThreshold() {
-        // Valid config (0.15 < 0.249): trigger is left untouched.
+    func test_init_capsSampleTriggerWhenRequestedAtOrAboveHangThreshold() {
+        // Even a trigger >= hangThreshold caps to the fraction, not just an out-of-range value.
+        let limits = HangLimits(hangThreshold: 0.1, sampleTriggerThreshold: 0.15)
+        XCTAssertLessThan(limits.sampleTriggerThreshold, limits.hangThreshold)
         XCTAssertEqual(
-            HangLimits(hangThreshold: 0.249, sampleTriggerThreshold: 0.15).sampleTriggerThreshold,
-            0.15, accuracy: 1e-9)
+            limits.sampleTriggerThreshold,
+            limits.hangThreshold * HangLimits.sampleTriggerFraction, accuracy: 1e-9)
     }
 
     func test_init_orderingKeepsDerivedTriggerBounded_forHugeHangThreshold() {

--- a/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
+++ b/Tests/EmbraceConfigurationTests/HangLimitsTests.swift
@@ -85,6 +85,16 @@ final class HangLimitsTests: XCTestCase {
         XCTAssertLessThan(limits.sampleTriggerThreshold, limits.hangThreshold)
     }
 
+    func test_init_floorWinsOverCapForSmallHangThreshold() {
+        // hangThreshold below minSampleTriggerThreshold / sampleTriggerFraction (≈ 0.083): 60% of it
+        // (≈ 0.036) is below the floor, so the floor takes precedence over the cap. Guards the
+        // `max(…, minSampleTriggerThreshold)` in the ceiling — without it the trigger would dip below
+        // the floor. (For an even smaller hangThreshold ≤ the floor the below-hangThreshold guarantee is
+        // intentionally sacrificed; that's a degenerate config, documented on `sampleTriggerThreshold`.)
+        let limits = HangLimits(hangThreshold: 0.06, sampleTriggerThreshold: 0.05)
+        XCTAssertEqual(limits.sampleTriggerThreshold, HangLimits.minSampleTriggerThreshold, accuracy: 1e-9)
+    }
+
     // MARK: - hangThreshold sanitization
 
     func test_init_sanitizesNonPositiveOrNonFiniteHangThreshold() {
@@ -122,8 +132,8 @@ final class HangLimitsTests: XCTestCase {
     }
 
     func test_sampleTriggerFraction_isBelowOne() {
-        // The re-derivation `hangThreshold * sampleTriggerFraction` only stays below hangThreshold
-        // while the fraction is < 1. Pin it so that invariant can't silently break.
+        // The cap `hangThreshold * sampleTriggerFraction` only stays below hangThreshold while the
+        // fraction is < 1. Pin it so that invariant can't silently break.
         XCTAssertGreaterThan(HangLimits.sampleTriggerFraction, 0)
         XCTAssertLessThan(HangLimits.sampleTriggerFraction, 1)
     }

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceConcurrencyTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceConcurrencyTests.swift
@@ -26,6 +26,11 @@
     final class HangCaptureServiceConcurrencyTests: XCTestCase {
 
         func test_concurrentConfigUpdatesAndStop_areRaceFreeAndDoNotDeadlock() {
+            // Precondition: no backtracer configured, so the sampler's KSCrash walk (unsafe under
+            // sanitizers) never runs. Fail loudly if another test left a client/backtracer installed,
+            // rather than silently changing what this test exercises under TSan.
+            XCTAssertFalse(EmbraceBacktrace.isAvailable, "no Embrace.client/backtracer should be set for this test")
+
             let otel = MockEmbraceOpenTelemetry()
             let service = HangCaptureService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
             service.install(otel: otel)

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceConcurrencyTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceConcurrencyTests.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+    import TestSupport
+    import XCTest
+
+    @testable import EmbraceConfiguration
+    @testable import EmbraceCore
+
+    /// Thread-safety stress for `HangCaptureService`'s activate/stop/config-update surface — a path
+    /// with no other concurrency coverage. Payoff is under the **thread** sanitizer (CI: `push: main`
+    /// and PRs labeled `ci:sanitizers`), where it surfaces data races in the concurrent build/swap/stop
+    /// of the monitor+sampler; in a plain run it guards against deadlock and crashes under contention.
+    ///
+    /// Note: the final post-quiesce assertion is a smoke check, not a guard on the `activate()`
+    /// "stopped mid-build" (`!stored`) branch — a transient orphan there is cleaned up by the next
+    /// stop/rebuild, so it wouldn't survive to the end. That branch rests on review + the isolated
+    /// `onStop`/inactive-`onConfigUpdated` tests.
+    ///
+    /// No `Embrace.client` is set up (only a mock otel), so `EmbraceBacktrace.isAvailable` is false and
+    /// the KSCrash walk (unsafe under sanitizers) never runs in-window.
+    final class HangCaptureServiceConcurrencyTests: XCTestCase {
+
+        func test_concurrentConfigUpdatesAndStop_areRaceFreeAndDoNotDeadlock() {
+            let otel = MockEmbraceOpenTelemetry()
+            let service = HangCaptureService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
+            service.install(otel: otel)
+            service.start()
+
+            let iterations = 500
+            let group = DispatchGroup()
+
+            // Config-update storm: alternate thresholds so each update is a real rebuild.
+            DispatchQueue.global(qos: .userInitiated).async(group: group) {
+                for i in 0..<iterations {
+                    let threshold = (i % 2 == 0) ? 0.249 : 0.5
+                    service.onConfigUpdated(
+                        MockEmbraceConfigurable(hangLimits: HangLimits(hangThreshold: threshold, hangPerSession: 6)))
+                    if i % 8 == 0 { sched_yield() }  // widen interleavings
+                }
+            }
+            // Lifecycle storm: toggle stop/start to race the activate() commit window.
+            DispatchQueue.global(qos: .userInitiated).async(group: group) {
+                for i in 0..<iterations {
+                    service.stop()
+                    service.start()
+                    if i % 8 == 0 { sched_yield() }
+                }
+            }
+
+            let outcome = group.wait(timeout: .now() + 60)
+            XCTAssertEqual(outcome, .success, "config-update/stop stress deadlocked in HangCaptureService")
+
+            // Quiesce, then assert no leak: after a final stop, neither sampler nor monitor remains.
+            service.stop()
+            XCTAssertNil(service.limitData.withLock { $0.sampler }, "no sampler should remain after stop")
+            XCTAssertNil(service.limitData.withLock { $0.watchdog }, "no monitor should remain after stop")
+        }
+    }
+
+#endif

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -164,6 +164,45 @@
             wait(delay: 0.3)
             XCTAssertEqual(otel.spanProcessor.startedSpans.filter { $0.name == SpanSemantics.Hang.name }.count, 0)
         }
+
+        // MARK: - During-block sampler wiring
+
+        func test_hangStarted_attachesNoStackEvent() {
+            let service = makeInstalledService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
+
+            service.hangStarted(at: Date(), duration: 0.5)
+
+            wait(timeout: .defaultTimeout) {
+                self.otel.spanProcessor.startedSpans.contains { $0.name == SpanSemantics.Hang.name }
+            }
+            // The stack is attached at hangEnded from the sampler now; nothing is captured on-main here.
+            let span = otel.spanProcessor.startedSpans.first { $0.name == SpanSemantics.Hang.name }
+            XCTAssertEqual(span?.events.filter { $0.name == SpanEventSemantics.Hang.name }.count, 0)
+        }
+
+        func test_hangEnded_queriesSamplerWithReconciledWindow() {
+            let service = makeInstalledService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
+            let sampler = MockMainThreadStackSampler()
+            service.limitData.withLock {
+                $0.sampler?.stop()
+                $0.sampler = sampler
+            }
+
+            let start = Date()
+            service.hangStarted(at: start, duration: 0.5)
+            service.hangEnded(at: start.addingTimeInterval(0.5), duration: 0.5)
+
+            wait(timeout: .defaultTimeout) {
+                self.otel.spanProcessor.endedSpans.contains { $0.name == SpanSemantics.Hang.name }
+            }
+
+            // hangEnded reconciles a monotonic window ≈ duration + tolerance, then queries the sampler.
+            XCTAssertEqual(sampler.queriedRanges.count, 1)
+            if let range = sampler.queriedRanges.first {
+                let widthMs = Double(range.upperBound - range.lowerBound) / 1_000_000
+                XCTAssertEqual(widthMs, 520, accuracy: 80)  // 500 ms duration + 20 ms tolerance
+            }
+        }
     }
 
     // MARK: - Test Helpers
@@ -295,6 +334,22 @@
             lock.unlock()
 
             callback?(at, duration)
+        }
+    }
+
+    /// Records the windows it is queried with and returns canned samples (optionally range-filtered).
+    final class MockMainThreadStackSampler: MainThreadStackSampler {
+        var cannedSamples: [MainThreadStackSample] = []
+        var respectRange = true
+        private(set) var queriedRanges: [ClosedRange<UInt64>] = []
+
+        func start() {}
+        func stop() {}
+        func pause() {}
+        func resume() {}
+        func samples(in range: ClosedRange<UInt64>) -> [MainThreadStackSample] {
+            queriedRanges.append(range)
+            return respectRange ? cannedSamples.filter { range.contains($0.timestamp) } : cannedSamples
         }
     }
 

--- a/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/HangCaptureServiceTests.swift
@@ -146,6 +146,37 @@
             XCTAssertEqual(otel.spanProcessor.endedSpans.filter { $0.name == SpanSemantics.Hang.name }.count, 2)
         }
 
+        // MARK: - Lifecycle teardown
+
+        func test_onStop_tearsDownSamplerAndMonitor() {
+            let service = makeInstalledService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
+            let sampler = MockMainThreadStackSampler()
+            service.limitData.withLock {
+                $0.sampler?.stop()
+                $0.sampler = sampler
+            }
+
+            service.stop()
+
+            let (samplerAfter, watchdogAfter) = service.limitData.withLock { ($0.sampler, $0.watchdog) }
+            XCTAssertNil(samplerAfter, "onStop should clear the sampler")
+            XCTAssertNil(watchdogAfter, "onStop should clear the monitor")
+            XCTAssertTrue(sampler.stopCalled, "onStop should stop the sampler")
+        }
+
+        func test_onConfigUpdated_onInactiveService_storesLimitsButDoesNotActivateSampler() {
+            // Installed-but-never-started service is not active.
+            let service = HangCaptureService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
+
+            let newLimits = HangLimits(hangThreshold: 0.5, hangPerSession: 6)
+            service.onConfigUpdated(MockEmbraceConfigurable(hangLimits: newLimits))
+
+            XCTAssertEqual(service.limits.hangThreshold, 0.5, "new limits should still be stored")
+            XCTAssertNil(
+                service.limitData.withLock { $0.sampler },
+                "a config update on an inactive service must not spin up a sampler")
+        }
+
         // MARK: - Config disables monitor
 
         func test_onConfigUpdated_disablesHangs_whenPerSessionIsZero() {
@@ -342,9 +373,11 @@
         var cannedSamples: [MainThreadStackSample] = []
         var respectRange = true
         private(set) var queriedRanges: [ClosedRange<UInt64>] = []
+        private(set) var startCalled = false
+        private(set) var stopCalled = false
 
-        func start() {}
-        func stop() {}
+        func start() { startCalled = true }
+        func stop() { stopCalled = true }
         func pause() {}
         func resume() {}
         func samples(in range: ClosedRange<UInt64>) -> [MainThreadStackSample] {

--- a/Tests/EmbraceCoreTests/Capture/Hang/StallTriggeredSamplerConcurrencyTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/StallTriggeredSamplerConcurrencyTests.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+    import XCTest
+
+    @testable import EmbraceCore
+
+    /// Thread-safety stress for `StallTriggeredSampler`. The payoff comes when run under the
+    /// **thread** sanitizer (CI runs it on `push: main` and on PRs labeled `ci:sanitizers`): the hand
+    /// written lifecycle/atomic code is hammered from many threads so TSan can surface data races. In
+    /// a plain run it still guards against deadlocks and crashes under contention.
+    ///
+    /// No `Embrace.client` is set up on purpose: `captureSample()` early-returns when no backtracer is
+    /// available, so the KSCrash walk (unsafe under sanitizers) never runs — leaving only the sampler's
+    /// own concurrency under test.
+    ///
+    /// Note: there is no per-suspend "injected delay" seam here because the suspend window is
+    /// single-threaded (only the one poll thread ever suspends/walks). The real concurrency lives in
+    /// the lifecycle + state surface, which this exercises directly.
+    final class StallTriggeredSamplerConcurrencyTests: XCTestCase {
+
+        func test_concurrentLifecycleAndQueries_areRaceFreeAndDoNotDeadlock() {
+            let sampler = StallTriggeredSampler(
+                mainThread: pthread_self(),
+                triggerThreshold: 0.05,
+                pollInterval: 0.01,
+                logger: nil
+            )
+            defer { sampler.stop() }
+
+            let threadCount = 6
+            let iterations = 1_000
+            let group = DispatchGroup()
+
+            for worker in 0..<threadCount {
+                DispatchQueue.global(qos: .userInitiated).async(group: group) {
+                    // Cheap per-thread PRNG (no shared Foundation RNG state to muddy the race picture).
+                    var seed = UInt64(worker + 1) &* 0x9E37_79B9_7F4A_7C15
+                    func next() -> UInt64 {
+                        seed = seed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+                        return seed >> 33
+                    }
+
+                    for _ in 0..<iterations {
+                        switch next() % 10 {
+                        case 0: sampler.start()
+                        case 1: sampler.stop()
+                        case 2: sampler.pause()
+                        case 3: sampler.resume()
+                        default:
+                            let lo = next()
+                            _ = sampler.samples(in: lo...(lo &+ 1_000_000))
+                        }
+                        if next() % 8 == 0 { sched_yield() }  // widen interleavings
+                    }
+                }
+            }
+
+            let outcome = group.wait(timeout: .now() + 60)
+            XCTAssertEqual(
+                outcome, .success,
+                "Concurrency stress did not finish within the timeout — a deadlock in the sampler's "
+                    + "lifecycle/state handling."
+            )
+        }
+    }
+
+#endif

--- a/Tests/EmbraceCoreTests/Capture/Hang/StallTriggeredSamplerConcurrencyTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/StallTriggeredSamplerConcurrencyTests.swift
@@ -67,6 +67,31 @@
                     + "lifecycle/state handling."
             )
         }
+
+        /// The poll loop must not retain the sampler (it holds only the shared state), so `deinit`
+        /// stays a real backstop: dropping the last strong reference — even after `start()` and
+        /// *without* an explicit `stop()` — must deallocate the sampler. A regression that captured
+        /// `self` in the poll thread would keep it alive forever and fail this.
+        func test_deinit_deallocatesWithoutExplicitStop() {
+            weak var weakSampler: StallTriggeredSampler?
+            autoreleasepool {
+                let sampler = StallTriggeredSampler(
+                    mainThread: pthread_self(),
+                    triggerThreshold: 0.05,
+                    pollInterval: 0.01,
+                    logger: nil
+                )
+                sampler.start()
+                weakSampler = sampler
+                // leave scope without calling stop()
+            }
+
+            let deadline = Date().addingTimeInterval(2)
+            while weakSampler != nil && Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+            XCTAssertNil(weakSampler, "sampler leaked: the poll thread is retaining self (deinit backstop broken)")
+        }
     }
 
 #endif

--- a/Tests/EmbraceCoreTests/Capture/Hang/StallTriggeredSamplerConcurrencyTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Hang/StallTriggeredSamplerConcurrencyTests.swift
@@ -68,10 +68,11 @@
             )
         }
 
-        /// The poll loop must not retain the sampler (it holds only the shared state), so `deinit`
-        /// stays a real backstop: dropping the last strong reference — even after `start()` and
-        /// *without* an explicit `stop()` — must deallocate the sampler. A regression that captured
-        /// `self` in the poll thread would keep it alive forever and fail this.
+        /// No strong reference may outlive the sampler's scope: the poll loop holds only the shared
+        /// state (never `self`), and the run-loop observer and lifecycle tokens capture `[weak self]`.
+        /// So dropping the last strong reference — even after `start()` and *without* an explicit
+        /// `stop()` — must deallocate it, with `deinit { stop() }` as the backstop. A regression that
+        /// strongly captured `self` in the poll thread would keep it alive forever and fail this.
         func test_deinit_deallocatesWithoutExplicitStop() {
             weak var weakSampler: StallTriggeredSampler?
             autoreleasepool {

--- a/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
@@ -154,7 +154,7 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
 
     // MARK: - addBackTrace Tests
 
-    func test_onAddBacktrace_doesNothing() {
+    func test_addBacktrace_addsStacktraceAttribute() {
         givenSessionController()
         givenMetadataFetcher()
         givenEmbraceLogAttributesBuilder()

--- a/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/Logs/EmbraceLogAttributesBuilderTests.swift
@@ -159,7 +159,11 @@ class EmbraceLogAttributesBuilderTests: XCTestCase {
         givenMetadataFetcher()
         givenEmbraceLogAttributesBuilder()
 
-        sut.addBacktrace(EmbraceBacktrace.backtrace())
+        // A canned single-thread backtrace: `addBacktrace` only needs a non-empty thread list, so
+        // this avoids depending on a configured backtracer to capture one.
+        let thread = EmbraceBacktraceThread(index: 0, callstack: .init(addresses: [0x1], count: 1))
+        let backtrace = EmbraceBacktrace(timestampUnits: .nanoseconds, timestamp: 0, threads: [thread])
+        sut.addBacktrace(backtrace)
         whenInvokingBuild()
 
         thenResultingAttributes(containsKey: "emb.stacktrace.ios")

--- a/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
+++ b/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
@@ -25,6 +25,13 @@ final class Embrace_OptionsTests: XCTestCase {
         XCTAssertTrue(options.symbolicator is KSCrashBacktracing)
     }
 
+    func test_init_exportOverload_defaultsToBuiltInBacktracerAndSymbolicator() throws {
+        // The export/no-appId initializer gets the same built-in defaults as the appId one.
+        let options = Embrace.Options(export: OpenTelemetryExport(), captureServices: [], crashReporter: nil)
+        XCTAssertTrue(options.backtracer is KSCrashBacktracing)
+        XCTAssertTrue(options.symbolicator is KSCrashBacktracing)
+    }
+
     func test_init_backtracerAndSymbolicatorAreOverridableToNil() throws {
         let options = Embrace.Options(
             appId: "myApp", captureServices: [], crashReporter: nil, backtracer: nil, symbolicator: nil)

--- a/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
+++ b/Tests/EmbraceCoreTests/Options/Embrace+OptionsTests.swift
@@ -5,6 +5,7 @@
 import EmbraceConfigInternal
 import EmbraceConfiguration
 import EmbraceCore
+import EmbraceKSCrashBacktraceSupport
 import EmbraceOTelInternal
 import TestSupport
 import XCTest
@@ -15,6 +16,20 @@ final class Embrace_OptionsTests: XCTestCase {
         let options = Embrace.Options(appId: "myApp", captureServices: [], crashReporter: nil)
         XCTAssertEqual(options.appId, "myApp")
         XCTAssertNil(options.export)
+    }
+
+    func test_init_defaultsToBuiltInBacktracerAndSymbolicator() throws {
+        // Symbolication works out of the box for EmbraceCore-only integrators (matches 7.0).
+        let options = Embrace.Options(appId: "myApp", captureServices: [], crashReporter: nil)
+        XCTAssertTrue(options.backtracer is KSCrashBacktracing)
+        XCTAssertTrue(options.symbolicator is KSCrashBacktracing)
+    }
+
+    func test_init_backtracerAndSymbolicatorAreOverridableToNil() throws {
+        let options = Embrace.Options(
+            appId: "myApp", captureServices: [], crashReporter: nil, backtracer: nil, symbolicator: nil)
+        XCTAssertNil(options.backtracer)
+        XCTAssertNil(options.symbolicator)
     }
 
     func test_init_withEndpoints_setsEndpoints() throws {

--- a/Tests/EmbraceIOTests/BacktraceFrameSkipTests.swift
+++ b/Tests/EmbraceIOTests/BacktraceFrameSkipTests.swift
@@ -1,0 +1,217 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import Foundation
+import TestSupport
+import TestSupportObjc
+import XCTest
+
+@testable import EmbraceCore
+@testable import EmbraceIO
+
+/// A distinctively-named, deliberately un-inlinable self-capture site.
+///
+/// It walks its *own* thread (`pthread_self()`), so `_takeSnapshot` applies
+/// ``EmbraceBacktrace/selfCaptureFrameSkip``. If that constant is correct, this function is frame 0
+/// of the returned backtrace. `@inline(never)` guarantees the frame exists so the test isn't fooled
+/// by the *caller's* inlining — only the SDK's internal wrapper depth is under test.
+@inline(never)
+private func embFrameSkipPinnedCaller() -> EmbraceBacktrace {
+    EmbraceBacktrace.backtrace(of: pthread_self(), threadIndex: 0)
+}
+
+/// A distinctively-named, un-inlinable function a background thread parks in while another thread
+/// suspends and walks it. Publishes its own `pthread_t`, signals `ready`, then blocks on `hold` — so
+/// while the walker runs, this frame is guaranteed to be on the parked thread's stack.
+@inline(never)
+private func embFrameSkipParkedThread(
+    ready: DispatchSemaphore,
+    hold: DispatchSemaphore,
+    publish: (pthread_t) -> Void
+) {
+    publish(pthread_self())
+    ready.signal()
+    hold.wait()
+}
+
+private final class PThreadBox {
+    var value: pthread_t?
+}
+
+/// Pins the hardcoded backtrace frame-skip constants against the *real* SDK capture chain.
+///
+/// These constants are wrapper *depth*, not semantics: they only stay correct while the internal
+/// call chain above the caller is unchanged and the optimizer doesn't inline a wrapper away. This
+/// test converts a silent regression (traces that start one frame off) into a loud CI failure that
+/// points at the constant to update. It must pass in **both Debug and Release** — inlining can shift
+/// the depth between configurations, and if it does, a single constant is insufficient.
+final class BacktraceFrameSkipTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        // Wires the default backtracer + symbolicator (`KSCrashBacktracing`) onto `Embrace.client`,
+        // which `EmbraceBacktrace` reads. Without it, capture returns no frames.
+        _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
+    }
+
+    override class func tearDown() {
+        _ = try? Embrace.client?.stop()
+        Embrace.client = nil
+        super.tearDown()
+    }
+
+    func test_selfCaptureFrameSkip_landsFrameZeroOnCaller() throws {
+        // ksbic_init (KSCrash binary-image cache) is not safe under sanitizer instrumentation:
+        // TSan aborts; ASan deadlocks until the job cap fires. Symbolication is required here.
+        try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+
+        let frames = embFrameSkipPinnedCaller().threads.first?.callstack.frames(symbolicated: true) ?? []
+        let topNames = frames.prefix(8).map { $0.symbol?.name ?? "<nil>" }
+
+        XCTAssertTrue(
+            frames.first?.symbol?.name.contains("embFrameSkipPinnedCaller") == true,
+            """
+            selfCaptureFrameSkip (\(EmbraceBacktrace.selfCaptureFrameSkip)) no longer lands frame 0 on \
+            the self-capture caller. Top frames after the skip were:
+            \(topNames.enumerated().map { "  [\($0.offset)] \($0.element)" }.joined(separator: "\n"))
+            The SDK capture-wrapper depth changed (an internal refactor, or the optimizer inlined a \
+            wrapper). Find `embFrameSkipPinnedCaller` in the list above, set `selfCaptureFrameSkip` so \
+            it becomes frame 0, and re-run this test in Debug AND Release before landing the change.
+            """
+        )
+    }
+
+    /// Exercises the off-main / `canSuspend == true` path: allocate buffer → suspend → alloc-free
+    /// `backtrace(of:into:capacity:)` → resume → slice. Proves the alloc-free route returns the
+    /// *target* thread's real frames with skip 0 (no SDK plumbing on top).
+    func test_suspendCapture_returnsTargetFramesWithNoSDKPlumbingOnTop() throws {
+        try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+
+        let ready = DispatchSemaphore(value: 0)
+        let hold = DispatchSemaphore(value: 0)
+        let box = PThreadBox()
+
+        let thread = Thread {
+            embFrameSkipParkedThread(ready: ready, hold: hold) { box.value = $0 }
+        }
+        thread.name = "emb.frameskip.parked"
+        thread.start()
+
+        // `ready` ordering guarantees `box.value` is published and the thread is inside
+        // `embFrameSkipParkedThread` (about to / already blocked on `hold`) before we walk it.
+        ready.wait()
+        defer { hold.signal() }  // let the parked thread finish no matter how the test exits
+
+        let target = try XCTUnwrap(box.value, "parked thread did not publish its pthread_t")
+        let frames =
+            EmbraceBacktrace.backtrace(of: target, threadIndex: 0)
+            .threads.first?.callstack.frames(symbolicated: true) ?? []
+        let names = frames.compactMap { $0.symbol?.name }
+
+        // (a) alloc-free suspend walk produced real frames.
+        XCTAssertFalse(frames.isEmpty, "suspend-path capture returned no frames")
+
+        // (b) we walked the RIGHT thread and skip 0 kept its real code.
+        XCTAssertTrue(
+            names.contains { $0.contains("embFrameSkipParkedThread") },
+            "parked function missing from the target thread's backtrace; names: \(names.prefix(12))"
+        )
+
+        // (c) skip 0 on the suspend path means the SDK's own capture wrappers are NOT on top
+        //     (that was the bug on the self path when applied to a suspended thread).
+        let topName = frames.first?.symbol?.name ?? ""
+        for wrapper in ["_takeSnapshot", "takeSnapshot", "EmbraceBacktrace"] {
+            XCTAssertFalse(
+                topName.contains(wrapper),
+                "SDK wrapper '\(wrapper)' leaked to the top of a suspended-thread capture: \(topName)"
+            )
+        }
+    }
+}
+
+/// Proves the thread-suspend backtrace window performs **no heap allocation** — the property that
+/// prevents the #423-class whole-process deadlock (walker allocates while the suspended thread holds
+/// the allocator lock).
+///
+/// The `test_...positiveControl...` test is not optional bookkeeping: a zero-violation result in the
+/// real test is only meaningful if we've proven the tripwire actually fires. If the positive control
+/// ever fails, `malloc_logger` isn't being invoked in this environment and the sentinel must move to
+/// symbol interposition (fishhook) before its results can be trusted.
+final class SuspendWindowSentinelTests: XCTestCase {
+
+    override class func setUp() {
+        super.setUp()
+        _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
+    }
+
+    override class func tearDown() {
+        _ = try? Embrace.client?.stop()
+        Embrace.client = nil
+        super.tearDown()
+    }
+
+    /// Positive control: a deliberate in-window allocation MUST be seen. Validates the mechanism.
+    func test_sentinel_positiveControl_detectsInWindowAllocation() throws {
+        try XCTSkipIfSanitizing("malloc interposition conflicts with sanitizer allocators")
+
+        EMBSuspendWindowSentinelArm()
+        defer { EMBSuspendWindowSentinelDisarm() }
+        EMBSuspendWindowSentinelResetViolations()
+
+        EMBSuspendWindowSentinelBeginWindow()
+        let p = malloc(32)
+        XCTAssertNotNil(p)
+        free(p)
+        EMBSuspendWindowSentinelEndWindow()
+
+        XCTAssertGreaterThan(
+            EMBSuspendWindowSentinelViolationCount(), 0,
+            """
+            The sentinel did not observe a deliberate in-window allocation. `malloc_logger` is not \
+            firing in this environment, so a zero-violation result in the real test is meaningless. \
+            Switch the sentinel to symbol interposition (fishhook) before trusting it.
+            """
+        )
+    }
+
+    #if DEBUG
+        /// The real test: walking a suspended thread must allocate nothing between suspend and resume.
+        func test_suspendWindow_performsNoAllocation() throws {
+            try XCTSkipIfSanitizing("KSCrash + malloc interposition are unsafe under sanitizer instrumentation")
+
+            let ready = DispatchSemaphore(value: 0)
+            let hold = DispatchSemaphore(value: 0)
+            let box = PThreadBox()
+            let thread = Thread {
+                embFrameSkipParkedThread(ready: ready, hold: hold) { box.value = $0 }
+            }
+            thread.name = "emb.sentinel.parked"
+            thread.start()
+            ready.wait()
+            defer { hold.signal() }
+            let target = try XCTUnwrap(box.value, "parked thread did not publish its pthread_t")
+
+            EMBSuspendWindowSentinelArm()
+            EmbraceBacktraceSuspendWindowProbe.willEnter = { EMBSuspendWindowSentinelBeginWindow() }
+            EmbraceBacktraceSuspendWindowProbe.didExit = { EMBSuspendWindowSentinelEndWindow() }
+            defer {
+                EmbraceBacktraceSuspendWindowProbe.willEnter = nil
+                EmbraceBacktraceSuspendWindowProbe.didExit = nil
+                EMBSuspendWindowSentinelDisarm()
+            }
+            EMBSuspendWindowSentinelResetViolations()
+
+            _ = EmbraceBacktrace.backtrace(of: target, threadIndex: 0)
+
+            XCTAssertEqual(
+                EMBSuspendWindowSentinelViolationCount(), 0,
+                """
+                An allocation occurred inside the thread-suspend window — the #423-class deadlock \
+                hazard. Inspect what runs between `willEnter`/`didExit` in `_takeSnapshot` (the \
+                `backtracer.backtrace(of:into:capacity:)` call and anything it triggers).
+                """
+            )
+        }
+    #endif
+}

--- a/Tests/EmbraceIOTests/BacktraceFrameSkipTests.swift
+++ b/Tests/EmbraceIOTests/BacktraceFrameSkipTests.swift
@@ -21,23 +21,31 @@ private func embFrameSkipPinnedCaller() -> EmbraceBacktrace {
     EmbraceBacktrace.backtrace(of: pthread_self(), threadIndex: 0)
 }
 
-/// A distinctively-named, un-inlinable function a background thread parks in while another thread
-/// suspends and walks it. Publishes its own `pthread_t`, signals `ready`, then blocks on `hold` — so
-/// while the walker runs, this frame is guaranteed to be on the parked thread's stack.
-@inline(never)
-private func embFrameSkipParkedThread(
-    ready: DispatchSemaphore,
-    hold: DispatchSemaphore,
-    publish: (pthread_t) -> Void
-) {
-    publish(pthread_self())
-    ready.signal()
-    hold.wait()
-}
+// The suspend-based (off-main) capture path only exists on platforms where the hang feature ships.
+// On watchOS thread suspension is unavailable (`emb_thread_suspend` is a no-op), and macOS is gated
+// out of the feature — so walking another, un-suspended thread there yields nothing. These helpers
+// and the tests that use them are scoped to match.
+#if !os(watchOS) && !os(macOS)
 
-private final class PThreadBox {
-    var value: pthread_t?
-}
+    /// A distinctively-named, un-inlinable function a background thread parks in while another thread
+    /// suspends and walks it. Publishes its own `pthread_t`, signals `ready`, then blocks on `hold` —
+    /// so while the walker runs, this frame is guaranteed to be on the parked thread's stack.
+    @inline(never)
+    private func embFrameSkipParkedThread(
+        ready: DispatchSemaphore,
+        hold: DispatchSemaphore,
+        publish: (pthread_t) -> Void
+    ) {
+        publish(pthread_self())
+        ready.signal()
+        hold.wait()
+    }
+
+    private final class PThreadBox {
+        var value: pthread_t?
+    }
+
+#endif
 
 /// Pins the hardcoded backtrace frame-skip constants against the *real* SDK capture chain.
 ///
@@ -85,49 +93,53 @@ final class BacktraceFrameSkipTests: XCTestCase {
     /// Exercises the off-main / `canSuspend == true` path: allocate buffer → suspend → alloc-free
     /// `backtrace(of:into:capacity:)` → resume → slice. Proves the alloc-free route returns the
     /// *target* thread's real frames with skip 0 (no SDK plumbing on top).
-    func test_suspendCapture_returnsTargetFramesWithNoSDKPlumbingOnTop() throws {
-        try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+    ///
+    /// Only meaningful where the feature ships: watchOS can't suspend threads and macOS is gated out.
+    #if !os(watchOS) && !os(macOS)
+        func test_suspendCapture_returnsTargetFramesWithNoSDKPlumbingOnTop() throws {
+            try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
 
-        let ready = DispatchSemaphore(value: 0)
-        let hold = DispatchSemaphore(value: 0)
-        let box = PThreadBox()
+            let ready = DispatchSemaphore(value: 0)
+            let hold = DispatchSemaphore(value: 0)
+            let box = PThreadBox()
 
-        let thread = Thread {
-            embFrameSkipParkedThread(ready: ready, hold: hold) { box.value = $0 }
-        }
-        thread.name = "emb.frameskip.parked"
-        thread.start()
+            let thread = Thread {
+                embFrameSkipParkedThread(ready: ready, hold: hold) { box.value = $0 }
+            }
+            thread.name = "emb.frameskip.parked"
+            thread.start()
 
-        // `ready` ordering guarantees `box.value` is published and the thread is inside
-        // `embFrameSkipParkedThread` (about to / already blocked on `hold`) before we walk it.
-        ready.wait()
-        defer { hold.signal() }  // let the parked thread finish no matter how the test exits
+            // `ready` ordering guarantees `box.value` is published and the thread is inside
+            // `embFrameSkipParkedThread` (about to / already blocked on `hold`) before we walk it.
+            ready.wait()
+            defer { hold.signal() }  // let the parked thread finish no matter how the test exits
 
-        let target = try XCTUnwrap(box.value, "parked thread did not publish its pthread_t")
-        let frames =
-            EmbraceBacktrace.backtrace(of: target, threadIndex: 0)
-            .threads.first?.callstack.frames(symbolicated: true) ?? []
-        let names = frames.compactMap { $0.symbol?.name }
+            let target = try XCTUnwrap(box.value, "parked thread did not publish its pthread_t")
+            let frames =
+                EmbraceBacktrace.backtrace(of: target, threadIndex: 0)
+                .threads.first?.callstack.frames(symbolicated: true) ?? []
+            let names = frames.compactMap { $0.symbol?.name }
 
-        // (a) alloc-free suspend walk produced real frames.
-        XCTAssertFalse(frames.isEmpty, "suspend-path capture returned no frames")
+            // (a) alloc-free suspend walk produced real frames.
+            XCTAssertFalse(frames.isEmpty, "suspend-path capture returned no frames")
 
-        // (b) we walked the RIGHT thread and skip 0 kept its real code.
-        XCTAssertTrue(
-            names.contains { $0.contains("embFrameSkipParkedThread") },
-            "parked function missing from the target thread's backtrace; names: \(names.prefix(12))"
-        )
-
-        // (c) skip 0 on the suspend path means the SDK's own capture wrappers are NOT on top
-        //     (that was the bug on the self path when applied to a suspended thread).
-        let topName = frames.first?.symbol?.name ?? ""
-        for wrapper in ["_takeSnapshot", "takeSnapshot", "EmbraceBacktrace"] {
-            XCTAssertFalse(
-                topName.contains(wrapper),
-                "SDK wrapper '\(wrapper)' leaked to the top of a suspended-thread capture: \(topName)"
+            // (b) we walked the RIGHT thread and skip 0 kept its real code.
+            XCTAssertTrue(
+                names.contains { $0.contains("embFrameSkipParkedThread") },
+                "parked function missing from the target thread's backtrace; names: \(names.prefix(12))"
             )
+
+            // (c) skip 0 on the suspend path means the SDK's own capture wrappers are NOT on top
+            //     (that was the bug on the self path when applied to a suspended thread).
+            let topName = frames.first?.symbol?.name ?? ""
+            for wrapper in ["_takeSnapshot", "takeSnapshot", "EmbraceBacktrace"] {
+                XCTAssertFalse(
+                    topName.contains(wrapper),
+                    "SDK wrapper '\(wrapper)' leaked to the top of a suspended-thread capture: \(topName)"
+                )
+            }
         }
-    }
+    #endif
 }
 
 /// Proves the thread-suspend backtrace window performs **no heap allocation** — the property that
@@ -138,80 +150,87 @@ final class BacktraceFrameSkipTests: XCTestCase {
 /// real test is only meaningful if we've proven the tripwire actually fires. If the positive control
 /// ever fails, `malloc_logger` isn't being invoked in this environment and the sentinel must move to
 /// symbol interposition (fishhook) before its results can be trusted.
-final class SuspendWindowSentinelTests: XCTestCase {
+///
+/// Scoped to the platforms that have a suspend window at all (watchOS can't suspend threads; macOS is
+/// gated out of the feature).
+#if !os(watchOS) && !os(macOS)
 
-    override class func setUp() {
-        super.setUp()
-        _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
-    }
+    final class SuspendWindowSentinelTests: XCTestCase {
 
-    override class func tearDown() {
-        _ = try? Embrace.client?.stop()
-        Embrace.client = nil
-        super.tearDown()
-    }
+        override class func setUp() {
+            super.setUp()
+            _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
+        }
 
-    /// Positive control: a deliberate in-window allocation MUST be seen. Validates the mechanism.
-    func test_sentinel_positiveControl_detectsInWindowAllocation() throws {
-        try XCTSkipIfSanitizing("malloc interposition conflicts with sanitizer allocators")
+        override class func tearDown() {
+            _ = try? Embrace.client?.stop()
+            Embrace.client = nil
+            super.tearDown()
+        }
 
-        EMBSuspendWindowSentinelArm()
-        defer { EMBSuspendWindowSentinelDisarm() }
-        EMBSuspendWindowSentinelResetViolations()
-
-        EMBSuspendWindowSentinelBeginWindow()
-        let p = malloc(32)
-        XCTAssertNotNil(p)
-        free(p)
-        EMBSuspendWindowSentinelEndWindow()
-
-        XCTAssertGreaterThan(
-            EMBSuspendWindowSentinelViolationCount(), 0,
-            """
-            The sentinel did not observe a deliberate in-window allocation. `malloc_logger` is not \
-            firing in this environment, so a zero-violation result in the real test is meaningless. \
-            Switch the sentinel to symbol interposition (fishhook) before trusting it.
-            """
-        )
-    }
-
-    #if DEBUG
-        /// The real test: walking a suspended thread must allocate nothing between suspend and resume.
-        func test_suspendWindow_performsNoAllocation() throws {
-            try XCTSkipIfSanitizing("KSCrash + malloc interposition are unsafe under sanitizer instrumentation")
-
-            let ready = DispatchSemaphore(value: 0)
-            let hold = DispatchSemaphore(value: 0)
-            let box = PThreadBox()
-            let thread = Thread {
-                embFrameSkipParkedThread(ready: ready, hold: hold) { box.value = $0 }
-            }
-            thread.name = "emb.sentinel.parked"
-            thread.start()
-            ready.wait()
-            defer { hold.signal() }
-            let target = try XCTUnwrap(box.value, "parked thread did not publish its pthread_t")
+        /// Positive control: a deliberate in-window allocation MUST be seen. Validates the mechanism.
+        func test_sentinel_positiveControl_detectsInWindowAllocation() throws {
+            try XCTSkipIfSanitizing("malloc interposition conflicts with sanitizer allocators")
 
             EMBSuspendWindowSentinelArm()
-            EmbraceBacktraceSuspendWindowProbe.willEnter = { EMBSuspendWindowSentinelBeginWindow() }
-            EmbraceBacktraceSuspendWindowProbe.didExit = { EMBSuspendWindowSentinelEndWindow() }
-            defer {
-                EmbraceBacktraceSuspendWindowProbe.willEnter = nil
-                EmbraceBacktraceSuspendWindowProbe.didExit = nil
-                EMBSuspendWindowSentinelDisarm()
-            }
+            defer { EMBSuspendWindowSentinelDisarm() }
             EMBSuspendWindowSentinelResetViolations()
 
-            _ = EmbraceBacktrace.backtrace(of: target, threadIndex: 0)
+            EMBSuspendWindowSentinelBeginWindow()
+            let p = malloc(32)
+            XCTAssertNotNil(p)
+            free(p)
+            EMBSuspendWindowSentinelEndWindow()
 
-            XCTAssertEqual(
+            XCTAssertGreaterThan(
                 EMBSuspendWindowSentinelViolationCount(), 0,
                 """
-                An allocation occurred inside the thread-suspend window — the #423-class deadlock \
-                hazard. Inspect what runs between `willEnter`/`didExit` in `_takeSnapshot` (the \
-                `backtracer.backtrace(of:into:capacity:)` call and anything it triggers).
+                The sentinel did not observe a deliberate in-window allocation. `malloc_logger` is not \
+                firing in this environment, so a zero-violation result in the real test is meaningless. \
+                Switch the sentinel to symbol interposition (fishhook) before trusting it.
                 """
             )
         }
-    #endif
-}
+
+        #if DEBUG
+            /// The real test: walking a suspended thread must allocate nothing between suspend and resume.
+            func test_suspendWindow_performsNoAllocation() throws {
+                try XCTSkipIfSanitizing("KSCrash + malloc interposition are unsafe under sanitizer instrumentation")
+
+                let ready = DispatchSemaphore(value: 0)
+                let hold = DispatchSemaphore(value: 0)
+                let box = PThreadBox()
+                let thread = Thread {
+                    embFrameSkipParkedThread(ready: ready, hold: hold) { box.value = $0 }
+                }
+                thread.name = "emb.sentinel.parked"
+                thread.start()
+                ready.wait()
+                defer { hold.signal() }
+                let target = try XCTUnwrap(box.value, "parked thread did not publish its pthread_t")
+
+                EMBSuspendWindowSentinelArm()
+                EmbraceBacktraceSuspendWindowProbe.willEnter = { EMBSuspendWindowSentinelBeginWindow() }
+                EmbraceBacktraceSuspendWindowProbe.didExit = { EMBSuspendWindowSentinelEndWindow() }
+                defer {
+                    EmbraceBacktraceSuspendWindowProbe.willEnter = nil
+                    EmbraceBacktraceSuspendWindowProbe.didExit = nil
+                    EMBSuspendWindowSentinelDisarm()
+                }
+                EMBSuspendWindowSentinelResetViolations()
+
+                _ = EmbraceBacktrace.backtrace(of: target, threadIndex: 0)
+
+                XCTAssertEqual(
+                    EMBSuspendWindowSentinelViolationCount(), 0,
+                    """
+                    An allocation occurred inside the thread-suspend window — the #423-class deadlock \
+                    hazard. Inspect what runs between `willEnter`/`didExit` in `_takeSnapshot` (the \
+                    `backtracer.backtrace(of:into:capacity:)` call and anything it triggers).
+                    """
+                )
+            }
+        #endif
+    }
+
+#endif

--- a/Tests/EmbraceIOTests/BacktraceImageUUIDTests.swift
+++ b/Tests/EmbraceIOTests/BacktraceImageUUIDTests.swift
@@ -1,0 +1,116 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceCommonInternal
+import Foundation
+import XCTest
+
+@testable import EmbraceCore
+@testable import EmbraceIO
+
+/// A `Symbolicator` that resolves every address to a frame carrying a known, full-length Mach-O UUID.
+///
+/// The UUID is the value the *real* symbolicator would already have produced (via
+/// `NSUUID(uuidBytes:).uuidString` from KSCrash's raw `uuid_t`). It is deliberately a full 36-char
+/// UUID string so the test can prove it survives `EmbraceBacktrace.symbolicated()` unchanged.
+private final class FixedUUIDSymbolicator: NSObject, Symbolicator {
+    static let fullUUID = "F70C76E3-1352-3A80-A123-456789ABCDEF"  // 36 chars
+
+    func resolve(address: FrameAddress) -> SymbolicatedFrame? {
+        SymbolicatedFrame(
+            returnAddress: address,
+            callInstruction: address,
+            symbolAddress: 0x1000,
+            symbolName: "emb_test_symbol",
+            imageName: "TestImage",
+            imageUUID: Self.fullUUID,
+            imageAddress: 0x1000,
+            imageSize: 0x2000
+        )
+    }
+}
+
+/// Regression guard for a UUID-truncation bug in `EmbraceBacktrace.symbolicated()`.
+///
+/// The `SymbolicatedFrame.imageUUID` handed back by the symbolicator is *already* the full Mach-O
+/// UUID **string**. A previous version re-ran it through `NSUUID(uuidBytes:)`, which reinterprets the
+/// string's first 16 UTF-8 bytes as a raw `uuid_t` — silently truncating the UUID to its first 16
+/// characters (e.g. `F70C76E3-1352-3A80-…` collapsed to the `uuidString` of "F70C76E3-1352-3A"). That
+/// broke server-side symbolication of system frames in hang/backtrace payloads, where the full image
+/// UUID is what matches the symbol file. These tests fail loudly if that reinterpretation returns.
+final class BacktraceImageUUIDTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // The EmbraceCore designated initializer is the documented way to inject a custom symbolicator.
+        // `symbolicated()` reads `Embrace.client?.options.symbolicator`, so it must be set on the client.
+        let options = Embrace.Options(
+            appId: "myApp",
+            captureServices: [],
+            crashReporter: nil,
+            symbolicator: FixedUUIDSymbolicator()
+        )
+        _ = try? Embrace.setup(options: options).start()
+    }
+
+    override func tearDown() {
+        _ = try? Embrace.client?.stop()
+        Embrace.client = nil
+        super.tearDown()
+    }
+
+    /// The exact output the truncation bug produced: the `uuidString` of the first 16 UTF-8 bytes of
+    /// the UUID string. Kept as an explicit fixture so a reintroduced bug is matched precisely.
+    private var knownTruncation: String {
+        NSUUID(uuidBytes: Array(FixedUUIDSymbolicator.fullUUID.utf8)).uuidString
+    }
+
+    func test_symbolicatedFrame_preservesFullImageUUID() throws {
+        let thread = EmbraceBacktraceThread(
+            index: 0,
+            callstack: .init(addresses: [0xABCD_EF00], count: 1)
+        )
+
+        let image = try XCTUnwrap(
+            thread.frames(symbolicated: true).first?.image,
+            "frame was not symbolicated (no image); check that the mock symbolicator is wired up"
+        )
+
+        XCTAssertEqual(
+            image.uuid, FixedUUIDSymbolicator.fullUUID,
+            "image UUID was corrupted during symbolication"
+        )
+        XCTAssertEqual(
+            image.uuid.count, 36,
+            "expected a full 36-char Mach-O UUID, got \(image.uuid.count) chars: \(image.uuid)"
+        )
+        XCTAssertNotEqual(
+            image.uuid, knownTruncation,
+            "image UUID matches the known truncation-bug output — the UUID string is being "
+                + "reinterpreted as raw uuid_t bytes again in EmbraceBacktrace.symbolicated()"
+        )
+    }
+
+    /// The value must also survive into the processed-frame dictionary (`u` key) that is serialized
+    /// into the hang/crash payload — the layer where the corruption was originally observed.
+    func test_processedFrame_carriesFullImageUUID() throws {
+        let thread = EmbraceBacktraceThread(
+            index: 0,
+            callstack: .init(addresses: [0xABCD_EF10], count: 1)
+        )
+
+        let frame = try XCTUnwrap(thread.frames(symbolicated: true).first)
+        let processed = try XCTUnwrap(
+            frame.asProcessedFrame(),
+            "frame did not produce a processed dictionary (image or symbol was nil)"
+        )
+        let uuid = try XCTUnwrap(
+            processed[EmbraceBacktraceFrame.moduleUUIDKey] as? String,
+            "processed frame is missing the UUID (`u`) key"
+        )
+
+        XCTAssertEqual(uuid, FixedUUIDSymbolicator.fullUUID)
+        XCTAssertEqual(uuid.count, 36, "payload `u` was truncated: \(uuid)")
+    }
+}

--- a/Tests/EmbraceIOTests/HangCaptureServiceSamplerIntegrationTests.swift
+++ b/Tests/EmbraceIOTests/HangCaptureServiceSamplerIntegrationTests.swift
@@ -1,0 +1,107 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import EmbraceCommonInternal
+    import EmbraceConfiguration
+    import EmbraceSemantics
+    import Foundation
+    import OpenTelemetryApi
+    import TestSupport
+    import XCTest
+
+    @testable import EmbraceCore
+    @testable import EmbraceIO
+
+    /// End-to-end wiring of the during-block sampler into `HangCaptureService`, with a **real**
+    /// backtracer/symbolicator (from `Embrace.setup`) so `thread_blockage_sample` frames actually
+    /// resolve. `EmbraceCoreTests` can't do this — it has no symbolicator — so it only checks the
+    /// reconciliation/query wiring; the "event actually attaches with frames" proof lives here.
+    final class HangCaptureServiceSamplerIntegrationTests: XCTestCase {
+
+        override class func setUp() {
+            super.setUp()
+            _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
+        }
+
+        override class func tearDown() {
+            _ = try? Embrace.client?.stop()
+            Embrace.client = nil
+            super.tearDown()
+        }
+
+        private func makeService(otel: MockEmbraceOpenTelemetry, sampler: MainThreadStackSampler) -> HangCaptureService {
+            let service = HangCaptureService(limits: HangLimits(hangThreshold: 0.249, hangPerSession: 6))
+            service.install(otel: otel)
+            service.start()
+            service.limitData.withLock {
+                $0.sampler?.stop()
+                $0.sampler = sampler
+            }
+            return service
+        }
+
+        func test_hangEnded_attachesInWindowSampleAsThreadBlockageEvent() throws {
+            try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+
+            let otel = MockEmbraceOpenTelemetry()
+            let sampler = MockSampler()
+            // A real self-capture: gives addresses the symbolicator can resolve to non-nil frames.
+            let backtrace = EmbraceBacktrace.backtrace(of: pthread_self(), threadIndex: 0)
+            sampler.cannedSamples = [
+                MainThreadStackSample(timestamp: backtrace.timestamp, overhead: 4321, backtrace: backtrace)
+            ]
+            let service = makeService(otel: otel, sampler: sampler)
+
+            let start = Date()
+            service.hangStarted(at: start, duration: 0.5)
+            service.hangEnded(at: start.addingTimeInterval(0.5), duration: 0.5)
+
+            wait(timeout: .defaultTimeout) {
+                otel.spanProcessor.endedSpans.contains { $0.name == SpanSemantics.Hang.name }
+            }
+
+            let span = otel.spanProcessor.endedSpans.first { $0.name == SpanSemantics.Hang.name }
+            let event = span?.events.first { $0.name == SpanEventSemantics.Hang.name }
+            XCTAssertNotNil(event, "hangEnded should attach a thread_blockage_sample event for an in-window sample")
+
+            if case let .int(frameCount)? = event?.attributes[SpanEventSemantics.Hang.keyFrameCount] {
+                XCTAssertGreaterThan(frameCount, 0, "attached sample should carry resolved frames")
+            } else {
+                XCTFail("frame_count attribute missing or not an int")
+            }
+        }
+
+        func test_hangEnded_withNoSample_endsSpanWithoutEvent() {
+            let otel = MockEmbraceOpenTelemetry()
+            let service = makeService(otel: otel, sampler: MockSampler())  // returns nothing
+
+            let start = Date()
+            service.hangStarted(at: start, duration: 0.5)
+            service.hangEnded(at: start.addingTimeInterval(0.5), duration: 0.5)
+
+            wait(timeout: .defaultTimeout) {
+                otel.spanProcessor.endedSpans.contains { $0.name == SpanSemantics.Hang.name }
+            }
+
+            let span = otel.spanProcessor.endedSpans.first { $0.name == SpanSemantics.Hang.name }
+            XCTAssertNotNil(span, "span should still end when no sample is available")
+            XCTAssertNil(
+                span?.events.first { $0.name == SpanEventSemantics.Hang.name },
+                "no in-window sample → honest no-stack (no thread_blockage_sample event)"
+            )
+        }
+    }
+
+    private final class MockSampler: MainThreadStackSampler {
+        var cannedSamples: [MainThreadStackSample] = []
+        func start() {}
+        func stop() {}
+        func pause() {}
+        func resume() {}
+        func samples(in range: ClosedRange<UInt64>) -> [MainThreadStackSample] { cannedSamples }
+    }
+
+#endif

--- a/Tests/EmbraceIOTests/HangCaptureServiceSamplerIntegrationTests.swift
+++ b/Tests/EmbraceIOTests/HangCaptureServiceSamplerIntegrationTests.swift
@@ -74,6 +74,37 @@
             }
         }
 
+        func test_hangEnded_attachesEarliestInWindowSample() throws {
+            try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+
+            let otel = MockEmbraceOpenTelemetry()
+            let sampler = MockSampler()
+            let backtrace = EmbraceBacktrace.backtrace(of: pthread_self(), threadIndex: 0)
+            // Two in-window samples; the service must attach the FIRST (earliest) one, not the last.
+            sampler.cannedSamples = [
+                MainThreadStackSample(timestamp: backtrace.timestamp, overhead: 1111, backtrace: backtrace),
+                MainThreadStackSample(timestamp: backtrace.timestamp, overhead: 9999, backtrace: backtrace)
+            ]
+            let service = makeService(otel: otel, sampler: sampler)
+
+            let start = Date()
+            service.hangStarted(at: start, duration: 0.5)
+            service.hangEnded(at: start.addingTimeInterval(0.5), duration: 0.5)
+
+            wait(timeout: .defaultTimeout) {
+                otel.spanProcessor.endedSpans.contains { $0.name == SpanSemantics.Hang.name }
+            }
+
+            let span = otel.spanProcessor.endedSpans.first { $0.name == SpanSemantics.Hang.name }
+            let event = span?.events.first { $0.name == SpanEventSemantics.Hang.name }
+            XCTAssertNotNil(event)
+            if case let .int(overhead)? = event?.attributes[SpanEventSemantics.Hang.keySampleOverhead] {
+                XCTAssertEqual(overhead, 1111, "should attach the earliest in-window sample, not the last")
+            } else {
+                XCTFail("sample_overhead attribute missing or not an int")
+            }
+        }
+
         func test_hangEnded_withNoSample_endsSpanWithoutEvent() {
             let otel = MockEmbraceOpenTelemetry()
             let service = makeService(otel: otel, sampler: MockSampler())  // returns nothing

--- a/Tests/EmbraceIOTests/PerformanceTests.swift
+++ b/Tests/EmbraceIOTests/PerformanceTests.swift
@@ -110,14 +110,14 @@ class PerformanceBacktraceTests: XCTestCase {
     }
 
     func test_embraceBacktrace() {
-        _ = EmbraceBacktrace.backtrace()
+        _ = EmbraceBacktrace.backtrace(of: pthread_self())
     }
 
     func test_embraceBacktraceAndSymbolicate() throws {
         // ksbic_init (KSCrash binary-image cache) is not safe under sanitizer instrumentation:
         // TSan aborts; ASan deadlocks until the 30-minute job cap fires.
         try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
-        _ = EmbraceBacktrace.backtrace().threads.compactMap { thread in
+        _ = EmbraceBacktrace.backtrace(of: pthread_self()).threads.compactMap { thread in
             thread.callstack.frames(symbolicated: true)
         }
     }

--- a/Tests/EmbraceIOTests/StallTriggeredSamplerTests.swift
+++ b/Tests/EmbraceIOTests/StallTriggeredSamplerTests.swift
@@ -1,0 +1,121 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+    import TestSupport
+    import XCTest
+
+    @testable import EmbraceCore
+    @testable import EmbraceIO
+
+    /// Blocks the calling thread for `seconds`. `@inline(never)` + a distinctive name so it is
+    /// identifiable in a suspended-thread backtrace.
+    @inline(never)
+    private func embSamplerBlockingWork(seconds: TimeInterval) {
+        Thread.sleep(forTimeInterval: seconds)
+    }
+
+    final class StallTriggeredSamplerTests: XCTestCase {
+
+        override class func setUp() {
+            super.setUp()
+            _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
+        }
+
+        override class func tearDown() {
+            _ = try? Embrace.client?.stop()
+            Embrace.client = nil
+            super.tearDown()
+        }
+
+        /// Runs `body` on the main queue (blocking main) while pumping the main run loop, so the
+        /// beacon sees a busy epoch and the background sampler can walk main mid-block.
+        @MainActor
+        private func blockMainThread(for seconds: TimeInterval) {
+            let done = expectation(description: "main unblocked")
+            DispatchQueue.main.async {
+                embSamplerBlockingWork(seconds: seconds)
+                done.fulfill()
+            }
+            wait(for: [done], timeout: seconds + 5)
+        }
+
+        @MainActor
+        func test_capturesOneDuringBlockSample_withBlockingWorkOnStack() throws {
+            try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+
+            let sampler = StallTriggeredSampler(
+                mainThread: pthread_self(),  // XCTest runs this on the main thread
+                triggerThreshold: 0.05,
+                pollInterval: 0.02,
+                logger: nil
+            )
+            sampler.start()
+            defer { sampler.stop() }
+
+            blockMainThread(for: 0.3)
+
+            let samples = sampler.samples(in: 0...UInt64.max)
+
+            // Exactly one snapshot for the single stall episode (poller samples once per epoch).
+            XCTAssertEqual(samples.count, 1, "expected exactly one during-block sample per stall episode")
+
+            let names =
+                samples.first?.backtrace.threads.first?.callstack
+                .frames(symbolicated: true).compactMap { $0.symbol?.name } ?? []
+            XCTAssertTrue(
+                names.contains { $0.contains("embSamplerBlockingWork") },
+                "during-block sample did not capture the blocking work; names: \(names.prefix(12))"
+            )
+        }
+
+        func test_belowFloorValuesAreClampedUp() {
+            // A hostile/bad remote config: both below the compiled-in floors.
+            let sampler = StallTriggeredSampler(
+                mainThread: pthread_self(),
+                triggerThreshold: 0.001,
+                pollInterval: 0.0001,
+                logger: nil
+            )
+            XCTAssertEqual(sampler.effectiveTriggerThreshold, StallTriggeredSampler.minTriggerThreshold, accuracy: 1e-9)
+            XCTAssertEqual(sampler.effectivePollInterval, StallTriggeredSampler.minPollInterval, accuracy: 1e-9)
+        }
+
+        func test_aboveFloorValuesArePreserved() {
+            let sampler = StallTriggeredSampler(
+                mainThread: pthread_self(),
+                triggerThreshold: 0.2,
+                pollInterval: 0.03,
+                logger: nil
+            )
+            XCTAssertEqual(sampler.effectiveTriggerThreshold, 0.2, accuracy: 1e-6)
+            XCTAssertEqual(sampler.effectivePollInterval, 0.03, accuracy: 1e-6)
+        }
+
+        @MainActor
+        func test_pauseSuppressesSampling_thenResumeReArms() throws {
+            try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")
+
+            let sampler = StallTriggeredSampler(
+                mainThread: pthread_self(),
+                triggerThreshold: 0.05,
+                pollInterval: 0.02,
+                logger: nil
+            )
+            sampler.start()
+            defer { sampler.stop() }
+
+            sampler.pause()
+            blockMainThread(for: 0.3)
+            XCTAssertEqual(sampler.samples(in: 0...UInt64.max).count, 0, "pause() should suppress sampling")
+
+            sampler.resume()
+            blockMainThread(for: 0.3)
+            XCTAssertEqual(sampler.samples(in: 0...UInt64.max).count, 1, "resume() should re-arm sampling")
+        }
+    }
+
+#endif

--- a/Tests/EmbraceIOTests/StallTriggeredSamplerTests.swift
+++ b/Tests/EmbraceIOTests/StallTriggeredSamplerTests.swift
@@ -4,6 +4,7 @@
 
 #if !os(watchOS) && !os(macOS)
 
+    import EmbraceConfiguration
     import Foundation
     import TestSupport
     import XCTest
@@ -80,8 +81,8 @@
                 pollInterval: 0.0001,
                 logger: nil
             )
-            XCTAssertEqual(sampler.effectiveTriggerThreshold, StallTriggeredSampler.minTriggerThreshold, accuracy: 1e-9)
-            XCTAssertEqual(sampler.effectivePollInterval, StallTriggeredSampler.minPollInterval, accuracy: 1e-9)
+            XCTAssertEqual(sampler.effectiveTriggerThreshold, HangLimits.minSampleTriggerThreshold, accuracy: 1e-9)
+            XCTAssertEqual(sampler.effectivePollInterval, HangLimits.minSamplePollInterval, accuracy: 1e-9)
         }
 
         func test_aboveFloorValuesArePreserved() {

--- a/Tests/EmbraceIOTests/StallTriggeredSamplerTests.swift
+++ b/Tests/EmbraceIOTests/StallTriggeredSamplerTests.swift
@@ -96,6 +96,34 @@
             XCTAssertEqual(sampler.effectivePollInterval, 0.03, accuracy: 1e-6)
         }
 
+        func test_aboveCeilingValuesAreClampedDown() {
+            // Defense-in-depth for direct callers: a seconds/ms mixup that would overflow the ns
+            // conversion and trap must be clamped to the ceiling instead.
+            let sampler = StallTriggeredSampler(
+                mainThread: pthread_self(),
+                triggerThreshold: 5000,
+                pollInterval: 5000,
+                logger: nil
+            )
+            XCTAssertEqual(sampler.effectiveTriggerThreshold, HangLimits.maxSampleTriggerThreshold, accuracy: 1e-6)
+            XCTAssertEqual(sampler.effectivePollInterval, HangLimits.maxSamplePollInterval, accuracy: 1e-6)
+        }
+
+        func test_nonFiniteValuesFallBackToDefaults() {
+            for bad in [Double.nan, .infinity] {
+                let sampler = StallTriggeredSampler(
+                    mainThread: pthread_self(),
+                    triggerThreshold: bad,
+                    pollInterval: bad,
+                    logger: nil
+                )
+                XCTAssertEqual(
+                    sampler.effectiveTriggerThreshold, HangLimits.defaultSampleTriggerThreshold, accuracy: 1e-6)
+                XCTAssertEqual(
+                    sampler.effectivePollInterval, HangLimits.defaultSamplePollInterval, accuracy: 1e-6)
+            }
+        }
+
         @MainActor
         func test_pauseSuppressesSampling_thenResumeReArms() throws {
             try XCTSkipIfSanitizing("KSCrash symbolication is incompatible with sanitizer instrumentation")

--- a/Tests/EmbraceIOTests/SuspendWindowDeadlockTests.swift
+++ b/Tests/EmbraceIOTests/SuspendWindowDeadlockTests.swift
@@ -1,0 +1,191 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+    import ObjectiveC
+    import TestSupport
+    import XCTest
+    import os
+
+    #if !EMBRACE_COCOAPOD_BUILDING_SDK
+        import EmbraceCommonInternal
+    #endif
+
+    @testable import EmbraceCore
+    @testable import EmbraceIO
+
+    private final class PThreadBox {
+        var value: pthread_t?
+    }
+
+    /// Deadlock amplifier for the thread-suspend backtrace window.
+    ///
+    /// A backtrace suspends the target thread and walks it. If that walk ever needed a lock the
+    /// **suspended** thread is holding, the process would deadlock (the #423 class of bug). These
+    /// tests deliberately suspend a victim thread that is holding — or hammering — each lock class
+    /// and assert the walk still completes within a timeout.
+    ///
+    /// The **allocator** case is the load-bearing one: `malloc`'s lock is the only lock the walk
+    /// could plausibly contend on, so a victim caught mid-`malloc` is the real scenario. The explicit
+    /// app-lock cases prove the walk is robust when the victim is suspended mid-critical-section (how
+    /// a real hung main thread often looks) and guard against future changes that add runtime work to
+    /// the window.
+    ///
+    /// A genuine deadlock surfaces as the sampling thread never signaling `done` → the wait times out
+    /// → the test fails, instead of hanging the whole suite.
+    final class SuspendWindowDeadlockTests: XCTestCase {
+
+        override class func setUp() {
+            super.setUp()
+            _ = try? Embrace.setup(options: Embrace.Options(appId: "myApp")).start()
+        }
+
+        override class func tearDown() {
+            _ = try? Embrace.client?.stop()
+            Embrace.client = nil
+            super.tearDown()
+        }
+
+        /// Walks `victim` on a background thread and returns whether it finished within `timeout`.
+        private func sampleCompletes(victim: pthread_t, timeout: TimeInterval = 5) -> Bool {
+            let done = DispatchSemaphore(value: 0)
+            DispatchQueue.global(qos: .userInitiated).async {
+                _ = EmbraceBacktrace.backtrace(of: victim, threadIndex: 0)
+                done.signal()
+            }
+            return done.wait(timeout: .now() + timeout) == .success
+        }
+
+        /// Spawns a victim thread that acquires a lock (via `enter`), parks while holding it, is
+        /// sampled, then releases (via `release`) and finishes — all before returning, so the caller
+        /// can safely tear down lock storage.
+        private func assertNoDeadlockWhileVictimHolds(
+            _ lockName: String,
+            enter: @escaping () -> Void,
+            release: @escaping () -> Void,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let ready = DispatchSemaphore(value: 0)
+            let mayRelease = DispatchSemaphore(value: 0)
+            let finished = DispatchSemaphore(value: 0)
+            let box = PThreadBox()
+
+            let victim = Thread {
+                enter()
+                box.value = pthread_self()
+                ready.signal()
+                mayRelease.wait()  // park WHILE HOLDING the lock, across the sampling
+                release()
+                finished.signal()
+            }
+            victim.name = "emb.deadlock.victim"
+            victim.start()
+            ready.wait()
+
+            guard let target = box.value else {
+                XCTFail("victim did not publish its pthread_t", file: file, line: line)
+                return
+            }
+
+            let completed = sampleCompletes(victim: target)
+
+            mayRelease.signal()  // let the victim release the lock…
+            finished.wait()  // …and fully finish before the caller frees lock storage
+
+            XCTAssertTrue(
+                completed,
+                "Sampling a thread holding \(lockName) did not complete within the timeout — "
+                    + "the suspend-window walk likely needs that lock (deadlock).",
+                file: file,
+                line: line
+            )
+        }
+
+        func test_noDeadlock_victimHolds_osUnfairLock() throws {
+            try XCTSkipIfSanitizing("thread suspension + KSCrash walk are unsafe under sanitizer instrumentation")
+
+            let lock = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+            lock.initialize(to: os_unfair_lock())
+            defer {
+                lock.deinitialize(count: 1)
+                lock.deallocate()
+            }
+
+            assertNoDeadlockWhileVictimHolds(
+                "os_unfair_lock",
+                enter: { os_unfair_lock_lock(lock) },
+                release: { os_unfair_lock_unlock(lock) }
+            )
+        }
+
+        func test_noDeadlock_victimHolds_pthreadMutex() throws {
+            try XCTSkipIfSanitizing("thread suspension + KSCrash walk are unsafe under sanitizer instrumentation")
+
+            let mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+            XCTAssertEqual(pthread_mutex_init(mutex, nil), 0)
+            defer {
+                pthread_mutex_destroy(mutex)
+                mutex.deallocate()
+            }
+
+            assertNoDeadlockWhileVictimHolds(
+                "pthread_mutex",
+                enter: { pthread_mutex_lock(mutex) },
+                release: { pthread_mutex_unlock(mutex) }
+            )
+        }
+
+        func test_noDeadlock_victimHolds_objcSync() throws {
+            try XCTSkipIfSanitizing("thread suspension + KSCrash walk are unsafe under sanitizer instrumentation")
+
+            let object = NSObject()
+            assertNoDeadlockWhileVictimHolds(
+                "@synchronized (objc_sync)",
+                enter: { objc_sync_enter(object) },
+                release: { objc_sync_exit(object) }
+            )
+        }
+
+        /// The load-bearing case: the victim continuously allocates/frees, so suspending it
+        /// repeatedly catches it mid-`malloc` holding the allocator lock. If the alloc-free window
+        /// regressed and started allocating, this would deadlock and time out.
+        func test_noDeadlock_victimHammersAllocator() throws {
+            try XCTSkipIfSanitizing("thread suspension + KSCrash walk are unsafe under sanitizer instrumentation")
+
+            let running = EmbraceAtomic<Bool>(true)
+            let ready = DispatchSemaphore(value: 0)
+            let box = PThreadBox()
+
+            let victim = Thread {
+                box.value = pthread_self()
+                ready.signal()
+                while running.load(order: .relaxed) {
+                    if let p = malloc(64) {
+                        memset(p, 1, 64)
+                        free(p)
+                    }
+                }
+            }
+            victim.name = "emb.deadlock.allocator"
+            victim.start()
+            ready.wait()
+            defer { running.store(false, order: .relaxed) }
+
+            let target = try XCTUnwrap(box.value, "victim did not publish its pthread_t")
+
+            // Many attempts to raise the odds of catching the victim inside the allocator lock.
+            for iteration in 0..<200 {
+                XCTAssertTrue(
+                    sampleCompletes(victim: target),
+                    "Sampling stalled on iteration \(iteration) while the victim hammered the allocator "
+                        + "— the suspend-window walk is not allocation-free (deadlock)."
+                )
+            }
+        }
+    }
+
+#endif

--- a/Tests/TestSupport/Mocks/MockLogger.swift
+++ b/Tests/TestSupport/Mocks/MockLogger.swift
@@ -10,14 +10,21 @@ public class MockLogger: InternalLogger {
     public var level: LogLevel = .debug
 
     /// Every message passed to `log`, regardless of level, so tests can assert on what was logged.
-    public private(set) var loggedMessages: [(level: LogLevel, message: String)] = []
+    /// Guarded by a mutex so a shared `MockLogger` stays safe to log to from multiple threads.
+    private let _loggedMessages = EmbraceMutex<[(level: LogLevel, message: String)]>([])
+    public var loggedMessages: [(level: LogLevel, message: String)] { _loggedMessages.withLock { $0 } }
 
     public init(level: LogLevel = .none) {
         self.level = level
     }
 
+    /// Clears the recorded messages (for tests that reuse a single instance across cases).
+    public func reset() {
+        _loggedMessages.withLock { $0.removeAll() }
+    }
+
     public func log(level: LogLevel, message: String, attributes: [String: String] = [:]) -> Bool {
-        loggedMessages.append((level, message))
+        _loggedMessages.withLock { $0.append((level, message)) }
 
         guard self.level != .none && self.level.rawValue <= level.rawValue else {
             return false

--- a/Tests/TestSupport/Mocks/MockLogger.swift
+++ b/Tests/TestSupport/Mocks/MockLogger.swift
@@ -9,11 +9,16 @@ public class MockLogger: InternalLogger {
 
     public var level: LogLevel = .debug
 
+    /// Every message passed to `log`, regardless of level, so tests can assert on what was logged.
+    public private(set) var loggedMessages: [(level: LogLevel, message: String)] = []
+
     public init(level: LogLevel = .none) {
         self.level = level
     }
 
     public func log(level: LogLevel, message: String, attributes: [String: String] = [:]) -> Bool {
+        loggedMessages.append((level, message))
+
         guard self.level != .none && self.level.rawValue <= level.rawValue else {
             return false
         }

--- a/Tests/TestSupport/Objc/include/EMBSuspendWindowSentinel.h
+++ b/Tests/TestSupport/Objc/include/EMBSuspendWindowSentinel.h
@@ -1,0 +1,50 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#ifndef EMB_SUSPEND_WINDOW_SENTINEL_H
+#define EMB_SUSPEND_WINDOW_SENTINEL_H
+
+#include <stdint.h>
+
+/// A test-only tripwire that proves the thread-suspend backtrace window performs **no heap
+/// allocation**. Allocating between `thread_suspend` and `thread_resume` risks a whole-process
+/// deadlock if the suspended thread holds the allocator lock (the "#423" class of bug).
+///
+/// Mechanism: while armed, it observes every allocation in the process via `malloc_logger`. Any
+/// allocation made **on the window thread** while a window is open is recorded as a violation. The
+/// observer only touches lock-free atomics, so it never allocates or locks itself.
+///
+/// Usage: `Arm()` once, bracket the window with `BeginWindow()`/`EndWindow()` from the walking
+/// thread, then assert `ViolationCount()` is zero. Always pair with a positive-control test that
+/// deliberately allocates inside a window and asserts the count rises — otherwise a zero could just
+/// mean the mechanism isn't firing.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Installs the process-wide allocation observer. Idempotent; saves any previous `malloc_logger`.
+void EMBSuspendWindowSentinelArm(void);
+
+/// Removes the observer, restores the previous `malloc_logger`, and clears window state. Idempotent.
+void EMBSuspendWindowSentinelDisarm(void);
+
+/// Opens the forbidden window and binds it to the **calling** thread. Allocations on that thread
+/// until `EndWindow()` are counted as violations. Only atomics run here — safe to call in-window.
+void EMBSuspendWindowSentinelBeginWindow(void);
+
+/// Closes the forbidden window.
+void EMBSuspendWindowSentinelEndWindow(void);
+
+/// Allocations observed on the window thread while a window was open, since the last reset.
+uint64_t EMBSuspendWindowSentinelViolationCount(void);
+
+/// Resets the violation counter to zero.
+void EMBSuspendWindowSentinelResetViolations(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EMB_SUSPEND_WINDOW_SENTINEL_H */

--- a/Tests/TestSupport/Objc/source/EMBSuspendWindowSentinel.m
+++ b/Tests/TestSupport/Objc/source/EMBSuspendWindowSentinel.m
@@ -1,0 +1,67 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#import "EMBSuspendWindowSentinel.h"
+
+#import <pthread.h>
+#import <stdatomic.h>
+
+// `malloc_logger` is a private-but-exported libmalloc global. When non-NULL, libmalloc invokes it on
+// every allocation/free (this is the hook Instruments' allocation tracking uses). We declare it here
+// because it is not in a public header.
+typedef void(malloc_logger_t)(uint32_t type, uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, uintptr_t result,
+                              uint32_t num_hot_frames_to_skip);
+extern malloc_logger_t *malloc_logger;
+
+static malloc_logger_t *emb_previous_logger = NULL;
+static _Atomic(int) emb_armed = 0;
+static _Atomic(int) emb_in_window = 0;
+static _Atomic(uint64_t) emb_violations = 0;
+static pthread_t emb_window_thread;  // guarded by emb_in_window ordering
+
+// Runs inside libmalloc, possibly while the allocator lock is held. MUST NOT allocate or lock —
+// only lock-free atomics here, or we become the very deadlock we are testing for.
+static void emb_allocation_observer(uint32_t type, uintptr_t arg1, uintptr_t arg2, uintptr_t arg3, uintptr_t result,
+                                    uint32_t num_hot_frames_to_skip)
+{
+    if (atomic_load_explicit(&emb_in_window, memory_order_acquire)) {
+        if (pthread_equal(pthread_self(), emb_window_thread)) {
+            atomic_fetch_add_explicit(&emb_violations, 1, memory_order_relaxed);
+        }
+    }
+}
+
+void EMBSuspendWindowSentinelArm(void)
+{
+    if (atomic_exchange_explicit(&emb_armed, 1, memory_order_acq_rel)) {
+        return;  // already armed
+    }
+    emb_previous_logger = malloc_logger;
+    malloc_logger = emb_allocation_observer;
+}
+
+void EMBSuspendWindowSentinelDisarm(void)
+{
+    if (!atomic_exchange_explicit(&emb_armed, 0, memory_order_acq_rel)) {
+        return;  // not armed
+    }
+    malloc_logger = emb_previous_logger;
+    emb_previous_logger = NULL;
+    atomic_store_explicit(&emb_in_window, 0, memory_order_release);
+}
+
+void EMBSuspendWindowSentinelBeginWindow(void)
+{
+    emb_window_thread = pthread_self();
+    atomic_store_explicit(&emb_in_window, 1, memory_order_release);
+}
+
+void EMBSuspendWindowSentinelEndWindow(void) { atomic_store_explicit(&emb_in_window, 0, memory_order_release); }
+
+uint64_t EMBSuspendWindowSentinelViolationCount(void)
+{
+    return atomic_load_explicit(&emb_violations, memory_order_relaxed);
+}
+
+void EMBSuspendWindowSentinelResetViolations(void) { atomic_store_explicit(&emb_violations, 0, memory_order_relaxed); }


### PR DESCRIPTION
Implements a new main thread watchdog and stacktrace sampler for the main thread so that when a Hang is confirmed by the Framerate Monitor, we can have a relevant Stacktrace available to include in the span. The current implementation picks up a stacktrace after the hang ended, which is completely useless.