### PR TITLE
Fix: Tests: restore global state leaked by PerformanceTests

### DIFF
--- a/Tests/EmbraceIOTests/PerformanceTests.swift
+++ b/Tests/EmbraceIOTests/PerformanceTests.swift
@@ -26,7 +26,10 @@ class PerformanceTests: XCTestCase {
     func runStartup(_ options: Embrace.Options) {
 
         #if !os(watchOS)
+            let swizzleCacheBaseline = Set(SwizzleCache.shared.residueDescription)
             defer {
+                _ = try? Embrace.client?.stop()
+                SwizzleCache.shared.restoreEntries(addedSince: swizzleCacheBaseline)
                 Embrace.client = nil
             }
 
@@ -45,10 +48,13 @@ class PerformanceTests: XCTestCase {
                     didBecomeActiveNotif = UIApplication.didBecomeActiveNotification
                     didFinishLaunchingNotif = UIApplication.didFinishLaunchingNotification
                 #endif
-                NotificationCenter.default.addObserver(forName: didBecomeActiveNotif, object: nil, queue: .main) { _ in
+                let observer = NotificationCenter.default.addObserver(forName: didBecomeActiveNotif, object: nil, queue: .main) { _ in
                     RunLoop.main.perform(inModes: [.common]) {
                         expect.fulfill()
                     }
+                }
+                defer {
+                    NotificationCenter.default.removeObserver(observer)
                 }
 
                 NotificationCenter.default.post(name: didFinishLaunchingNotif, object: nil)


### PR DESCRIPTION
## Goal

Make a full `swift test` run green. Four tests in `EmbraceCommonInternalTests.SwizzleCacheTests`
fail today in a full-package run and pass in every narrower run, because `PerformanceTests`
leaves the Objective-C runtime and `SwizzleCache` dirty for everything that runs after it.

## Problem

`PerformanceTests.test_embraceStartBasic` starts the SDK with
`CaptureServicesOptions.default().list`, which installs the URLSession and WKWebView swizzlers.
Capture services have no uninstall API by design, and the test's only cleanup was
`Embrace.client = nil`, so 17 to 18 `SwizzleCache` entries (depending on which swizzler tests
ran in between) survived for the remainder of the process:

```
DataTaskWithURLSwizzler on NSURLSession.dataTaskWithURL:
URLSessionInitWithDelegateSwizzler on NSURLSession.sessionWithConfiguration:delegate:delegateQueue:
WKWebViewLoadRequestSwizzler on WKWebView.loadRequest:
... 14 more
```

All test targets link into one `EmbraceIOPackageTests.xctest` binary and XCTest runs classes
alphabetically across targets, so `PerformanceTests` (P) runs before `SwizzleCacheTests` (S) and
trips its empty cache guard in `setUpWithError`:

```
SwizzleCacheTests.swift:36: error: XCTAssertTrue failed - test pollution from prior tests: [...]
```

Two consequences beyond the four red tests:

1. Every test that runs after `PerformanceTests` executes against `NSURLSession` and `WKWebView`
   methods still swizzled to a torn down SDK's blocks.
2. The `EmbraceCoreTests` swizzler tests that follow hit `SwizzleCache`'s duplicate install path,
   so their `assertNoNewSwizzleCacheEntries()` teardown assertion passes vacuously and stops
   detecting their own leaks.

## Reproduce

```
swift test --filter PerformanceTests --filter SwizzleCacheTests
```

Fails on `main` with 5 assertion failures across 4 tests. `swift test --filter SwizzleCacheTests`
and `swift test --filter EmbraceCommonInternalTests` both pass, which is why this has not shown
up in CI.

## Changes

Test only, no SDK source changes.

`runStartup` now snapshots `SwizzleCache` before setup and, on scope exit, stops the client and
restores every entry added since that snapshot via the existing public
`SwizzleCache.restoreEntries(addedSince:)` API. This is the same mechanism the capture service
tests in `EmbraceCoreTests` already use through `restoreSwizzleCacheAdditions()`.

The same `defer` also removes the `didBecomeActive` observer. Each startup previously left one
registered for the lifetime of the process, capturing that test's `XCTestExpectation`, so a later
startup's notification fulfilled an expectation belonging to a test that had already finished.

## Verification

| Command | Before | After |
| --- | --- | --- |
| `swift test` | 1326 tests, 4 skipped, 5 failures | 1326 tests, 4 skipped, 0 failures |
| `swift test --filter PerformanceTests --filter SwizzleCacheTests` | 5 failures | 8 tests, 0 failures |
| `swift test --filter EmbraceCoreTests` | 801 passed, 4 skipped | unchanged |

`test_embraceStartBasic` still takes 0.111s and `test_embraceStartSimple` 0.007s, identical to
before, so the startup work these tests exist to exercise is unchanged. The residue is restored
after the measurement, not skipped. `swift format lint --strict` on the changed file is clean.

## Notes

An alternative is to move `SwizzlerTestCase` from `Tests/EmbraceCoreTests/TestSupport/Utilities/`
into the shared `Tests/TestSupport` target and make `PerformanceTests` subclass it, which would
add the `assertNoNewSwizzleCacheEntries()` guard here and make the helper available to every test
target. I kept this PR minimal, but happy to do that instead if you prefer it.

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
