### PR TITLE
Add regression test for completed session spans reaching custom exporters (#710)

### DIFF
--- a/Tests/EmbraceOTelBridgeTests/SessionSpanCustomExporterTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/SessionSpanCustomExporterTests.swift
@@ -1,0 +1,131 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+import EmbraceCommonInternal
+import EmbraceSemantics
+import OpenTelemetryApi
+import OpenTelemetrySdk
+import TestSupport
+import XCTest
+
+@testable import EmbraceOTelBridge
+
+/// Regression test for https://github.com/embrace-io/embrace-apple-sdk/issues/710:
+/// "Completed session spans are not exported to custom exporters".
+///
+/// In 6.x, `EmbraceOTelInternal`'s `EmbraceSpanProcessor.hydrateSpan` returned `nil` for any
+/// ended `ux.session` span, so a custom `SpanExporter` (wired via `OpenTelemetryExport`) only
+/// ever saw in-progress heartbeat snapshots and never the final, ended span. That processor was
+/// removed in 7.0 (#675); today's `EmbraceOTelBridge/EmbraceSpanProcessor` forwards every span
+/// to its child exporters on `onEnd`, with no session-span filter.
+///
+/// This locks that behaviour in at the bridge layer, covering the gap between
+/// `EmbraceSpanProcessorTests.test_onEnd_skipsInternalSpans` (an internal span is withheld from
+/// the *Core delegate*) and `test_onEnd_forwardsSpanDataToChildExporters` (an *external* span
+/// reaches child exporters). Neither asserts what #710 is actually about: an internal span must
+/// be withheld from the delegate **and** still reach a user-supplied exporter.
+///
+/// Scope: this drives `EmbraceOTelBridge` directly, mirroring the three calls `SessionController`
+/// ends up making, because `EmbraceOTelBridgeTests` cannot depend on `EmbraceCore`:
+/// - `SessionSpanUtils.span(otel:id:startTime:state:coldStart:)` reaches `startSpan` via
+///   `DefaultOTelSignalsHandler.createInternalSpan`.
+/// - `SessionController.update(heartbeat:)` reaches `updateSpanAttribute` via
+///   `SessionSpanUtils.setHeartbeat` → `EmbraceSpan.setInternalAttribute`.
+/// - `SessionController.endSessionNoLock` reaches `endSpan` via `EmbraceSpan.end(endTime:)`.
+///
+/// It therefore does **not** cover the Core-side layers above the bridge (the signals handler,
+/// its sanitizer, or `SessionController` itself); a regression introduced there would need a
+/// companion test in `EmbraceCoreTests`.
+final class SessionSpanCustomExporterTests: XCTestCase {
+
+    // Held as properties: `EmbraceOTelBridge.delegate` and `.metadataProvider` are `weak`, so
+    // mocks passed as temporaries would deallocate before the test body runs — leaving the
+    // processor on its `delegate == nil` path, where `isInternalSpan` is never consulted and
+    // this test would silently stop covering what it claims to.
+    private var bridge: EmbraceOTelBridge!
+    private var customExporter: InMemorySpanExporter!
+    private var mockDelegate: MockOTelDelegate!
+    private var mockMetadata: MockMetadataProvider!
+
+    override func setUp() {
+        super.setUp()
+        customExporter = InMemorySpanExporter()
+        mockDelegate = MockOTelDelegate()
+        mockMetadata = MockMetadataProvider()
+        bridge = EmbraceOTelBridge(spanExporters: [customExporter])
+        bridge.setup(delegate: mockDelegate, metadataProvider: mockMetadata)
+    }
+
+    func test_endedSessionSpan_isExportedToCustomExporter() throws {
+        XCTAssertNotNil(bridge.delegate, "delegate must outlive setup — see the property comment above")
+        XCTAssertNotNil(bridge.metadataProvider, "metadata provider must outlive setup")
+
+        let start = Date(timeIntervalSince1970: 1_000)
+        let heartbeat = start.addingTimeInterval(30)
+        let end = start.addingTimeInterval(60)
+
+        // Mirrors SessionSpanUtils.span(otel:id:startTime:state:coldStart:). `emb.type` is set
+        // explicitly here because createInternalSpan stamps it from its `type:` argument.
+        let context = bridge.startSpan(
+            name: SpanSemantics.Session.name,
+            parentSpan: nil,
+            status: .unset,
+            startTime: start,
+            endTime: nil,
+            events: [],
+            links: [],
+            attributes: [
+                SpanSemantics.keyEmbraceType: EmbraceType.session.rawValue,
+                SpanSemantics.Session.keyPartId: "part-123",
+                SpanSemantics.Session.keyState: SessionState.foreground.rawValue,
+                SpanSemantics.Session.keyColdStart: String(true)
+            ]
+        )
+        let spanId = try XCTUnwrap(SpanId(fromHexString: context.spanId))
+        let sessionSpan = MockEmbraceSpan(spanId: context.spanId, traceId: context.traceId)
+
+        // Mirrors SessionController.update(heartbeat:) -> SessionSpanUtils.setHeartbeat, the
+        // periodic tick the original issue described as leaking a partial export every ~5s.
+        bridge.updateSpanAttribute(
+            sessionSpan,
+            key: SpanSemantics.Session.keyHeartbeat,
+            value: String(heartbeat.nanosecondsSince1970Truncated)
+        )
+
+        // Drain the processor queue before asserting absence: exports are dispatched
+        // asynchronously, so an unsynchronized nil check here could never fail.
+        bridge.waitForAllWork()
+        XCTAssertTrue(
+            customExporter.exportedSpans.isEmpty,
+            "a heartbeat attribute update must not export — the processor only runs on onStart/onEnd"
+        )
+
+        // Mirrors SessionController.endSessionNoLock's `inProgressSessionSpan.end(endTime: now)`,
+        // which routes through DefaultOTelSignalsHandler.onSpanEnded -> bridge.endSpan.
+        bridge.endSpan(sessionSpan, endTime: end)
+
+        wait(timeout: .defaultTimeout) { self.customExporter.exportedSpans.count == 1 }
+
+        let exported = try XCTUnwrap(customExporter.exportedSpans[spanId])
+
+        XCTAssertEqual(exported.name, SpanSemantics.Session.name)
+        XCTAssertTrue(exported.hasEnded, "custom exporter must receive the ended span, not an in-progress snapshot")
+        XCTAssertEqual(exported.endTime, end)
+        XCTAssertEqual(
+            exported.attributes[SpanSemantics.keyEmbraceType],
+            .string(EmbraceType.session.rawValue),
+            "emb.type must survive as ux.session — injectAttributes overwrites it if the span is misread as external"
+        )
+        XCTAssertEqual(
+            exported.attributes[SpanSemantics.Session.keyHeartbeat],
+            .string(String(heartbeat.nanosecondsSince1970Truncated)),
+            "the final export should still carry the last heartbeat value set during the session"
+        )
+
+        // The other half of #710: the span is the bridge's own, so Core must not be notified of
+        // it as an external signal — yet it still has to reach the user-supplied exporter above.
+        XCTAssertTrue(mockDelegate.startedSpans.isEmpty, "an internal session span must not reach the Core delegate")
+        XCTAssertTrue(mockDelegate.endedSpans.isEmpty, "an internal session span must not reach the Core delegate")
+    }
+}

--- a/Tests/EmbraceOTelBridgeTests/SessionSpanCustomExporterTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/SessionSpanCustomExporterTests.swift
@@ -101,13 +101,17 @@ final class SessionSpanCustomExporterTests: XCTestCase {
             0,
             "a heartbeat attribute update must not trigger exporter calls"
         )
-        XCTAssertTrue(customExporter.exportedSpans.isEmpty)
+        XCTAssertTrue(
+            customExporter.exportedSpans.isEmpty,
+            "no partial snapshot may reach the exporter mid-session"
+        )
 
         // Mirrors SessionController.endSessionNoLock's `inProgressSessionSpan.end(endTime: now)`,
         // which routes through DefaultOTelSignalsHandler.onSpanEnded -> bridge.endSpan.
         bridge.endSpan(sessionSpan, endTime: end)
 
-        wait(timeout: .defaultTimeout) { self.customExporter.exportCallCount == 1 }
+        // endSpan queues exporter work onto the processor queue; drain deterministically before asserts.
+        bridge.waitForAllWork()
 
         XCTAssertEqual(
             customExporter.exportCallCount,

--- a/Tests/EmbraceOTelBridgeTests/SessionSpanCustomExporterTests.swift
+++ b/Tests/EmbraceOTelBridgeTests/SessionSpanCustomExporterTests.swift
@@ -94,18 +94,26 @@ final class SessionSpanCustomExporterTests: XCTestCase {
         )
 
         // Drain the processor queue before asserting absence: exports are dispatched
-        // asynchronously, so an unsynchronized nil check here could never fail.
+        // asynchronously, so an unsynchronized check here could never fail.
         bridge.waitForAllWork()
-        XCTAssertTrue(
-            customExporter.exportedSpans.isEmpty,
-            "a heartbeat attribute update must not export — the processor only runs on onStart/onEnd"
+        XCTAssertEqual(
+            customExporter.exportCallCount,
+            0,
+            "a heartbeat attribute update must not trigger exporter calls"
         )
+        XCTAssertTrue(customExporter.exportedSpans.isEmpty)
 
         // Mirrors SessionController.endSessionNoLock's `inProgressSessionSpan.end(endTime: now)`,
         // which routes through DefaultOTelSignalsHandler.onSpanEnded -> bridge.endSpan.
         bridge.endSpan(sessionSpan, endTime: end)
 
-        wait(timeout: .defaultTimeout) { self.customExporter.exportedSpans.count == 1 }
+        wait(timeout: .defaultTimeout) { self.customExporter.exportCallCount == 1 }
+
+        XCTAssertEqual(
+            customExporter.exportCallCount,
+            1,
+            "session span should be exported exactly once, on end"
+        )
 
         let exported = try XCTUnwrap(customExporter.exportedSpans[spanId])
 

--- a/Tests/TestSupport/Mocks/SpanExporter/InMemorySpanExporter.swift
+++ b/Tests/TestSupport/Mocks/SpanExporter/InMemorySpanExporter.swift
@@ -16,6 +16,13 @@ public class InMemorySpanExporter: SpanExporter {
         return _exportedSpans
     }
 
+    private var _exportCallCount = 0
+    public var exportCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _exportCallCount
+    }
+
     private var _isShutdown = false
     public var isShutdown: Bool {
         lock.lock()
@@ -44,6 +51,8 @@ public class InMemorySpanExporter: SpanExporter {
     public func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
         lock.lock()
         defer { lock.unlock() }
+
+        _exportCallCount += 1
 
         spans.forEach { data in
             _exportedSpans[data.spanId] = data


### PR DESCRIPTION
## Summary
Adds a bridge-level regression test for #710: an internal `ux.session` span must be withheld
from the Core delegate **and** still reach a user-supplied `SpanExporter`.

Investigated #710 and could not reproduce it on `main`. The pre-7.0 architecture named in the
issue (`EmbraceOTelInternal`, `EmbraceSpanProcessor.hydrateSpan`, `StorageSpanExporter`) was
removed in 7.0 (#675). `hydrateSpan` returned `nil` for any ended `ux.session` span; the current
`EmbraceSpanProcessor.onEnd` has no equivalent filter and forwards every span to its child
exporters.

The other half of the report is also gone: `SessionSpanUtils.setHeartbeat` mutates the live OTel
span via `EmbraceOTelBridge.updateSpanAttribute` and never reaches the processor, which only runs
on `onStart`/`onEnd`. So no code path remains that exports an in-progress snapshot.

## Gap this covers
`EmbraceSpanProcessorTests` already has `test_onEnd_skipsInternalSpans` (internal span withheld
from the Core delegate) and `test_onEnd_forwardsSpanDataToChildExporters` (external span reaches
child exporters). Neither asserts the combination #710 is actually about: an internal session
span withheld from the delegate *while still* reaching a user-supplied exporter.

## Scope and limits
Drives `EmbraceOTelBridge` directly, mirroring the three calls `SessionController` makes, because
`EmbraceOTelBridgeTests` does not depend on `EmbraceCore`. It therefore does **not** cover the
Core layers above the bridge: the signals handler, its sanitizer, or `SessionController` itself.
A regression introduced there would need a companion test in `EmbraceCoreTests`.

## Verified by mutation
The test was checked against three deliberate regressions, each reverted afterwards:
- Reintroducing the `hydrateSpan` session filter in `onEnd` → export assertions fail.
- Exporting an in-progress snapshot from `updateSpanAttribute` → heartbeat assertion fails.
- Making `isInternalSpan` return `false` → `emb.type` and delegate assertions fail.

## Test Plan
- `EmbraceOTelBridgeTests`: 98 tests pass
- `make check-swift-format-changes` (the CI gate, `--strict`): clean
- `swiftlint lint` (default rules as the repo has no `.swiftlint.yml`): 0 violations

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
