### PR TITLE
[EMBR-13825] Feature: Implementing fragments handling in the WebViewCaptureService

### DIFF
--- a/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService+Options.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService+Options.swift
@@ -12,7 +12,7 @@
         /// the server, so it is commonly used to carry values that are not meant to leave the browser, such as
         /// the access tokens returned by the OAuth 2.0 implicit grant. It is also used to carry information that
         /// is useful when debugging, such as the hash routes of a single page application.
-        public enum FragmentHandling: Int {
+        public enum FragmentHandling {
             /// The fragment is captured exactly as it appears in the URL.
             case keep
 

--- a/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService+Options.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService+Options.swift
@@ -6,15 +6,45 @@
     import Foundation
 
     extension WebViewCaptureService {
+        /// Defines how the SDK should treat the fragment component of a URL captured from a web view.
+        ///
+        /// The fragment (everything after the first `#`) is resolved by the user agent alone and never sent to
+        /// the server, so it is commonly used to carry values that are not meant to leave the browser, such as
+        /// the access tokens returned by the OAuth 2.0 implicit grant. It is also used to carry information that
+        /// is useful when debugging, such as the hash routes of a single page application.
+        public enum FragmentHandling: Int {
+            /// The fragment is captured exactly as it appears in the URL.
+            case keep
+
+            /// Values in `key=value` pairs are removed, and unstructured segments long enough to be a payload
+            /// rather than a label are dropped. Hash routes and short anchors are preserved.
+            case redact
+
+            /// The fragment is removed from the captured URL entirely.
+            case remove
+        }
+
         /// Used to setup a WebViewCaptureService.
         public struct Options {
             /// Defines whether or not the Embrace SDK should remove the query params when capturing URLs from a web view.
             public let stripQueryParams: Bool
 
+            /// Defines how the Embrace SDK should treat the fragment when capturing URLs from a web view.
+            ///
+            /// This setting is independent of `stripQueryParams`: whether a fragment is captured never depends on
+            /// whether the URL has a query.
+            public let fragmentHandling: FragmentHandling
+
             /// Creates a new `Options` with the given values.
-            /// - Parameter stripQueryParams: Whether the SDK should remove query params when capturing URLs from a web view.
-            public init(stripQueryParams: Bool = false) {
+            /// - Parameters:
+            ///   - stripQueryParams: Whether the SDK should remove query params when capturing URLs from a web view.
+            ///   - fragmentHandling: How the SDK should treat the fragment when capturing URLs from a web view.
+            public init(
+                stripQueryParams: Bool = false,
+                fragmentHandling: FragmentHandling = .keep
+            ) {
                 self.stripQueryParams = stripQueryParams
+                self.fragmentHandling = fragmentHandling
             }
         }
     }

--- a/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WebViewCaptureService.swift
@@ -107,17 +107,11 @@
         }
 
         private func getUrlString(url: URL) -> String {
-            guard options.stripQueryParams else {
-                return url.absoluteString
-            }
-
-            guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                return url.absoluteString
-            }
-
-            components.query = nil
-
-            return components.string ?? url.absoluteString
+            WebViewURLSanitizer.sanitize(
+                url.absoluteString,
+                stripQueryParams: options.stripQueryParams,
+                fragmentHandling: options.fragmentHandling
+            )
         }
     }
 

--- a/Sources/EmbraceCore/Capture/WebView/WebViewURLSanitizer.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WebViewURLSanitizer.swift
@@ -134,12 +134,20 @@
             // A hash route, which carries the screen the user was on rather than sensitive data: keep it, and take
             // anything after a `?` within it through the same rules. Excluding `/` and `?` from parameter names
             // above is what lets a route like `/search?q=shoes` reach this rule.
-            if let first = segment.first, first == slash || first == exclamationMark, depth < maxRecursionDepth {
+            if let first = segment.first, first == slash || first == exclamationMark {
                 guard let queryIndex = segment.firstIndex(of: questionMark) else {
                     return string(segment)
                 }
 
                 let route = segment[segment.startIndex...queryIndex]
+
+                // Past the nesting limit the route is kept but its query is dropped rather than emitted as-is.
+                // Text this deep in a fragment has stopped being something we can claim to have parsed, and
+                // keeping it would keep whatever values it holds.
+                guard depth < maxRecursionDepth else {
+                    return string(route)
+                }
+
                 let query = segment[segment.index(after: queryIndex)..<segment.endIndex]
 
                 return string(route) + redact(query, depth: depth + 1)

--- a/Sources/EmbraceCore/Capture/WebView/WebViewURLSanitizer.swift
+++ b/Sources/EmbraceCore/Capture/WebView/WebViewURLSanitizer.swift
@@ -1,0 +1,165 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if canImport(WebKit)
+    import Foundation
+
+    /// Rewrites the URLs captured from a web view according to the privacy settings in `WebViewCaptureService.Options`.
+    ///
+    /// All the processing happens on the raw URL string, exactly as it was captured and still percent-encoded.
+    /// Percent-decoding before parsing would turn an encoded separator such as `%26` into a live one, so nothing
+    /// here decodes anything: the parts of the URL that are kept are emitted byte for byte.
+    ///
+    /// The scanning is done over UTF-8 bytes rather than characters. Every delimiter this looks for is ASCII, and
+    /// walking a string by `Character` means segmenting it into grapheme clusters, which costs several times more
+    /// than the rest of the work put together.
+    enum WebViewURLSanitizer {
+
+        /// The longest text that can plausibly be a parameter name in a fragment segment.
+        static let maxKeyLength = 64
+
+        /// The length at which a fragment segment with no recognizable structure stops being a label, such as an
+        /// anchor, and starts being a payload, such as base64 application state or a token.
+        static let opaqueSegmentThreshold = 64
+
+        /// The maximum number of times redaction recurses into the query of a hash route.
+        static let maxRecursionDepth = 4
+
+        private static let hash = UInt8(ascii: "#")
+        private static let questionMark = UInt8(ascii: "?")
+        private static let equals = UInt8(ascii: "=")
+        private static let slash = UInt8(ascii: "/")
+        private static let exclamationMark = UInt8(ascii: "!")
+
+        /// The bytes that act as separators between the segments of a fragment. Both turn up in real data.
+        private static let separators: Set<UInt8> = [UInt8(ascii: "&"), UInt8(ascii: ";")]
+
+        /// The bytes that a parameter name can never contain: the URL delimiters, and whitespace.
+        ///
+        /// This is a denylist rather than an allowlist such as `[A-Za-z0-9_-]` on purpose: real parameter names
+        /// include shapes like `mids[]` and `filter:name`, and rejecting those would keep their values.
+        private static let invalidKeyBytes: Set<UInt8> = [
+            UInt8(ascii: "/"), UInt8(ascii: "?"), UInt8(ascii: "#"), UInt8(ascii: "&"), UInt8(ascii: "="),
+            0x20, 0x09, 0x0A, 0x0B, 0x0C, 0x0D
+        ]
+
+        /// Returns the given URL string with the query and the fragment processed as requested.
+        /// - Parameters:
+        ///   - urlString: The URL exactly as it was captured.
+        ///   - stripQueryParams: Whether the query component should be removed.
+        ///   - fragmentHandling: How the fragment component should be treated.
+        static func sanitize(
+            _ urlString: String,
+            stripQueryParams: Bool,
+            fragmentHandling: WebViewCaptureService.FragmentHandling
+        ) -> String {
+
+            guard stripQueryParams || fragmentHandling != .keep else {
+                return urlString
+            }
+
+            let bytes = urlString.utf8
+
+            // The fragment is the last component of a URL and runs to its end, and a literal `#` inside a fragment
+            // must be percent-encoded, so the first `#` is always the delimiter and any later one is data.
+            var base = bytes[bytes.startIndex..<bytes.endIndex]
+            var fragment: Substring.UTF8View?
+
+            if let hashIndex = bytes.firstIndex(of: hash) {
+                base = bytes[bytes.startIndex..<hashIndex]
+                fragment = bytes[bytes.index(after: hashIndex)..<bytes.endIndex]
+            }
+
+            // With the fragment already separated, the query runs from the first `?` to the end of the base. This
+            // is what keeps the two settings independent of each other.
+            if stripQueryParams, let queryIndex = base.firstIndex(of: questionMark) {
+                base = base[base.startIndex..<queryIndex]
+            }
+
+            guard let fragment = fragment else {
+                return string(base)
+            }
+
+            switch fragmentHandling {
+            case .keep:
+                return string(base) + "#" + string(fragment)
+            case .remove:
+                return string(base)
+            case .redact:
+                return string(base) + "#" + redact(fragment, depth: 0)
+            }
+        }
+
+        /// Redacts a fragment, or the query of a hash route inside one, by splitting it into segments and taking
+        /// each through the segment rules. The separators and their positions are preserved, so a segment that is
+        /// dropped leaves an empty segment behind and the shape of the fragment survives.
+        private static func redact(_ text: Substring.UTF8View, depth: Int) -> String {
+            var result = ""
+            result.reserveCapacity(text.count)
+
+            var segmentStart = text.startIndex
+            var index = text.startIndex
+
+            while index < text.endIndex {
+                let byte = text[index]
+
+                if separators.contains(byte) {
+                    result += redactSegment(text[segmentStart..<index], depth: depth)
+                    result.append(Character(UnicodeScalar(byte)))
+                    segmentStart = text.index(after: index)
+                }
+
+                index = text.index(after: index)
+            }
+
+            result += redactSegment(text[segmentStart..<text.endIndex], depth: depth)
+
+            return result
+        }
+
+        /// Applies the segment rules, first match wins.
+        private static func redactSegment(_ segment: Substring.UTF8View, depth: Int) -> String {
+
+            // A `key=value` pair whose name is plausibly a parameter name: keep the name and the `=`, drop the
+            // value. The name is validated instead of simply splitting on the first `=`, because an opaque payload
+            // can contain an `=` too: the base64 padding at the end of a long blob would otherwise be read as one
+            // enormous name with an empty value, and the whole blob would be preserved.
+            if let equalsIndex = segment.firstIndex(of: equals),
+                isPlausibleKey(segment[segment.startIndex..<equalsIndex])
+            {
+                return string(segment[segment.startIndex...equalsIndex])
+            }
+
+            // A hash route, which carries the screen the user was on rather than sensitive data: keep it, and take
+            // anything after a `?` within it through the same rules. Excluding `/` and `?` from parameter names
+            // above is what lets a route like `/search?q=shoes` reach this rule.
+            if let first = segment.first, first == slash || first == exclamationMark, depth < maxRecursionDepth {
+                guard let queryIndex = segment.firstIndex(of: questionMark) else {
+                    return string(segment)
+                }
+
+                let route = segment[segment.startIndex...queryIndex]
+                let query = segment[segment.index(after: queryIndex)..<segment.endIndex]
+
+                return string(route) + redact(query, depth: depth + 1)
+            }
+
+            // No recognizable structure: short enough to be a label, or long enough to be a payload.
+            return segment.count <= opaqueSegmentThreshold ? string(segment) : ""
+        }
+
+        /// Returns whether the given text could plausibly be the name of a parameter.
+        private static func isPlausibleKey(_ key: Substring.UTF8View) -> Bool {
+            guard !key.isEmpty, key.count <= maxKeyLength else {
+                return false
+            }
+
+            return !key.contains { invalidKeyBytes.contains($0) }
+        }
+
+        private static func string(_ bytes: Substring.UTF8View) -> String {
+            String(decoding: bytes, as: UTF8.self)
+        }
+    }
+#endif

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceOptionsTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceOptionsTests.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if canImport(WebKit)
+    @testable import EmbraceCore
+    import XCTest
+
+    class WebViewCaptureServiceOptionsTests: XCTestCase {
+
+        func test_defaults() {
+            let options = WebViewCaptureService.Options()
+
+            XCTAssertFalse(options.stripQueryParams)
+            XCTAssertEqual(options.fragmentHandling, .keep)
+        }
+
+        func test_settingTheQueryOptionAloneLeavesTheFragmentHandlingUntouched() {
+            let options = WebViewCaptureService.Options(stripQueryParams: true)
+
+            XCTAssertTrue(options.stripQueryParams)
+            XCTAssertEqual(options.fragmentHandling, .keep)
+        }
+
+        func test_settingTheFragmentHandlingAloneLeavesTheQueryOptionUntouched() {
+            let options = WebViewCaptureService.Options(fragmentHandling: .remove)
+
+            XCTAssertFalse(options.stripQueryParams)
+            XCTAssertEqual(options.fragmentHandling, .remove)
+        }
+    }
+#endif

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewCaptureServiceTests.swift
@@ -170,4 +170,29 @@
         }
     }
 
+    class WebViewCaptureServiceTests_Six: WebViewCaptureServiceTests {
+
+        // Like the test above, this goes through `didLoad` rather than the swizzle path, so it needs no
+        // `checkTestAllowed()` gating. The exhaustive coverage of the redaction rules lives in
+        // `WebViewURLSanitizerTests`; this only proves the option reaches the captured attribute.
+        func test_didLoad_fragmentHandling_controlsFragmentInCapturedURL() {
+            let url = URL(string: "https://example.com/path?id=42#access_token=eyJhbGciOiJIUzI1NiJ9&/orders/123")!
+
+            let expected: [WebViewCaptureService.FragmentHandling: String] = [
+                .keep: url.absoluteString,
+                .redact: "https://example.com/path?id=42#access_token=&/orders/123",
+                .remove: "https://example.com/path?id=42"
+            ]
+
+            for (handling, expectedURL) in expected {
+                let service = WebViewCaptureService(options: .init(fragmentHandling: handling))
+                let otel = MockOTelSignalsHandler()
+                service.install(otel: otel)
+                service.didLoad(url: url, statusCode: 200)
+
+                XCTAssertEqual(otel.events.last!.attributes["webview.url"]!.description, expectedURL)
+            }
+        }
+    }
+
 #endif

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewURLSanitizerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewURLSanitizerTests.swift
@@ -1,0 +1,305 @@
+//
+//  Copyright © 2026 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if canImport(WebKit)
+    @testable import EmbraceCore
+    import XCTest
+
+    class WebViewURLSanitizerTests: XCTestCase {
+
+        // MARK: - Helpers
+
+        private func sanitize(
+            _ urlString: String,
+            stripQueryParams: Bool = false,
+            fragmentHandling: WebViewCaptureService.FragmentHandling = .keep
+        ) -> String {
+            WebViewURLSanitizer.sanitize(
+                urlString,
+                stripQueryParams: stripQueryParams,
+                fragmentHandling: fragmentHandling
+            )
+        }
+
+        /// Redacts a bare fragment and returns it without the leading `#`, to keep the pair tests readable.
+        private func redactFragment(_ fragment: String) -> String {
+            let result = sanitize("https://host/#" + fragment, fragmentHandling: .redact)
+            return String(result.dropFirst("https://host/#".count))
+        }
+
+        /// Text with no `=` in it, used to build payloads of an exact length.
+        private static let base64Body = String(
+            repeating: "eyJsYXlvdXQiOnsidGl0bGUiOiJIb21lIn19",
+            count: 46
+        )
+
+        /// A 1624 character base64 payload whose only `=` is the final padding character.
+        private static let paddedBlob = String(base64Body.prefix(1623)) + "="
+
+        /// The same payload at the same length, but with no padding emitted.
+        private static let unpaddedBlob = String(base64Body.prefix(1624))
+
+        // MARK: - Modes and independence
+
+        func test_keep_leavesEveryURLUntouched() {
+            let urls = [
+                "https://host/",
+                "https://host/path",
+                "https://host/#",
+                "https://host/#access_token=eyJhbGciOiJIUzI1NiJ9",
+                "https://host/#/orders/123",
+                "https://host/?a=1",
+                "https://host/?a=1#access_token=eyJhbGciOiJIUzI1NiJ9",
+                "https://host/?a=1#/orders/123"
+            ]
+
+            for url in urls {
+                XCTAssertEqual(sanitize(url), url)
+            }
+        }
+
+        func test_remove_dropsTheFragmentWithAndWithoutAQuery() {
+            // the two leaking examples: removal must not depend on the presence of a query
+            XCTAssertEqual(
+                sanitize("https://host/#access_token=x", fragmentHandling: .remove),
+                "https://host/"
+            )
+            XCTAssertEqual(
+                sanitize("https://host/?a=1#access_token=x", fragmentHandling: .remove),
+                "https://host/?a=1"
+            )
+        }
+
+        func test_settingsAreIndependentOfEachOther() {
+            let url = "https://host/path?a=1&b=2#access_token=eyJhbGciOiJIUzI1NiJ9"
+
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: false, fragmentHandling: .keep),
+                url
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: false, fragmentHandling: .redact),
+                "https://host/path?a=1&b=2#access_token="
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: false, fragmentHandling: .remove),
+                "https://host/path?a=1&b=2"
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: true, fragmentHandling: .keep),
+                "https://host/path#access_token=eyJhbGciOiJIUzI1NiJ9"
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: true, fragmentHandling: .redact),
+                "https://host/path#access_token="
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: true, fragmentHandling: .remove),
+                "https://host/path"
+            )
+        }
+
+        func test_strippingTheQueryDoesNotTouchTheFragment() {
+            // the query is removed, the fragment survives whole, including any `?` inside it
+            XCTAssertEqual(
+                sanitize("https://host/?a=1#/search?q=shoes", stripQueryParams: true),
+                "https://host/#/search?q=shoes"
+            )
+
+            // and a fragment is never invented for a URL that had none
+            XCTAssertEqual(
+                sanitize("https://host/path?a=1", stripQueryParams: true),
+                "https://host/path"
+            )
+        }
+
+        // MARK: - Rule 1: key/value pairs
+
+        func test_redact_removesTheValuesOfKeyValuePairs() {
+            XCTAssertEqual(
+                redactFragment("access_token=eyJhbGciOiJIUzI1NiJ9&token_type=Bearer&expires_in=3600"),
+                "access_token=&token_type=&expires_in="
+            )
+        }
+
+        func test_redact_treatsSemicolonAsASeparator() {
+            XCTAssertEqual(redactFragment("a=1;b=2"), "a=;b=")
+            XCTAssertEqual(redactFragment("a=1;b=2&c=3"), "a=;b=&c=")
+        }
+
+        func test_redact_keepsParameterNamesThatAnAllowlistWouldReject() {
+            XCTAssertEqual(redactFragment("mids[]=6"), "mids[]=")
+            XCTAssertEqual(redactFragment("filter:name=shoes"), "filter:name=")
+            XCTAssertEqual(redactFragment("user.id=42"), "user.id=")
+        }
+
+        func test_redact_dropsEverythingAfterTheFirstEquals() {
+            XCTAssertEqual(redactFragment("t=a=b=c"), "t=")
+        }
+
+        func test_redact_pairWithAnEmptyNameIsNotAPair() {
+            // no name to keep, so the segment falls through to the length rules
+            XCTAssertEqual(redactFragment("=value"), "=value")
+        }
+
+        func test_redact_parameterNameLengthBoundary() {
+            let name = String(repeating: "k", count: WebViewURLSanitizer.maxKeyLength)
+            XCTAssertEqual(redactFragment(name + "=value"), name + "=")
+
+            // one character longer is no longer a plausible name, so the segment is unstructured and,
+            // at this length, a payload
+            let longName = String(repeating: "k", count: WebViewURLSanitizer.maxKeyLength + 1)
+            XCTAssertEqual(redactFragment(longName + "=value"), "")
+        }
+
+        // MARK: - Rule 2: hash routes
+
+        func test_redact_keepsHashRoutes() {
+            XCTAssertEqual(redactFragment("/orders/123"), "/orders/123")
+            XCTAssertEqual(redactFragment("!/legacy/orders/123"), "!/legacy/orders/123")
+        }
+
+        func test_redact_recursesIntoTheQueryOfAHashRoute() {
+            XCTAssertEqual(redactFragment("/search?q=shoes"), "/search?q=")
+            XCTAssertEqual(redactFragment("/search?q=shoes&page=2"), "/search?q=&page=")
+            XCTAssertEqual(redactFragment("/search?q=shoes;page=2"), "/search?q=;page=")
+        }
+
+        func test_redact_keepsALongRouteThatWouldBeDroppedAsAPayload() {
+            let route = "/" + String(repeating: "a", count: WebViewURLSanitizer.opaqueSegmentThreshold + 10)
+            XCTAssertEqual(redactFragment(route), route)
+        }
+
+        // MARK: - Rules 3 and 4: unstructured segments
+
+        func test_redact_keepsShortAnchors() {
+            XCTAssertEqual(redactFragment("terms-and-conditions"), "terms-and-conditions")
+            XCTAssertEqual(redactFragment("section_4.2"), "section_4.2")
+        }
+
+        func test_redact_opaqueSegmentLengthBoundary() {
+            let kept = String(repeating: "a", count: WebViewURLSanitizer.opaqueSegmentThreshold)
+            XCTAssertEqual(redactFragment(kept), kept)
+
+            let dropped = String(repeating: "a", count: WebViewURLSanitizer.opaqueSegmentThreshold + 1)
+            XCTAssertEqual(redactFragment(dropped), "")
+        }
+
+        func test_redact_dropsALongBase64Payload() {
+            XCTAssertEqual(redactFragment(Self.unpaddedBlob), "")
+        }
+
+        // MARK: - Trap: base64 padding
+
+        func test_redact_base64PaddingIsNotReadAsAParameterName() {
+            // the only `=` in this payload is its final padding character; a naive split on `=` would read the
+            // whole blob as one enormous name with an empty value and preserve it
+            XCTAssertEqual(Self.paddedBlob.count, 1624)
+            XCTAssertEqual(Self.paddedBlob.filter { $0 == "=" }.count, 1)
+            XCTAssertEqual(redactFragment(Self.paddedBlob), "")
+
+            // and the result must not depend on whether the payload's length happened to emit padding
+            XCTAssertEqual(Self.unpaddedBlob.count, Self.paddedBlob.count)
+            XCTAssertFalse(Self.unpaddedBlob.contains("="))
+            XCTAssertEqual(redactFragment(Self.paddedBlob), redactFragment(Self.unpaddedBlob))
+        }
+
+        func test_redact_paddedPayloadIsDroppedAlongsideRealPairs() {
+            XCTAssertEqual(
+                redactFragment("state=abc&" + Self.paddedBlob + "&/orders/123"),
+                "state=&&/orders/123"
+            )
+        }
+
+        // MARK: - Trap: percent-encoded separators
+
+        func test_redact_doesNotTreatEncodedSeparatorsAsSeparators() {
+            // `%26` is part of the value, not a second pair
+            XCTAssertEqual(redactFragment("a=1%26b=2"), "a=")
+            // the same for an encoded `;` and an encoded `=`
+            XCTAssertEqual(redactFragment("a=1%3Bb=2"), "a=")
+            XCTAssertEqual(redactFragment("a=1%3D2"), "a=")
+        }
+
+        func test_redact_doesNotDecodeMultipleEncodingLayers() {
+            // real data carries two and three layers of encoding
+            XCTAssertEqual(redactFragment("filters=a%252Cb%25252Cc&page=2"), "filters=&page=")
+        }
+
+        func test_redact_neverChangesTheEncodingOfWhatItKeeps() {
+            XCTAssertEqual(redactFragment("%2Fnot-a-route"), "%2Fnot-a-route")
+            XCTAssertEqual(redactFragment("caf%C3%A9"), "caf%C3%A9")
+            XCTAssertEqual(redactFragment("/orders%2F123?q=a%20b"), "/orders%2F123?q=")
+        }
+
+        // MARK: - Edge cases
+
+        func test_redact_fragmentThatRedactsToNothingKeepsItsHash() {
+            XCTAssertEqual(
+                sanitize("https://host/#" + Self.paddedBlob, fragmentHandling: .redact),
+                "https://host/#"
+            )
+        }
+
+        func test_emptyFragment() {
+            XCTAssertEqual(sanitize("https://host/#", fragmentHandling: .keep), "https://host/#")
+            XCTAssertEqual(sanitize("https://host/#", fragmentHandling: .redact), "https://host/#")
+            XCTAssertEqual(sanitize("https://host/#", fragmentHandling: .remove), "https://host/")
+        }
+
+        func test_redact_fragmentOfOnlySeparators() {
+            XCTAssertEqual(redactFragment("&&"), "&&")
+            XCTAssertEqual(redactFragment(";"), ";")
+            XCTAssertEqual(redactFragment("a=1&&b=2"), "a=&&b=")
+        }
+
+        func test_onlyTheFirstHashDelimitsTheFragment() {
+            // a later `#` is fragment data, not a second delimiter
+            XCTAssertEqual(
+                sanitize("https://host/#a=1#b=2", fragmentHandling: .redact),
+                "https://host/#a="
+            )
+            XCTAssertEqual(
+                sanitize("https://host/#a=1#b=2", fragmentHandling: .remove),
+                "https://host/"
+            )
+        }
+
+        func test_doesNotNormalizeTheURLTheWayURLComponentsWould() {
+            // round tripping through `URLComponents` rewrites parts of the URL that these settings are not
+            // about; the captured string must only differ in what was asked for
+            let url = "https://host/pa th?a=1#access_token=x"
+            XCTAssertNotEqual(URLComponents(string: url)?.string, url)
+
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: true, fragmentHandling: .remove),
+                "https://host/pa th"
+            )
+            XCTAssertEqual(
+                sanitize(url, fragmentHandling: .redact),
+                "https://host/pa th?a=1#access_token="
+            )
+        }
+
+        func test_reportedURL() {
+            let url =
+                "https://permissions.company.eu/?language_code=es-es&country_code=ESP"
+                + "&app_id=6C8A3A2E-1F4B-4F3E-9F0E-6A1B2C3D4E5F#access_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc"
+
+            XCTAssertEqual(
+                sanitize(url, fragmentHandling: .redact),
+                "https://permissions.company.eu/?language_code=es-es&country_code=ESP"
+                    + "&app_id=6C8A3A2E-1F4B-4F3E-9F0E-6A1B2C3D4E5F#access_token="
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: true, fragmentHandling: .redact),
+                "https://permissions.company.eu/#access_token="
+            )
+            XCTAssertEqual(
+                sanitize(url, stripQueryParams: true, fragmentHandling: .remove),
+                "https://permissions.company.eu/"
+            )
+        }
+    }
+#endif

--- a/Tests/EmbraceCoreTests/Capture/WebView/WebViewURLSanitizerTests.swift
+++ b/Tests/EmbraceCoreTests/Capture/WebView/WebViewURLSanitizerTests.swift
@@ -166,6 +166,50 @@
             XCTAssertEqual(redactFragment("/search?q=shoes;page=2"), "/search?q=;page=")
         }
 
+        func test_redact_recursesUpToTheNestingLimit() {
+            let limit = WebViewURLSanitizer.maxRecursionDepth
+
+            // a chain of routes that bottoms out exactly at the limit still has its pair redacted
+            let routes = (0..<limit).map { "/r\($0)?" }.joined()
+
+            XCTAssertEqual(redactFragment(routes + "token=secret"), routes + "token=")
+        }
+
+        func test_redact_stopsRecursingPastTheNestingLimit() {
+            let limit = WebViewURLSanitizer.maxRecursionDepth
+
+            // a chain nested one level deeper than the limit allows, carrying a value at the bottom
+            let fragment = (0...limit + 1).map { "/r\($0)?" }.joined() + "token=secret"
+
+            // the levels up to and including the limit are kept, and everything below it is dropped rather
+            // than emitted verbatim — the limit must not let an unredacted value through
+            let result = redactFragment(fragment)
+
+            XCTAssertEqual(result, (0...limit).map { "/r\($0)?" }.joined())
+            XCTAssertFalse(result.contains("secret"))
+        }
+
+        func test_redact_pathologicalNestingTerminatesWithoutLeaking() {
+            let fragment = String(repeating: "/x?", count: 5000) + "token=secret"
+
+            let result = redactFragment(fragment)
+
+            XCTAssertEqual(result, String(repeating: "/x?", count: WebViewURLSanitizer.maxRecursionDepth + 1))
+            XCTAssertFalse(result.contains("secret"))
+        }
+
+        func test_redact_theNestingLimitAppliesPerBranch() {
+            // each sibling segment starts at the top of the budget, so a deeply nested branch cannot consume
+            // the allowance of the ones next to it
+            let deep = (0...WebViewURLSanitizer.maxRecursionDepth + 1).map { "/r\($0)?" }.joined() + "token=secret"
+
+            let result = redactFragment(deep + "&/orders/123?q=shoes")
+
+            XCTAssertTrue(result.hasSuffix("&/orders/123?q="))
+            XCTAssertFalse(result.contains("secret"))
+            XCTAssertFalse(result.contains("shoes"))
+        }
+
         func test_redact_keepsALongRouteThatWouldBeDroppedAsAPayload() {
             let route = "/" + String(repeating: "a", count: WebViewURLSanitizer.opaqueSegmentThreshold + 10)
             XCTAssertEqual(redactFragment(route), route)

--- a/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
+++ b/Tests/EmbraceIOTests/CaptureServicesOptionsBuilderTests.swift
@@ -159,13 +159,14 @@ class CaptureServicesOptionsBuilderTests: XCTestCase {
             // when adding custom webview options
             builder.addWebViewCaptureService(
                 withOptions:
-                    .init(stripQueryParams: true)
+                    .init(stripQueryParams: true, fragmentHandling: .redact)
             )
 
             // then the result contains the correct options
             let options = builder.build()
 
             XCTAssertTrue(options.webView!.stripQueryParams)
+            XCTAssertEqual(options.webView!.fragmentHandling, .redact)
         }
 
         func test_webView_remove() throws {


### PR DESCRIPTION
Note that even though I could've kept the old logic for `stripQueryParams = true `and `fragmentsHandling = .keep`, I've decided to use the new sanitizer to cover all cases because it is more performant than the Apple API we were using.