### PR TITLE
[EMBR-12977] Fix: Update UI Tests App for new session handling

### DIFF
--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Swizzles/NetworkingSwizzle.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Common/Swizzles/NetworkingSwizzle.swift
@@ -30,6 +30,14 @@ class NetworkingSwizzle: NSObject {
     /// Part ids in the order their payloads were first captured.
     private(set) var postedPartIds: [String] = []
 
+    /// User-session ids (`session.id` on the payload's `emb-session` span) in the order they were
+    /// first seen in a posted payload. The public part id is no longer exposed by the SDK, so this is
+    /// how the UI surfaces "the last session we sent" without reaching into live SDK state.
+    private(set) var postedUserSessionIds: [String] = []
+
+    /// The user-session id of the most recently posted payload, or `nil` if nothing has been sent yet.
+    var lastPostedUserSessionId: String? { postedUserSessionIds.last }
+
     /// All exported spans grouped by their `emb.session_part_id`. Every exported span — including
     /// the `emb-session` span itself — carries this attribute, so spans are correlated to the part
     /// they belong to deterministically, without any time-based guessing.
@@ -37,8 +45,10 @@ class NetworkingSwizzle: NSObject {
 
     private let dataLock = NSLock()
 
-    /// Contains all the logs exported, grouped by Session Id.
-    private(set) var exportedLogsBySessions: [String: [ReadableLogRecord]] = [:]
+    /// All exported logs grouped by their own `emb.session_part_id` attribute. Logs carry the full
+    /// identity trio, so we group by the part id stamped on each record — mirroring the part-based
+    /// `exportedSpansByPart` model — rather than reaching into live SDK state.
+    private(set) var exportedLogsByPart: [String: [ReadableLogRecord]] = [:]
 
     /// For whatever reason, some tasks get lost in the ether so their completion handlers are never called.
     /// A quick fix is to just keep a reference to them here... Not ideal but this is a test app not intended to run for too long.
@@ -151,6 +161,7 @@ class NetworkingSwizzle: NSObject {
         let sessionSpan = (spans + spans_snapshots).first { $0["name"] as? String == "emb-session" }
         let attributes = sessionSpan?["attributes"] as? [[String: String]]
         let partId = attributes?.first { $0["key"] == "emb.session_part_id" }?["value"]
+        let userSessionId = attributes?.first { $0["key"] == "session.id" }?["value"]
 
         guard
             let partId = partId
@@ -162,6 +173,9 @@ class NetworkingSwizzle: NSObject {
         postedJsonsByPart[partId, default: []].append(json)
         if !postedPartIds.contains(partId) {
             postedPartIds.append(partId)
+        }
+        if let userSessionId = userSessionId, !postedUserSessionIds.contains(userSessionId) {
+            postedUserSessionIds.append(userSessionId)
         }
         dataLock.unlock()
 
@@ -182,10 +196,11 @@ class NetworkingSwizzle: NSObject {
     }
 
     private func capturedExportedLog(_ logExporter: TestLogRecordExporter) {
-        guard let currentSessionId = EmbraceIO.shared.currentSessionId else {
-            return
+        dataLock.lock()
+        for log in logExporter.latestExportedLogs {
+            let partId = log.attributes["emb.session_part_id"]?.description ?? ""
+            exportedLogsByPart[partId, default: []].append(log)
         }
-
-        exportedLogsBySessions[currentSessionId, default: []].append(contentsOf: logExporter.latestExportedLogs)
+        dataLock.unlock()
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Crashes/Tests/CrashesTests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Crashes/Tests/CrashesTests.swift
@@ -18,10 +18,6 @@ class CrashesTests: PayloadTest {
         UserDefaults.standard.bool(forKey: "CrashTriggered")
     }
 
-    private var crashedSessionId: String? {
-        UserDefaults.standard.string(forKey: "CrashedSessionId")
-    }
-
     func runTestPreparations() {
         if !crashTriggered {
             recordCrash()
@@ -40,12 +36,6 @@ class CrashesTests: PayloadTest {
     func test(logs: [ReadableLogRecord]) -> TestReport {
         var testItems = [TestReportItem]()
 
-        guard let crashedSessionId = crashedSessionId else {
-            testItems.append(
-                .init(target: "crashedSessionId", expected: "cached crash session", recorded: "missing", result: .fail))
-            return .init(items: testItems)
-        }
-
         guard let crashLog = logs.first(where: { $0.attributes["emb.type"]?.description == "sys.ios.crash" }) else {
             testItems.append(.init(target: "emb.type", expected: "sys.ios.crash", recorded: "missing", result: .fail))
             return .init(items: testItems)
@@ -53,7 +43,6 @@ class CrashesTests: PayloadTest {
 
         testItems.append(
             .init(target: "emb.type", expected: "sys.ios.crash", recorded: "sys.ios.crash", result: .success))
-        testItems.append(evaluate("emb.payload", contains: crashedSessionId, on: crashLog.attributes))
         testItems.append(evaluate("emb.provider", expecting: "kscrash", on: crashLog.attributes))
         testItems.append(contentsOf: OTelSemanticsValidation.validateAttributeNames(crashLog.attributes))
         clearCrashRecord()
@@ -62,14 +51,12 @@ class CrashesTests: PayloadTest {
 
     private func recordCrash() {
         UserDefaults.standard.setValue(true, forKey: "CrashTriggered")
-        UserDefaults.standard.setValue(EmbraceIO.shared.currentSessionId ?? "INVALID", forKey: "CrashedSessionId")
         UserDefaults.standard.synchronize()
 
     }
 
     private func clearCrashRecord() {
         UserDefaults.standard.setValue(false, forKey: "CrashTriggered")
-        UserDefaults.standard.setValue(nil, forKey: "CrashedSessionId")
         UserDefaults.standard.synchronize()
     }
 }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Crashes/Tests/CrashesTests.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Crashes/Tests/CrashesTests.swift
@@ -9,6 +9,11 @@ import OpenTelemetryApi
 import OpenTelemetrySdk
 import SwiftUI
 
+/// TODO: Crash Tests need more work so we're just removing "currentSessionId" usage for now so that the app compiles and runs.
+/// Need to correlate the crash to the corresponding user session.
+/// Need to also figure out how to add crash tests to the test suite since the debugger stops when a crash happens so it's not possible to test them as of now other than running a manual test.
+///
+
 class CrashesTests: PayloadTest {
     var testRelevantPayloadNames: [String] { [] }
     var requiresCleanup: Bool { false }
@@ -22,7 +27,7 @@ class CrashesTests: PayloadTest {
         if !crashTriggered {
             recordCrash()
 
-            // Gives time for User Defaults to store the crash session.
+            // Gives time for User Defaults to store the crash record.
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 var nullPointer: CrashTestDummyObject? = .init()
 

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Session/Tests/FinishedSessionTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Session/Tests/FinishedSessionTest.swift
@@ -17,10 +17,7 @@ class FinishedSessionTest: PayloadTest {
 
     var fakeAppState: Bool = false
 
-    private var currentSession: String = ""
-
     func runTestPreparations() {
-        currentSession = EmbraceIO.shared.currentSessionId ?? ""
         if fakeAppState {
             NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
 
@@ -33,13 +30,23 @@ class FinishedSessionTest: PayloadTest {
     func test(spans: [OpenTelemetrySdk.SpanData]) -> TestReport {
         var testItems = [TestReportItem]()
 
-        // Match on `emb.session_part_id` — the part UUID that `currentSessionId` returns. The
-        // exported `emb-session` span deliberately does NOT carry `session.id` / `emb.user_session_id`;
-        // those are stamped only at payload-build time from the stored `SessionRecord.userSessionId`.
-        // See `UploadedSessionPayloadTest` for the identity assertions on the uploaded payload.
-        let (resultItem, sessionSpan) = evaluateSpanExistence(
-            identifiedBy: currentSession, underAttributeKey: "emb.session_part_id", on: spans)
-        testItems.append(resultItem)
+        // The live `emb-session` span carries only `emb.session_part_id`, and that part UUID is no
+        // longer exposed by the public API — so we can't correlate "our" session by id. Instead we
+        // select it structurally: `requiresCleanup` clears `emb-session` before the action, so the
+        // finished, foreground `emb-session` span in this fresh window is the one this test ended.
+        // (`session.id` / `emb.user_session_id` are stamped only at payload-build time — see
+        // `UploadedSessionPayloadTest` for the identity assertions on the uploaded payload.)
+        let sessionSpan = spans.first {
+            $0.name == "emb-session"
+                && $0.attributes["emb.state"]?.description == "foreground"
+                && $0.hasEnded
+        }
+        testItems.append(
+            .init(
+                target: "Finished foreground emb-session span",
+                expected: "exists",
+                recorded: sessionSpan != nil ? "exists" : "missing",
+                result: sessionSpan != nil ? .success : .fail))
 
         guard let sessionSpan = sessionSpan else {
             return .init(items: testItems)
@@ -61,7 +68,7 @@ class FinishedSessionTest: PayloadTest {
 
         testItems.append(evaluate("emb.type", expecting: "ux.session", on: sessionSpan.attributes))
         testItems.append(evaluate("emb.state", expecting: "foreground", on: sessionSpan.attributes))
-        testItems.append(evaluate("emb.session_part_id", expecting: currentSession, on: sessionSpan.attributes))
+        testItems.append(evaluate("emb.session_part_id", expectedToExist: true, on: sessionSpan.attributes))
         testItems.append(heartbeatReportItem(for: sessionSpan))
         testItems.append(evaluate("emb.cold_start", expectedToExist: true, on: sessionSpan.attributes))
         testItems.append(contentsOf: OTelSemanticsValidation.validateAttributeNames(sessionSpan.attributes))

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Session/Tests/UserSessionTest.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/Session/Tests/UserSessionTest.swift
@@ -21,19 +21,21 @@ import SwiftUI
 ///   2. the active user session is terminated with `.manual` and a *different* user session is
 ///      started (verified from the public user-session notifications).
 ///
-/// ### Why this test does NOT poll `EmbraceIO.shared.currentSessionId`
+/// ### Why the roll is verified through notifications, not live SDK state
 ///
 /// `endUserSession()` is **asynchronous**: it dispatches the whole roll
 /// (end-part → end-user-session → start-part) onto the session-controller's serial queue, and the
-/// new part id is only published at the very last step. Meanwhile this `test(spans:)` method is
+/// new user session is only published at the very last step. Meanwhile this `test(spans:)` method is
 /// invoked from the span-exporter's notification, which runs on the exporter's processing queue and
 /// fires the moment the *old* part's span is exported — i.e. at the *start* of the roll, before the
-/// new part exists. Reading `currentSessionId` here therefore races the roll and frequently returns
-/// `nil` (the window after the old part is cleared but before the new part is assigned). A
-/// `Thread.sleep` on the main thread does not help because none of this work runs on main.
+/// new user session exists. Polling live SDK state here would race the roll. Instead we observe it
+/// through the public, event-driven user-session notifications and wait on them with semaphores,
+/// which is order-independent and not racy.
 ///
-/// Instead we observe the roll through the public, event-driven user-session notifications and wait
-/// on them with semaphores, which is order-independent and not racy.
+/// The exported `emb-session` span is selected **structurally** (finished + foreground) rather than
+/// by id: the live span carries only `emb.session_part_id`, which the public API no longer exposes,
+/// and `requiresCleanup` clears `emb-session` before the action so the finished foreground span in
+/// this window is the part the roll just closed.
 ///
 /// - Note: `endUserSession()` is rate-limited to one call every 5 seconds. If this test is run
 ///   again within that window the call is ignored, no roll happens, and the notification waits time
@@ -48,10 +50,6 @@ class UserSessionTest: PayloadTest {
     /// the asynchronous roll posts on the main queue.
     private static let notificationTimeout: TimeInterval = 3.0
 
-    /// Part id of the session that is active when the test starts. Ending the user session closes
-    /// this part, so this is the id we expect on the finished `emb-session` span that gets exported.
-    private var endedSessionPartId: String = ""
-
     // Captured from the public user-session notifications posted during the roll.
     private let lock = NSLock()
     private var _endedUserSession: EmbraceUserSession?
@@ -61,8 +59,6 @@ class UserSessionTest: PayloadTest {
     private var observers: [NSObjectProtocol] = []
 
     func runTestPreparations() {
-        endedSessionPartId = EmbraceIO.shared.currentSessionId ?? ""
-
         // Subscribe BEFORE ending the session so we don't miss the notifications the roll posts.
         let endObserver = NotificationCenter.default.addObserver(
             forName: .embraceUserSessionDidEnd, object: nil, queue: nil
@@ -90,23 +86,24 @@ class UserSessionTest: PayloadTest {
     func test(spans: [OpenTelemetrySdk.SpanData]) -> TestReport {
         var testItems = [TestReportItem]()
 
-        // The part that was active when the test started must have been finished and exported.
-        let (existenceItem, endedSpan) = evaluateSpanExistence(
-            identifiedBy: endedSessionPartId, underAttributeKey: "emb.session_part_id", on: spans)
-        testItems.append(existenceItem)
+        // The part the roll just closed must have been finished and exported. Select it structurally
+        // (finished + foreground) since its part id is no longer obtainable from the public API.
+        let endedSpan = spans.first {
+            $0.name == "emb-session"
+                && $0.attributes["emb.state"]?.description == "foreground"
+                && $0.hasEnded
+        }
+        testItems.append(
+            .init(
+                target: "Finished foreground emb-session span",
+                expected: "exists",
+                recorded: endedSpan != nil ? "exists" : "missing",
+                result: endedSpan != nil ? .success : .fail))
 
         if let endedSpan = endedSpan {
-            // Ending the user session closes the part, so its span must be finished.
-            testItems.append(
-                .init(
-                    target: "Ended session part finished",
-                    expected: "finished",
-                    recorded: endedSpan.hasEnded ? "finished" : "open",
-                    result: endedSpan.hasEnded ? .success : .fail))
-
             testItems.append(evaluate("emb.type", expecting: "ux.session", on: endedSpan.attributes))
             testItems.append(evaluate("emb.state", expecting: "foreground", on: endedSpan.attributes))
-            testItems.append(evaluate("emb.session_part_id", expecting: endedSessionPartId, on: endedSpan.attributes))
+            testItems.append(evaluate("emb.session_part_id", expectedToExist: true, on: endedSpan.attributes))
             testItems.append(evaluate("emb.cold_start", expectedToExist: true, on: endedSpan.attributes))
             testItems.append(contentsOf: OTelSemanticsValidation.validateAttributeNames(endedSpan.attributes))
         }

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/UploadedPayloads/ViewModels/UploadedSessionPayloadTestViewModel.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/UploadedPayloads/ViewModels/UploadedSessionPayloadTestViewModel.swift
@@ -11,11 +11,12 @@ import SwiftUI
 class UploadedSessionPayloadTestViewModel: UIComponentViewModelBase {
     private var testObject: UploadedSessionPayloadTest
 
-    // Personas / user info are recorded keyed by the part id that was current when they were set
-    // (`EmbraceIO.shared.currentSessionId` is the part id). The picker also selects a part id, so
-    // these look up directly at test time — no id translation needed.
-    private var personasByPartId: [String: Set<String>] = [:]
-    private var userInfoByPartId: [String: UserInfo] = [:]
+    // Personas / user info are global SDK state, so we accumulate what was set during the app run and
+    // verify the selected payload carries it. The public part id that used to key these per-session
+    // is no longer exposed — and payloads keep personas/user-info set with carrying lifespans anyway,
+    // so a single accumulated set is both simpler and accurate for what this test checks.
+    private var recordedPersonas: Set<String> = []
+    private var recordedUserInfo: UserInfo = .init()
 
     /// Part ids (`emb.session_part_id`) that have been uploaded — one entry per posted payload.
     private(set) var postedParts: [String] = [] {
@@ -28,21 +29,16 @@ class UploadedSessionPayloadTestViewModel: UIComponentViewModelBase {
         }
     }
 
-    private(set) var currentSessionId: String? {
-        didSet {
-            if oldValue != nil {
-                self.lastSessionId = oldValue
-            }
-        }
-    }
+    /// User-session id (`session.id`) of the most recently posted payload, surfaced from the network
+    /// swizzle for display. The public API no longer exposes a session id, so this is our window into
+    /// "the last session we actually sent".
+    private(set) var lastPostedUserSessionId: String?
 
     var selectedPartId: String {
         didSet {
             testObject.partIdToTest = selectedPartId
         }
     }
-
-    private(set) var lastSessionId: String?
 
     var testButtonDisabled: Bool {
         postedParts.isEmpty
@@ -62,7 +58,6 @@ class UploadedSessionPayloadTestViewModel: UIComponentViewModelBase {
         self.testObject = testObject
         self.selectedPartId = ""
         super.init(dataModel: dataModel, payloadTestObject: testObject)
-        currentSessionId = EmbraceIO.shared.currentSessionId
         readUserInfoFromEmbrace()
         // The posted-parts list is populated from `onAppear` (via `refresh()`), once
         // `dataCollector` is available — see `updatedPostedParts()`.
@@ -86,18 +81,6 @@ class UploadedSessionPayloadTestViewModel: UIComponentViewModelBase {
             ) { [weak self] _ in
                 self?.updatedPostedParts()
             })
-
-        observerTokens.append(
-            NotificationCenter.default.addObserver(forName: .embraceSessionPartDidStart, object: nil, queue: .main) {
-                [weak self] _ in
-                self?.currentSessionId = EmbraceIO.shared.currentSessionId
-            })
-
-        observerTokens.append(
-            NotificationCenter.default.addObserver(forName: .embraceUserSessionDidEnd, object: nil, queue: .main) {
-                [weak self] _ in
-                self?.currentSessionId = nil
-            })
     }
 
     func refresh() {
@@ -105,49 +88,34 @@ class UploadedSessionPayloadTestViewModel: UIComponentViewModelBase {
         readUserInfoFromEmbrace()
         EmbraceIO.shared.getCurrentPersonas { [weak self] (personas: [String]) in
             guard let self = self else { return }
-            personas.forEach { persona in
-                self.addPersonaToCurrentSession(persona)
-            }
+            personas.forEach { self.recordedPersonas.insert($0) }
         }
     }
 
     func clearAllUserInfo() {
-        guard let currentSessionId = currentSessionId else { return }
-
         EmbraceIO.shared.removeAllProperties(lifespans: [])
         userInfoIdentifier = ""
-        userInfoByPartId[currentSessionId] = nil
+        recordedUserInfo = .init()
     }
 
     func addedNewPersona(_ persona: String, lifespan: MetadataLifespan) {
         EmbraceIO.shared.addPersona(persona, lifespan: lifespan)
-        addPersonaToCurrentSession(persona)
-    }
-
-    private func addPersonaToCurrentSession(_ persona: String) {
-        guard let currentSessionId = currentSessionId else { return }
-        personasByPartId[currentSessionId, default: []].insert(persona)
+        recordedPersonas.insert(persona)
     }
 
     func removeAllPersonas() {
         EmbraceIO.shared.removeAllPersonas(lifespans: [])
-        guard let currentSessionId = currentSessionId else { return }
-        personasByPartId[currentSessionId] = []
+        recordedPersonas.removeAll()
     }
 
     private func readUserInfoFromEmbrace() {
-        guard let currentSessionId = currentSessionId else { return }
         let identifier = EmbraceIO.shared.userIdentifier
-
         self.userInfoIdentifier = identifier ?? ""
-
-        userInfoByPartId[currentSessionId] = .init(identifier: identifier)
+        recordedUserInfo = .init(identifier: identifier)
     }
 
     private func updatedUserInfo() {
-        guard let currentSessionId = currentSessionId else { return }
-
-        userInfoByPartId[currentSessionId] = .init(identifier: userInfoIdentifier)
+        recordedUserInfo = .init(identifier: userInfoIdentifier)
     }
 
     private func updatedPostedParts() {
@@ -158,13 +126,14 @@ class UploadedSessionPayloadTestViewModel: UIComponentViewModelBase {
         let postedPartIds = networkSpy.postedPartIds
         let exportedPartIds = Set(networkSpy.exportedSpansByPart.keys)
         postedParts = postedPartIds.filter { exportedPartIds.contains($0) }
+        lastPostedUserSessionId = networkSpy.lastPostedUserSessionId
     }
 
     override func testButtonPressed() {
         guard let networkSpy = dataCollector?.networkSpy else { return }
 
-        testObject.personas = Array(personasByPartId[selectedPartId, default: []])
-        testObject.userInfo = userInfoByPartId[selectedPartId] ?? .init()
+        testObject.personas = Array(recordedPersonas)
+        testObject.userInfo = recordedUserInfo
 
         super.testButtonPressed()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in

--- a/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/UploadedPayloads/Views/UploadedSessionPayloadUIComponent.swift
+++ b/Examples/EmbraceIOTestApp/EmbraceIOTestApp/Tests/UploadedPayloads/Views/UploadedSessionPayloadUIComponent.swift
@@ -37,15 +37,8 @@ struct UploadedSessionPayloadUIComponent: View {
                     }
                 }
                 .padding([.top, .bottom], 8)
-                Section("Current Session:") {
-                    Text("\(viewModel.currentSessionId ?? "-")")
-                        .font(.embraceFont(size: 12))
-                        .padding(.top, 2)
-                        .padding(.bottom, 5)
-                        .padding(.leading, 10)
-                }
-                Section("Last Session:") {
-                    Text("\(viewModel.lastSessionId ?? "-")")
+                Section("Last Posted User Session:") {
+                    Text("\(viewModel.lastPostedUserSessionId ?? "-")")
                         .font(.embraceFont(size: 12))
                         .padding(.top, 2)
                         .padding(.bottom, 5)


### PR DESCRIPTION
Updates the UI Tests App to migrate from the old `currentSessionId` usage to the new `User Session` model implemented in 7.0