### PR TITLE
[EMBR-13708] Feature: Add Support for KSCrash 2.6.0 terminations

### DIFF
--- a/EmbraceIO.podspec
+++ b/EmbraceIO.podspec
@@ -133,7 +133,7 @@ Pod::Spec.new do |spec|
 
   # External
   spec.subspec 'EmbraceKSCrash' do |subs|
-    subs.dependency "KSCrash", "~> 2.5.1"
+    subs.dependency "KSCrash", "2.6.0"
   end
 
   spec.subspec 'OpenTelemetrySdk' do |subs|

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,7 +1,7 @@
 # Acknowledgements
 This project makes use of the following third party libraries:
 
-## KSCrash (2.5.1)
+## KSCrash (2.6.0)
 
 MIT License
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kstenerud/KSCrash",
       "state" : {
-        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
-        "version" : "2.5.1"
+        "revision" : "3f77f379c2db001e0c261c2a51b7e2b115d31f91",
+        "version" : "2.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/kstenerud/KSCrash",
-            from: "2.5.1"
+            exact: "2.6.0"
         ),
         .package(
             url: "https://github.com/open-telemetry/opentelemetry-swift-core",

--- a/Sources/ThirdParty/EmbraceKSCrashSupport/KSCrashReporter.swift
+++ b/Sources/ThirdParty/EmbraceKSCrashSupport/KSCrashReporter.swift
@@ -35,6 +35,15 @@ public final class KSCrashReporter: NSObject, CrashReporter {
         static let watchdgodEvent = "watchdog_event"
     }
 
+    private static let monitors: MonitorType = [
+        .machException,
+        .signal,
+        .cppException,
+        .nsException,
+        .userReported,
+        .termination
+    ]
+
     private let reporter: KSCrash = KSCrash.shared
 
     struct WatchdogEventData {
@@ -70,12 +79,12 @@ public final class KSCrashReporter: NSObject, CrashReporter {
 
     /// Used to determine if the last session ended cleanly or in a crash.
     public func getLastRunState() -> LastRunState {
-        return reporter.crashedLastLaunch ? .crash : .cleanExit
+        return reporter.previousTerminationReason == .crash ? .crash : .cleanExit
     }
 
     public func install(context: CrashReporterContext) throws {
         let config = KSCrashConfiguration()
-        config.enableSigTermMonitoring = false
+        config.monitors = Self.monitors
         config.enableSwapCxaThrow = false
         config.installPath = context.filePathProvider.directoryURL(for: "embrace_crash_reporter")?.path
         config.reportStoreConfiguration.appName = context.appId ?? "default"
@@ -112,6 +121,12 @@ public final class KSCrashReporter: NSObject, CrashReporter {
 
             // fetch report
             guard var report = store.report(for: id)?.value else {
+                continue
+            }
+
+            // Drop all reports except OOMs.
+            if report.isInjectedTerminationReport(), !report.isUserPerceptibleMemoryTermination() {
+                store.deleteReport(with: id)
                 continue
             }
 
@@ -289,6 +304,54 @@ extension KSCrashReporter {
 
 // KSCrash report format support
 extension Dictionary where Key == String, Value == Any {
+
+    private enum TerminationKey {
+        static let monitorId = "Termination"
+        static let memoryLimit = "memory_limit"
+        static let memoryPressure = "memory_pressure"
+    }
+
+    /// Check if this report was injected retroactively by KSCrash's `termination` monitor
+    /// rather than written by a crash handler during the previous run.
+    ///
+    /// These reports are hand-built by KSCrash and contain only a `report` and a `crash`
+    /// section, so they carry no `user` section and therefore no session id.
+    fileprivate func isInjectedTerminationReport() -> Bool {
+        guard let reportData = self["report"] as? [String: Any],
+            let monitorId = reportData["monitor_id"] as? String,
+            monitorId == TerminationKey.monitorId
+        else {
+            return false
+        }
+
+        return true
+    }
+
+    /// Check if an injected termination report describes an out-of-memory kill that the user
+    /// could have perceived, which is the only termination KSCrash 2.5.1 reported.
+    ///
+    /// `user_perceptible` is stitched in from the previous run's `Lifecycle` sidecar when the
+    /// report is read, and mirrors the foreground check 2.5.1 applied before promoting its OOM
+    /// breadcrumb. Its absence means we can't establish the app was in the foreground, so we
+    /// treat that as not perceptible.
+    fileprivate func isUserPerceptibleMemoryTermination() -> Bool {
+        guard let crashData = self["crash"] as? [String: Any],
+            let errorData = crashData["error"] as? [String: Any],
+            let reason = errorData["termination_reason"] as? String,
+            reason == TerminationKey.memoryLimit || reason == TerminationKey.memoryPressure
+        else {
+            return false
+        }
+
+        guard let systemData = self["system"] as? [String: Any],
+            let appStats = systemData["application_stats"] as? [String: Any],
+            let userPerceptible = appStats["user_perceptible"] as? Bool
+        else {
+            return false
+        }
+
+        return userPerceptible
+    }
 
     /// Check if this data shows it being a watchdog event report from KSCrash.
     fileprivate func isWatchdogEvent() -> Bool {

--- a/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
+++ b/Tests/EmbraceCrashTests/EmbraceCrashReporterTests.swift
@@ -241,6 +241,106 @@
 
             wait(for: [expectation], timeout: .defaultTimeout)
         }
+
+        // MARK: - Injected Termination Report Tests
+
+        // KSCrash 2.6.0's `termination` monitor injects a report at launch for every
+        // termination reason it infers. Its 2.5.1 predecessor only reported OOMs the user
+        // could have perceived, so only those may reach the crash pipeline.
+
+        func testOnInjectedTerminationReport_fetchUnsentCrashReports_userPerceptibleOOMshouldBeReported() throws {
+            givenCrashReporter()
+
+            try copyReport(
+                named: "termination_oom_foreground_report",
+                toFilePath: "/Reports/appId-report-0000000000000001.json"
+            )
+
+            let expectation = XCTestExpectation()
+            crashReporter.fetchUnsentCrashReports { reports in
+                XCTAssertEqual(reports.count, 1)
+                XCTAssertEqual(reports[0].internalId, 1)
+                // KSCrash fabricates a SIGKILL for these, matching what 2.5.1 stamped on a
+                // promoted OOM breadcrumb, so the default block list must not catch it.
+                XCTAssertEqual(reports[0].signal, .SIGKILL)
+                XCTAssertNotNil(reports[0].timestamp)
+                // Known gap versus 2.5.1: KSCrash hand-builds these reports with no `user`
+                // section, so there is no session to attribute them to.
+                XCTAssertNil(reports[0].sessionId)
+
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: .defaultTimeout)
+        }
+
+        func testOnInjectedTerminationReport_fetchUnsentCrashReports_backgroundOOMshouldntBeReported() throws {
+            givenCrashReporter()
+
+            try copyReport(
+                named: "termination_oom_background_report",
+                toFilePath: "/Reports/appId-report-0000000000000001.json"
+            )
+
+            let expectation = XCTestExpectation()
+            crashReporter.fetchUnsentCrashReports { reports in
+                XCTAssertEqual(reports.count, 0)
+                self.thenShouldntExistReport(withName: "appId-report-0000000000000001.json")
+
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: .defaultTimeout)
+        }
+
+        func testOnInjectedTerminationReport_fetchUnsentCrashReports_unexplainedShouldntBeReported() throws {
+            givenCrashReporter()
+
+            try copyReport(
+                named: "termination_unexplained_report",
+                toFilePath: "/Reports/appId-report-0000000000000001.json"
+            )
+
+            let expectation = XCTestExpectation()
+            crashReporter.fetchUnsentCrashReports { reports in
+                // A plain force-quit lands in `unexplained`; reporting it would turn every
+                // swipe-away in the app switcher into a crash.
+                XCTAssertEqual(reports.count, 0)
+                self.thenShouldntExistReport(withName: "appId-report-0000000000000001.json")
+
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: .defaultTimeout)
+        }
+
+        func testOnInjectedTerminationReports_fetchUnsentCrashReports_shouldntAffectRealCrashes() throws {
+            givenCrashReporter()
+
+            // given a real crash report alongside two droppable injected termination reports
+            try copyReport(named: "crash_report", toFilePath: "/Reports/appId-report-0000000000000001.json")
+            try copyReport(
+                named: "termination_unexplained_report",
+                toFilePath: "/Reports/appId-report-0000000000000002.json"
+            )
+            try copyReport(
+                named: "termination_oom_background_report",
+                toFilePath: "/Reports/appId-report-0000000000000003.json"
+            )
+
+            let expectation = XCTestExpectation()
+            crashReporter.fetchUnsentCrashReports { reports in
+                XCTAssertEqual(reports.count, 1)
+                XCTAssertEqual(reports[0].internalId, 1)
+                XCTAssertEqual(reports[0].sessionId, TestConstants.sessionId.stringValue)
+                self.thenShouldntExistReport(withName: "appId-report-0000000000000002.json")
+                self.thenShouldntExistReport(withName: "appId-report-0000000000000003.json")
+
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: .defaultTimeout)
+        }
     }
 
     extension EmbraceCrashReporterTests {

--- a/Tests/EmbraceCrashTests/Mocks/termination_oom_background_report.json
+++ b/Tests/EmbraceCrashTests/Mocks/termination_oom_background_report.json
@@ -1,0 +1,32 @@
+{
+    "report": {
+        "version": "3.9.0",
+        "id": "7E5C2A3F-2D4B-4F8C-8B1E-3A6D9C4F8B22",
+        "run_id": "B2C3D4E5-F6A7-4B8C-9D0E-1F2A3B4C5D6E",
+        "process_name": "",
+        "timestamp": 1696619964760585,
+        "type": "standard",
+        "monitor_id": "Termination"
+    },
+    "system": {
+        "application_stats": {
+            "application_active": false,
+            "application_in_foreground": false,
+            "app_transition_state": "background",
+            "user_perceptible": false
+        }
+    },
+    "crash": {
+        "error": {
+            "type": "termination",
+            "termination_reason": "memory_limit",
+            "is_fatal": true,
+            "is_clean_exit": false,
+            "signal": {
+                "signal": 9,
+                "name": "SIGKILL",
+                "code": 0
+            }
+        }
+    }
+}

--- a/Tests/EmbraceCrashTests/Mocks/termination_oom_foreground_report.json
+++ b/Tests/EmbraceCrashTests/Mocks/termination_oom_foreground_report.json
@@ -1,0 +1,32 @@
+{
+    "report": {
+        "version": "3.9.0",
+        "id": "6D4B1F2E-1C3A-4E7B-9A0D-2F5C8B3E7A11",
+        "run_id": "A1B2C3D4-E5F6-4A7B-8C9D-0E1F2A3B4C5D",
+        "process_name": "",
+        "timestamp": 1696619964760585,
+        "type": "standard",
+        "monitor_id": "Termination"
+    },
+    "system": {
+        "application_stats": {
+            "application_active": true,
+            "application_in_foreground": true,
+            "app_transition_state": "active",
+            "user_perceptible": true
+        }
+    },
+    "crash": {
+        "error": {
+            "type": "termination",
+            "termination_reason": "memory_limit",
+            "is_fatal": true,
+            "is_clean_exit": false,
+            "signal": {
+                "signal": 9,
+                "name": "SIGKILL",
+                "code": 0
+            }
+        }
+    }
+}

--- a/Tests/EmbraceCrashTests/Mocks/termination_unexplained_report.json
+++ b/Tests/EmbraceCrashTests/Mocks/termination_unexplained_report.json
@@ -1,0 +1,32 @@
+{
+    "report": {
+        "version": "3.9.0",
+        "id": "8F6D3B4A-3E5C-4A9D-9C2F-4B7E0D5A9C33",
+        "run_id": "C3D4E5F6-A7B8-4C9D-8E0F-2A3B4C5D6E7F",
+        "process_name": "",
+        "timestamp": 1696619964760585,
+        "type": "standard",
+        "monitor_id": "Termination"
+    },
+    "system": {
+        "application_stats": {
+            "application_active": true,
+            "application_in_foreground": true,
+            "app_transition_state": "active",
+            "user_perceptible": true
+        }
+    },
+    "crash": {
+        "error": {
+            "type": "termination",
+            "termination_reason": "unexplained",
+            "is_fatal": true,
+            "is_clean_exit": false,
+            "signal": {
+                "signal": 9,
+                "name": "SIGKILL",
+                "code": 0
+            }
+        }
+    }
+}

--- a/bin/templates/EmbraceIO.podspec.tpl
+++ b/bin/templates/EmbraceIO.podspec.tpl
@@ -132,7 +132,7 @@ Pod::Spec.new do |spec|
 
   # External
   spec.subspec 'EmbraceKSCrash' do |subs|
-    subs.dependency "KSCrash", "~> 2.5.1"
+    subs.dependency "KSCrash", "2.6.0"
   end
 
   spec.subspec 'OpenTelemetrySdk' do |subs|


### PR DESCRIPTION
- Makes both cocoapods and spm point to KSCrash 2.6.0 
- Adds code to handle 2.6.0 terminations the way we handled 2.5.1 terminations. 