### PR TITLE
[EMBR-13799] Feature: Fixing exported crash logs containing the wrong attributes and metadata

### DIFF
--- a/Sources/EmbraceCaptureService/CaptureService+OTel.swift
+++ b/Sources/EmbraceCaptureService/CaptureService+OTel.swift
@@ -119,8 +119,7 @@ extension CaptureService {
             attachment: attachment,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior,
-            isInternal: false,
-            send: true
+            isInternal: false
         )
     }
 }

--- a/Sources/EmbraceCommonInternal/OTelBridge/EmbraceOTelSignalsHandler.swift
+++ b/Sources/EmbraceCommonInternal/OTelBridge/EmbraceOTelSignalsHandler.swift
@@ -43,8 +43,7 @@ package protocol EmbraceOTelSignalsHandler: AnyObject {
         attachment: EmbraceLogAttachment?,
         attributes: EmbraceAttributes,
         stackTraceBehavior: EmbraceStackTraceBehavior,
-        isInternal: Bool,
-        send: Bool
+        isInternal: Bool
     ) throws
 }
 
@@ -109,8 +108,7 @@ extension EmbraceOTelSignalsHandler {
             attachment: attachment,
             attributes: attributes,
             stackTraceBehavior: stackTraceBehavior,
-            isInternal: true,
-            send: true
+            isInternal: true
         )
     }
 }

--- a/Sources/EmbraceCore/Internal/Logs/LogController.swift
+++ b/Sources/EmbraceCore/Internal/Logs/LogController.swift
@@ -96,7 +96,6 @@ class LogController: LogBatcherDelegate {
         attachment: EmbraceLogAttachment? = nil,
         attributes: EmbraceAttributes = [:],
         stackTraceBehavior: EmbraceStackTraceBehavior = .default,
-        send: Bool = true,
         completion: ((EmbraceLog?) -> Void)? = nil
     ) {
 
@@ -199,9 +198,7 @@ class LogController: LogBatcherDelegate {
                 sessionId: sessionController.currentSession?.id
             )
 
-            if send {
-                addLog(log)
-            }
+            addLog(log)
 
             completion?(log)
         }

--- a/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
+++ b/Sources/EmbraceCore/Internal/OTel/DefaultOTelSignalsHandler+Internal.swift
@@ -182,8 +182,7 @@ extension DefaultOTelSignalsHandler: InternalOTelSignalsHandler {
         attachment: EmbraceLogAttachment? = nil,
         attributes: EmbraceAttributes = [:],
         stackTraceBehavior: EmbraceStackTraceBehavior = .default,
-        isInternal: Bool = true,
-        send: Bool = true
+        isInternal: Bool = true
     ) throws {
 
         guard isInternal || limiter.shouldCreateLog(type: type, severity: severity) else {
@@ -197,8 +196,7 @@ extension DefaultOTelSignalsHandler: InternalOTelSignalsHandler {
             timestamp: timestamp,
             attachment: attachment,
             attributes: isInternal ? attributes : sanitizer.sanitizeLogAttributes(attributes),
-            stackTraceBehavior: stackTraceBehavior,
-            send: send
+            stackTraceBehavior: stackTraceBehavior
         ) { [weak self] log in
             if let log {
                 self?.bridge.createLog(log)
@@ -222,25 +220,15 @@ extension DefaultOTelSignalsHandler: InternalOTelSignalsHandler {
         limiter.reset()
     }
 
-    // creates a log that is not saved nor added to the batch
-    // only used for logs that are handled in a special manner
-    // but still need to be exported externally (i.e crash logs)
-    func exportLog(
-        _ message: String,
-        severity: EmbraceLogSeverity,
-        type: EmbraceType = .message,
-        timestamp: Date = Date(),
-        attributes: EmbraceAttributes = [:]
-    ) {
-        try? _log(
-            message,
-            severity: severity,
-            type: type,
-            timestamp: timestamp,
-            attributes: attributes,
-            isInternal: true,
-            send: false
-        )
+    // forwards an already-built log to the OTel pipeline, without saving it nor adding it
+    // to the batch. Only used for logs that are handled in a special manner but still need
+    // to be exported externally (i.e crash logs).
+    //
+    // The log is passed through untouched on purpose: these logs can describe a session and a
+    // process that already ended, so the caller owns their attributes and nothing is derived
+    // from the current session here.
+    func exportLog(_ log: EmbraceLog) {
+        bridge.createLog(log)
     }
 
     // creates a new span

--- a/Sources/EmbraceCore/Internal/OTel/InternalOTelSignalsHandler.swift
+++ b/Sources/EmbraceCore/Internal/OTel/InternalOTelSignalsHandler.swift
@@ -16,11 +16,12 @@ protocol AutoTerminationSpansHandler {
 }
 
 protocol OnlyExportableLogsHandler {
-    func exportLog(
-        _ message: String,
-        severity: EmbraceLogSeverity,
-        type: EmbraceType,
-        timestamp: Date,
-        attributes: EmbraceAttributes
-    )
+    /// Forwards an already-built log to the OTel pipeline, without saving it to storage
+    /// nor adding it to the upload batch.
+    ///
+    /// The log is exported verbatim. None of the session-scoped attributes that regular logs
+    /// get are derived here, because the caller is expected to have built them already: these
+    /// logs can belong to a session and a process other than the current ones, and re-deriving
+    /// the attributes would describe the wrong session.
+    func exportLog(_ log: EmbraceLog)
 }

--- a/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
+++ b/Sources/EmbraceCore/Session/DataRecovery/UnsentDataHandler.swift
@@ -184,15 +184,33 @@ class UnsentDataHandler {
         completion: UnsentDataHandlerCompletion? = nil
     ) {
         let timestamp = (report.timestamp ?? session?.lastHeartbeatTime) ?? Date()
+        let finalProcessId = processId ?? session?.processId
 
-        // send otel log
         let attributes = createLogCrashAttributes(
-            otel: otel,
             storage: storage,
             report: report,
             session: session,
-            timestamp: timestamp,
-            processId: processId
+            processId: finalProcessId
+        )
+
+        // Push the crash log through the OTel pipeline so processors and exporters set by the
+        // user get to see it. The log is handed over fully built: it describes the session and
+        // the process that crashed, both of which have already ended, so re-deriving any of its
+        // attributes from the current session would attribute the crash to the wrong one.
+        //
+        // The log id matches `LogSemantics.Crash.keyId` in the attributes, so the record and the
+        // crash report it carries are identified by the same value.
+        otel?.exportLog(
+            DefaultEmbraceLog(
+                id: report.id.withoutHyphen,
+                severity: .fatal,
+                type: .crash,
+                timestamp: timestamp,
+                body: "",
+                attributes: attributes,
+                sessionId: session?.id,
+                processId: finalProcessId ?? ProcessIdentifier.current
+            )
         )
 
         guard let upload = upload else {
@@ -210,7 +228,7 @@ class UnsentDataHandler {
                 attributes: attributes,
                 storage: storage,
                 userSessionId: session?.userSessionId,
-                processId: processId ?? session?.processId
+                processId: finalProcessId
             )
             let payloadData = try JSONEncoder().encode(payload).gzipped()
 
@@ -238,11 +256,9 @@ class UnsentDataHandler {
     }
 
     static private func createLogCrashAttributes(
-        otel: InternalOTelSignalsHandler?,
         storage: EmbraceStorage?,
         report: EmbraceCrashReport,
         session: EmbraceSession?,
-        timestamp: Date,
         processId: EmbraceIdentifier?
     ) -> EmbraceAttributes {
 
@@ -267,7 +283,7 @@ class UnsentDataHandler {
                 )?.value
         }
 
-        let attributes =
+        return
             attributesBuilder
             .addLogType(.crash)
             .addApplicationProperties()
@@ -276,16 +292,6 @@ class UnsentDataHandler {
             .addCrashReportProperties()
             .addExperiments(experiments)
             .build()
-
-        otel?.exportLog(
-            "",
-            severity: .fatal,
-            type: .crash,
-            timestamp: timestamp,
-            attributes: attributes
-        )
-
-        return attributes
     }
 
     static private func sendSessions(

--- a/Tests/EmbraceCoreTests/Internal/OTel/DefaultOTelSignalsHandlerInternalTests.swift
+++ b/Tests/EmbraceCoreTests/Internal/OTel/DefaultOTelSignalsHandlerInternalTests.swift
@@ -2,6 +2,7 @@
 //  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
 //
 
+import EmbraceCommonInternal
 import EmbraceSemantics
 import EmbraceStorageInternal
 import TestSupport
@@ -220,26 +221,58 @@ class DefaultOTelSignalsHandlerInternalTests: XCTestCase {
         limiter.shouldCreateLogReturnValue = false
         sanitizer.sanitizeLogAttributesReturnValue = ["sanitizedKey": "sanitizedValue"]
 
-        // when exporting a log
+        // given a prebuilt log that belongs to a session and a process other than the current ones
         let timestamp = Date(timeIntervalSince1970: 5)
+        let otherSessionId = EmbraceIdentifier.random
+        let otherProcessId = EmbraceIdentifier.random
+        let attributes: EmbraceAttributes = [
+            "key": "value",
+            LogSemantics.keyEmbraceType: EmbraceType.crash.rawValue,
+            LogSemantics.keyState: SessionState.background.rawValue,
+            LogSemantics.keySessionId: "other-user-session",
+            LogSemantics.keyUserSessionId: "other-user-session",
+            LogSemantics.keyPartId: otherSessionId.stringValue,
+            LogSemantics.keyExperiments: "other-experiments"
+        ]
+
+        // when exporting it
         handler.exportLog(
-            "test",
-            severity: .debug,
-            type: .message,
-            timestamp: timestamp,
-            attributes: ["key": "value"]
+            DefaultEmbraceLog(
+                id: "test-id",
+                severity: .fatal,
+                type: .crash,
+                timestamp: timestamp,
+                body: "test",
+                attributes: attributes,
+                sessionId: otherSessionId,
+                processId: otherProcessId
+            )
         )
 
-        // then the right calls are made
+        // then no limit is checked and nothing is sanitized
         XCTAssertEqual(limiter.shouldCreateLogCallCount, 0)
         XCTAssertEqual(sanitizer.sanitizeLogAttributesCallCount, 0)
 
-        // then the log is forwarded to the bridge without it being added to the batch
+        // then the log is forwarded to the bridge untouched
         wait(delay: .defaultTimeout)
-        XCTAssertNil(logController.batcher.currentBatch())
         XCTAssertEqual(bridge.createLogCallCount, 1)
+        let exported = try XCTUnwrap(bridge.createdLogs.first)
+        XCTAssertEqual(exported.id, "test-id")
+        XCTAssertEqual(exported.severity, .fatal)
+        XCTAssertEqual(exported.type, .crash)
+        XCTAssertEqual(exported.timestamp, timestamp)
+        XCTAssertEqual(exported.body, "test")
+        XCTAssertEqual(exported.sessionId, otherSessionId)
+        XCTAssertEqual(exported.processId, otherProcessId)
 
-        // then the log is not saved
+        // the attributes of the current session must not replace the ones the log came with
+        XCTAssertEqual(exported.attributes.count, attributes.count)
+        for (key, value) in attributes {
+            XCTAssertEqual(exported.attributes[key] as? String, value as? String, "attribute \(key) was modified")
+        }
+
+        // then the log is neither batched nor saved
+        XCTAssertNil(logController.batcher.currentBatch())
         XCTAssertEqual(storage.fetchAllLogs().count, 0)
     }
 

--- a/Tests/EmbraceCoreTests/Public/OTel/MockOTelSignalBridge.swift
+++ b/Tests/EmbraceCoreTests/Public/OTel/MockOTelSignalBridge.swift
@@ -58,7 +58,9 @@ class MockOTelSignalBridge: EmbraceOTelSignalBridge {
     }
 
     var createLogCallCount: Int = 0
+    var createdLogs: [EmbraceLog] = []
     func createLog(_ log: any EmbraceLog) {
         createLogCallCount += 1
+        createdLogs.append(log)
     }
 }

--- a/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
+++ b/Tests/EmbraceCoreTests/Session/UnsentDataHandlerTests.swift
@@ -686,6 +686,140 @@ class UnsentDataHandlerTests: XCTestCase {
         XCTAssertNil(resource["app_version"] as? String)
     }
 
+    func test_sendCrashReports_exportedLog_describesTheCrashedSession() async throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on WatchOS")
+        // mock successful requests
+        EmbraceHTTPMock.mock(url: testSpansUrl())
+        EmbraceHTTPMock.mock(url: testLogsUrl())
+
+        // given a storage and upload modules
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let upload = try EmbraceUpload(
+            options: uploadOptions, logger: logger, queue: queue)
+
+        let otel = MockOTelSignalsHandler()
+
+        // given a crash reporter with a report tied to a session
+        let crashReporter = CrashReporterMock(crashSessionId: TestConstants.sessionId.stringValue)
+        let embraceReporter = EmbraceCrashReporter(reporter: crashReporter)
+        let report = crashReporter.mockReports[0]
+
+        // given that session in the storage, backgrounded and belonging to a previous process
+        let previousProcessId = EmbraceIdentifier.random
+        let previousUserSessionId = EmbraceIdentifier.random
+        await storage.addSession(
+            id: TestConstants.sessionId,
+            processId: previousProcessId,
+            state: .background,
+            traceId: TestConstants.traceId,
+            spanId: TestConstants.spanId,
+            startTime: Date(timeIntervalSinceNow: -60),
+            endTime: Date(),
+            userSessionId: previousUserSessionId
+        )
+
+        // given experiments in storage for that process and for the current one
+        storage.addMetadata(
+            key: LogSemantics.keyExperiments,
+            value: "previous_experiments",
+            type: .requiredResource,
+            lifespan: .process,
+            lifespanId: previousProcessId.stringValue
+        )
+        storage.addMetadata(
+            key: LogSemantics.keyExperiments,
+            value: "current_experiments",
+            type: .requiredResource,
+            lifespan: .process,
+            lifespanId: ProcessIdentifier.current.stringValue
+        )
+
+        // when sending unsent data
+        await UnsentDataHandler.sendUnsentData(
+            storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: { EmbraceHTTPMock.requestBodiesForUrl(self.testLogsUrl()).count == 1 })
+        wait(timeout: .defaultTimeout, until: { otel.logs.count == 1 })
+
+        // then the log pushed through the OTel pipeline describes the session and the process
+        // that crashed, not the ones sending it
+        let exported = try XCTUnwrap(otel.logs.first)
+        XCTAssertEqual(exported.type, .crash)
+        XCTAssertEqual(exported.severity, .fatal)
+        XCTAssertEqual(exported.timestamp, report.timestamp)
+        XCTAssertEqual(exported.sessionId, TestConstants.sessionId)
+        XCTAssertEqual(exported.processId, previousProcessId)
+
+        XCTAssertEqual(exported.attributes[LogSemantics.keyPartId] as? String, TestConstants.sessionId.stringValue)
+        XCTAssertEqual(exported.attributes[LogSemantics.keySessionId] as? String, previousUserSessionId.stringValue)
+        XCTAssertEqual(
+            exported.attributes[LogSemantics.keyUserSessionId] as? String,
+            previousUserSessionId.stringValue
+        )
+        XCTAssertEqual(exported.attributes[LogSemantics.keyState] as? String, SessionState.background.rawValue)
+        XCTAssertEqual(exported.attributes[LogSemantics.keyExperiments] as? String, "previous_experiments")
+
+        // then the log is identified by the crash report it carries
+        XCTAssertEqual(exported.id, report.id.withoutHyphen)
+        XCTAssertEqual(exported.attributes[LogSemantics.Crash.keyId] as? String, report.id.withoutHyphen)
+    }
+
+    func test_sendCrashReports_exportedLog_noSessionNoProcessId_hasNoExperiments() async throws {
+        try XCTSkipIf(XCTestCase.isWatchOS(), "Unavailable on WatchOS")
+        // mock successful requests
+        EmbraceHTTPMock.mock(url: testSpansUrl())
+        EmbraceHTTPMock.mock(url: testLogsUrl())
+
+        // given a storage and upload modules
+        let storage = try EmbraceStorage.createInMemoryDb()
+        defer { storage.coreData.destroy() }
+
+        let upload = try EmbraceUpload(
+            options: uploadOptions, logger: logger, queue: queue)
+
+        let otel = MockOTelSignalsHandler()
+
+        // given a crash reporter with a report that has no session nor process
+        let crashReporter = CrashReporterMock(
+            mockReports: [
+                EmbraceCrashReport(
+                    payload: "test",
+                    provider: "mock",
+                    internalId: 123,
+                    sessionId: nil,
+                    processId: nil,
+                    timestamp: Date()
+                )
+            ]
+        )
+        let embraceReporter = EmbraceCrashReporter(reporter: crashReporter)
+
+        // given experiments in storage for the current process
+        storage.addMetadata(
+            key: LogSemantics.keyExperiments,
+            value: "current_experiments",
+            type: .requiredResource,
+            lifespan: .process,
+            lifespanId: ProcessIdentifier.current.stringValue
+        )
+
+        // when sending unsent data
+        await UnsentDataHandler.sendUnsentData(
+            storage: storage, upload: upload, otel: otel, crashReporter: embraceReporter)
+        wait(
+            timeout: .longTimeout, interval: .shortInterval,
+            until: { EmbraceHTTPMock.requestBodiesForUrl(self.testLogsUrl()).count == 1 })
+        wait(timeout: .defaultTimeout, until: { otel.logs.count == 1 })
+
+        // then the log pushed through the OTel pipeline carries no experiments: the crash belongs
+        // to a process that can't be identified, so the ones of this process would be a wrong guess
+        let exported = try XCTUnwrap(otel.logs.first)
+        XCTAssertNil(exported.attributes[LogSemantics.keyExperiments])
+    }
+
     func test_spanCleanUp_sendUnsentData() async throws {
         // mock successful requests
         EmbraceHTTPMock.mock(url: testSpansUrl())

--- a/Tests/TestSupport/Mocks/MockOTelSignalsHandler.swift
+++ b/Tests/TestSupport/Mocks/MockOTelSignalsHandler.swift
@@ -88,8 +88,7 @@ public class MockOTelSignalsHandler: InternalOTelSignalsHandler, MockSpanDelegat
         attachment: EmbraceLogAttachment? = nil,
         attributes: EmbraceAttributes = [:],
         stackTraceBehavior: EmbraceStackTraceBehavior = .default,
-        isInternal: Bool = true,
-        send: Bool = true
+        isInternal: Bool = true
     ) {
         let log = MockLog(
             id: UUID().withoutHyphen,
@@ -113,21 +112,7 @@ public class MockOTelSignalsHandler: InternalOTelSignalsHandler, MockSpanDelegat
 
     }
 
-    public func exportLog(
-        _ message: String,
-        severity: EmbraceLogSeverity,
-        type: EmbraceType,
-        timestamp: Date,
-        attributes: EmbraceAttributes
-    ) {
-        _log(
-            message,
-            severity: severity,
-            type: type,
-            timestamp: timestamp,
-            attachment: nil,
-            attributes: attributes,
-            stackTraceBehavior: .notIncluded
-        )
+    public func exportLog(_ log: EmbraceLog) {
+        logs.append(log)
     }
 }


### PR DESCRIPTION
This fixes the bug we found while building the Experiments feature for 6.x

This PR addresses this for 7.x, as discussed.