### PR TITLE
[EMBR-13450] Fix: Proxy: Fixed crash when selector is invoked on a released delegate

### DIFF
--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -21,11 +21,28 @@
 
 @end
 
-@implementation EMBURLSessionLegacyDelegateProxy
+@implementation EMBURLSessionLegacyDelegateProxy {
+    // Backups of the original delegate that survive `originalDelegate` being cleared.
+    //
+    // `originalDelegate` is a strong reference we intentionally release on session
+    // invalidation (see `-URLSession:didBecomeInvalidWithError:`) to break the
+    // session <-> proxy <-> delegate retain cycle. But URLSession/CFNetwork snapshots
+    // the delegate's responds-to-selector set when the session is created and later
+    // delivers callbacks *raw* (without re-checking `-respondsToSelector:`). A callback
+    // that arrives after invalidation — e.g. a WebSocket close still in flight — would
+    // otherwise reach the forwarding path with `originalDelegate == nil` and crash with
+    // an unrecognized selector. These let us still forward to the delegate if it is alive
+    // (`_weakOriginalDelegate`), and always produce a valid method signature so the message
+    // can be dropped gracefully in `-forwardInvocation:` (`_originalDelegateClass`).
+    __weak id _weakOriginalDelegate;
+    Class _originalDelegateClass;
+}
 
 - (instancetype)initWithDelegate:(id<NSURLSessionDelegate>)delegate handler:(id<URLSessionTaskHandler>)handler
 {
     _originalDelegate = delegate;
+    _weakOriginalDelegate = delegate;
+    _originalDelegateClass = [delegate class];
     _handler = handler;
     return self;
 }
@@ -52,12 +69,37 @@
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)selector
 {
-    return [(NSObject *)self.originalDelegate methodSignatureForSelector:selector];
+    // Prefer the live delegate's own signature (strong first, then the weak backup in case
+    // `originalDelegate` was released after invalidation while a callback was still in flight).
+    id target = self.originalDelegate ?: _weakOriginalDelegate;
+    if (target) {
+        NSMethodSignature *sig = [(NSObject *)target methodSignatureForSelector:selector];
+        if (sig) {
+            return sig;
+        }
+    }
+
+    // The delegate instance is gone. Fall back to its remembered class so we can still return a
+    // valid signature and drop the message in `-forwardInvocation:` rather than falling through
+    // to `-doesNotRecognizeSelector:` and crashing. (This is an `NSProxy` subclass, so there is
+    // no `[super methodSignatureForSelector:]` to safely fall back to — a nil result here yields
+    // the same unrecognized-selector semantics as before for genuinely unknown selectors.)
+    if (_originalDelegateClass) {
+        return [_originalDelegateClass instanceMethodSignatureForSelector:selector];
+    }
+
+    return nil;
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-    [invocation invokeWithTarget:self.originalDelegate];
+    // If the original delegate is still alive and handles the selector, deliver it; otherwise
+    // drop it. This is the safety net for callbacks (such as a WebSocket close) delivered after
+    // the session was invalidated and `originalDelegate` was released.
+    id target = self.originalDelegate ?: _weakOriginalDelegate;
+    if (target && [target respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:target];
+    }
 }
 
 - (BOOL)isKindOfClass:(Class)aClass

--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -98,6 +98,14 @@
     // If the original delegate is still alive and handles the selector, deliver it; otherwise
     // drop it. This is the safety net for callbacks (such as a WebSocket close) delivered after
     // the session was invalidated and `originalDelegate` was released.
+    //
+    // Known limitation: if the dropped selector carries a `completionHandler` (e.g.
+    // `URLSession:dataTask:willCacheResponse:completionHandler:`) the handler is never invoked,
+    // which leaves that one task parked until it times out. This is only reachable if the app
+    // both implemented such a method and fully deallocated its delegate before the callback
+    // raced in post-invalidation — extremely narrow given URLSession delivers
+    // `didBecomeInvalidWithError:` last and cancels/finishes tasks around invalidation. We
+    // accept the drop rather than synthesizing per-selector default responses here.
     id target = self.originalDelegate ?: _weakOriginalDelegate;
     if (target && [target respondsToSelector:invocation.selector]) {
         [invocation invokeWithTarget:target];

--- a/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/LegacyProxy/EMBURLSessionLegacyDelegateProxy.m
@@ -26,7 +26,9 @@
     //
     // `originalDelegate` is a strong reference we intentionally release on session
     // invalidation (see `-URLSession:didBecomeInvalidWithError:`) to break the
-    // session <-> proxy <-> delegate retain cycle. But URLSession/CFNetwork snapshots
+    // `session -> proxy -> delegate` retain chain: URLSession strongly retains its delegate
+    // (this proxy) until invalidation, so without this the delegate would be pinned for the
+    // session's entire lifetime. But URLSession/CFNetwork snapshots
     // the delegate's responds-to-selector set when the session is created and later
     // delivers callbacks *raw* (without re-checking `-respondsToSelector:`). A callback
     // that arrives after invalidation — e.g. a WebSocket close still in flight — would

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -11,7 +11,9 @@
     //
     // `originalDelegate` is a strong reference we intentionally release on session
     // invalidation (see `-URLSession:didBecomeInvalidWithError:`) to break the
-    // session <-> proxy <-> delegate retain cycle. But URLSession/CFNetwork snapshots
+    // `session -> proxy -> delegate` retain chain: URLSession strongly retains its delegate
+    // (this proxy) until invalidation, so without this the delegate would be pinned for the
+    // session's entire lifetime. But URLSession/CFNetwork snapshots
     // the delegate's responds-to-selector set when the session is created and later
     // delivers callbacks *raw* (without re-checking `-respondsToSelector:`). A callback
     // that arrives after invalidation — e.g. a WebSocket close still in flight — would

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -6,13 +6,30 @@
 #import <Foundation/Foundation.h>
 #import "objc/runtime.h"
 
-@implementation EMBURLSessionNewDelegateProxy
+@implementation EMBURLSessionNewDelegateProxy {
+    // Backups of the original delegate that survive `originalDelegate` being cleared.
+    //
+    // `originalDelegate` is a strong reference we intentionally release on session
+    // invalidation (see `-URLSession:didBecomeInvalidWithError:`) to break the
+    // session <-> proxy <-> delegate retain cycle. But URLSession/CFNetwork snapshots
+    // the delegate's responds-to-selector set when the session is created and later
+    // delivers callbacks *raw* (without re-checking `-respondsToSelector:`). A callback
+    // that arrives after invalidation — e.g. a WebSocket close still in flight — would
+    // otherwise reach the forwarding path with `originalDelegate == nil` and crash with
+    // an unrecognized selector. These let us still forward to the delegate if it is alive
+    // (`_weakOriginalDelegate`), and always produce a valid method signature so the message
+    // can be dropped gracefully in `-forwardInvocation:` (`_originalDelegateClass`).
+    __weak id _weakOriginalDelegate;
+    Class _originalDelegateClass;
+}
 
 - (instancetype)initWithDelegate:(id<NSURLSessionDelegate>)delegate handler:(id<URLSessionTaskHandler>)handler
 {
     self = [super init];
     if (self) {
         _originalDelegate = delegate;
+        _weakOriginalDelegate = delegate;
+        _originalDelegateClass = [delegate class];
         _handler = handler;
     }
     return self;
@@ -22,11 +39,39 @@
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
 {
-    id target = [self forwardingTargetForSelector:aSelector];
-    if (target == nil) {
-        return [super methodSignatureForSelector:aSelector];
+    // Prefer the live delegate's own signature (strong first, then the weak backup in case
+    // `originalDelegate` was released after invalidation while a callback was still in flight).
+    id target = self.originalDelegate ?: _weakOriginalDelegate;
+    if (target) {
+        NSMethodSignature *sig = [target methodSignatureForSelector:aSelector];
+        if (sig) {
+            return sig;
+        }
     }
-    return [target methodSignatureForSelector:aSelector];
+
+    // The delegate instance is gone. Fall back to its remembered class so we can still
+    // return a valid signature and drop the message in `-forwardInvocation:` rather than
+    // falling through to `-doesNotRecognizeSelector:` and crashing.
+    if (_originalDelegateClass) {
+        NSMethodSignature *sig = [_originalDelegateClass instanceMethodSignatureForSelector:aSelector];
+        if (sig) {
+            return sig;
+        }
+    }
+
+    return [super methodSignatureForSelector:aSelector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+    // Reached only via the slow forwarding path, i.e. when `-forwardingTargetForSelector:`
+    // declined. If the original delegate is still alive and handles the selector, deliver it;
+    // otherwise drop it. This is the safety net for callbacks (such as a WebSocket close)
+    // delivered after the session was invalidated and `originalDelegate` was released.
+    id target = self.originalDelegate ?: _weakOriginalDelegate;
+    if (target && [target respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:target];
+    }
 }
 
 - (id)getTargetForSelector:(SEL)sel session:(NSURLSession *)session

--- a/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
+++ b/Sources/EmbraceObjCUtilsInternal/source/NewProxy/EMBURLSessionNewDelegateProxy.m
@@ -66,10 +66,18 @@
 
 - (void)forwardInvocation:(NSInvocation *)invocation
 {
-    // Reached only via the slow forwarding path, i.e. when `-forwardingTargetForSelector:`
-    // declined. If the original delegate is still alive and handles the selector, deliver it;
-    // otherwise drop it. This is the safety net for callbacks (such as a WebSocket close)
-    // delivered after the session was invalidated and `originalDelegate` was released.
+    // Reached only when `-forwardingTargetForSelector:` returns nil for the selector. If the
+    // original delegate is still alive and handles the selector, deliver it; otherwise drop it.
+    // This is the safety net for callbacks (such as a WebSocket close) delivered after the
+    // session was invalidated and `originalDelegate` was released.
+    //
+    // Known limitation: if the dropped selector carries a `completionHandler` (e.g.
+    // `URLSession:dataTask:willCacheResponse:completionHandler:`) the handler is never invoked,
+    // which leaves that one task parked until it times out. This is only reachable if the app
+    // both implemented such a method and fully deallocated its delegate before the callback
+    // raced in post-invalidation — extremely narrow given URLSession delivers
+    // `didBecomeInvalidWithError:` last and cancels/finishes tasks around invalidation. We
+    // accept the drop rather than synthesizing per-selector default responses here.
     id target = self.originalDelegate ?: _weakOriginalDelegate;
     if (target && [target respondsToSelector:invocation.selector]) {
         [invocation invokeWithTarget:target];

--- a/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyWebSocketInvalidationTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/Network/Proxy/URLSessionDelegateProxyWebSocketInvalidationTests.swift
@@ -1,0 +1,112 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+import TestSupportObjc
+import XCTest
+
+@testable import EmbraceCore
+@testable import EmbraceObjCUtilsInternal
+
+/// Regression tests for a production crash:
+///
+///   `-[EMBURLSessionNewDelegateProxy URLSession:webSocketTask:didCloseWithCode:reason:]:
+///    unrecognized selector sent to instance 0x...`
+///
+/// The proxy advertises a selector via `-respondsToSelector:` by mirroring its
+/// `originalDelegate`. URLSession/CFNetwork snapshots that capability when the session is
+/// created and later delivers the callback *raw* — without re-checking `-respondsToSelector:`.
+/// If the `originalDelegate` was released in the meantime (e.g. the session was invalidated
+/// while a WebSocket close was still in flight), the forwarding path used to fall through to
+/// `-doesNotRecognizeSelector:` and crash.
+///
+/// The proxy must instead forward to the delegate when it is still alive, or drop the message
+/// safely when it is not. Both proxy implementations shared this vulnerability, so both are
+/// covered here. These tests reproduce the raw delivery that bypasses the usual
+/// `-respondsToSelector:` guard; if the fix regresses, they surface the same unrecognized
+/// selector exception.
+final class URLSessionDelegateProxyWebSocketInvalidationTests: XCTestCase {
+
+    private let closeSelector = NSSelectorFromString("URLSession:webSocketTask:didCloseWithCode:reason:")
+
+    // MARK: - New proxy
+
+    func test_newProxy_webSocketClose_afterOriginalDelegateReleased_forwardsWhileAlive() {
+        assertForwardsCloseWhileDelegateAlive(makeProxy: makeNewProxy)
+    }
+
+    func test_newProxy_webSocketClose_afterOriginalDelegateDeallocated_dropsSafely() {
+        assertDropsCloseWhenDelegateDeallocated(makeProxy: makeNewProxy)
+    }
+
+    // MARK: - Legacy proxy
+
+    func test_legacyProxy_webSocketClose_afterOriginalDelegateReleased_forwardsWhileAlive() {
+        assertForwardsCloseWhileDelegateAlive(makeProxy: makeLegacyProxy)
+    }
+
+    func test_legacyProxy_webSocketClose_afterOriginalDelegateDeallocated_dropsSafely() {
+        assertDropsCloseWhenDelegateDeallocated(makeProxy: makeLegacyProxy)
+    }
+
+    // MARK: - Shared scenarios
+
+    /// Session invalidation clears the proxy's strong reference, but the app still owns the
+    /// delegate (the proxy's weak backup stays valid) — so the close must still reach it.
+    private func assertForwardsCloseWhileDelegateAlive(
+        makeProxy: (WebSocketImplementingURLSessionDelegate) -> AnyObject
+    ) {
+        let delegate = WebSocketImplementingURLSessionDelegate()
+        let sut = makeProxy(delegate)
+
+        EMBClearOriginalDelegate(sut)
+
+        rawInvokeClose(on: sut)
+
+        XCTAssertTrue(delegate.didInvokeDidCloseWithCode)
+    }
+
+    /// The proxy held the last strong reference, so nil-ing it deallocates the delegate.
+    /// There is nothing to forward to — the close must be dropped rather than crash.
+    private func assertDropsCloseWhenDelegateDeallocated(
+        makeProxy: (WebSocketImplementingURLSessionDelegate) -> AnyObject
+    ) {
+        var sut: AnyObject!
+        autoreleasepool {
+            let delegate = WebSocketImplementingURLSessionDelegate()
+            sut = makeProxy(delegate)
+            EMBClearOriginalDelegate(sut)
+            // `delegate` deallocates at the end of this scope; the proxy's weak backup zeroes out.
+        }
+
+        rawInvokeClose(on: sut)
+    }
+
+    // MARK: - Helpers
+
+    // Both factories return `AnyObject` rather than `EMBURLSessionDelegateProxy`: the legacy proxy
+    // is an `NSProxy` subclass, and a Swift cast to the `@objc` protocol traps for it.
+    private func makeNewProxy(_ delegate: WebSocketImplementingURLSessionDelegate) -> AnyObject {
+        EmbraceMakeURLSessionDelegateProxy(delegate, MockURLSessionTaskHandler())
+    }
+
+    private func makeLegacyProxy(_ delegate: WebSocketImplementingURLSessionDelegate) -> AnyObject {
+        MakeLegacyURLSessionDelegateProxy(delegate, MockURLSessionTaskHandler()) as AnyObject
+    }
+
+    private func rawInvokeClose(on proxy: AnyObject) {
+        let task = URLSession.shared.webSocketTask(with: URL(string: "wss://embrace.io")!)
+        EMBRawInvoke(
+            proxy,
+            closeSelector,
+            WebSocketImplementingURLSessionDelegate.self,
+            [
+                URLSession.shared,
+                task,
+                // Scalar `closeCode` slot; the value is never read by the reproduced callback.
+                NSNumber(value: URLSessionWebSocketTask.CloseCode.abnormalClosure.rawValue),
+                Data()
+            ]
+        )
+    }
+}

--- a/Tests/TestSupport/Objc/include/EMBProxyForwardingTestUtils.h
+++ b/Tests/TestSupport/Objc/include/EMBProxyForwardingTestUtils.h
@@ -1,0 +1,35 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A URLSession delegate that implements the optional WebSocket close callback.
+///
+/// Used to reproduce a production crash where a delegate that *did* respond to
+/// `URLSession:webSocketTask:didCloseWithCode:reason:` was released (e.g. on session
+/// invalidation) while that callback was still in flight.
+@interface WebSocketImplementingURLSessionDelegate : NSObject <NSURLSessionDelegate>
+
+@property(nonatomic, assign) BOOL didInvokeDidCloseWithCode;
+
+@end
+
+/// Clears the proxy's strong `originalDelegate`, simulating what happens on session
+/// invalidation. Done in Objective-C because the legacy proxy is an `NSProxy` subclass and a
+/// Swift `as?`/`as!` cast to the `@objc` `EMBURLSessionDelegateProxy` protocol fails for it.
+FOUNDATION_EXPORT void EMBClearOriginalDelegate(id proxy);
+
+/// Sends `selector` to `target` by building an `NSInvocation` and invoking it directly,
+/// *without* first checking `-respondsToSelector:`.
+///
+/// This mirrors how CFNetwork delivers URLSession delegate callbacks: it uses a capability
+/// snapshot cached at session-creation time and then messages the delegate raw. That is the
+/// exact path that triggers the proxy's forwarding machinery. `signatureSource` supplies the
+/// method signature for the selector (typically the original delegate's class), since the
+/// proxy may no longer be able to.
+FOUNDATION_EXPORT void EMBRawInvoke(id target, SEL selector, Class signatureSource, NSArray *arguments);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/TestSupport/Objc/source/EMBProxyForwardingTestUtils.m
+++ b/Tests/TestSupport/Objc/source/EMBProxyForwardingTestUtils.m
@@ -1,0 +1,39 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#import "EMBProxyForwardingTestUtils.h"
+#import "EMBURLSessionDelegateProtocol.h"
+
+@implementation WebSocketImplementingURLSessionDelegate
+
+- (void)URLSession:(NSURLSession *)session
+       webSocketTask:(NSURLSessionWebSocketTask *)webSocketTask
+    didCloseWithCode:(NSURLSessionWebSocketCloseCode)closeCode
+              reason:(nullable NSData *)reason
+{
+    self.didInvokeDidCloseWithCode = YES;
+}
+
+@end
+
+void EMBClearOriginalDelegate(id proxy) { [(id<EMBURLSessionDelegateProxy>)proxy setOriginalDelegate:nil]; }
+
+void EMBRawInvoke(id target, SEL selector, Class signatureSource, NSArray *arguments)
+{
+    NSMethodSignature *sig = [signatureSource instanceMethodSignatureForSelector:selector];
+    NSCAssert(sig != nil, @"signatureSource must implement %@", NSStringFromSelector(selector));
+
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:sig];
+    inv.selector = selector;
+    inv.target = target;
+
+    // Arguments start at index 2 (self, _cmd occupy 0 and 1). Scalar parameters are copied
+    // by value from the boxed object's pointer bits; the reproduced callbacks never read them.
+    for (NSUInteger index = 0, argIndex = 2; index < arguments.count; index++, argIndex++) {
+        id arg = arguments[index];
+        [inv setArgument:&arg atIndex:argIndex];
+    }
+
+    [inv invoke];  // raw send to `target` — exercises the proxy's forwarding path
+}


### PR DESCRIPTION
Fixes an `unrecognizedSelector` crash when a delegate callback arrives after the SDK cleared its delegate reference.