### PR TITLE
[EMBR-13948] Fix: Move the Danger action past 3.22.1 so it runs on Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       embrace-io:
         patterns:
           - "embrace-io/*"
+    ignore:
+      # run-danger.yml pins past the 3.22.1 tag: that image installs Node 18, which
+      # danger-js 14 cannot run on. Dependabot would pin back to the tag and break
+      # Danger again. Drop this entry once 3.22.2 ships with Node 24.
+      - dependency-name: "danger/swift"
 
   - package-ecosystem: "swift"
     directory: "/"

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -20,7 +20,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Pinned past the 3.22.1 tag, whose image installs Node 18. The action's Dockerfile
+      # installs danger-js unpinned, and danger-js 14 needs Node 20.18.1+: its undici 7
+      # dependency touches the Node 20+ `File` global at require time. This ref is the
+      # first with Node 24 in the image; move back to a tag once 3.22.2 ships.
       - name: Run Danger Swift
-        uses: danger/swift@434d7c25f3b02d490a340b23f5e78dd15a5670bc # 3.22.1
+        uses: danger/swift@f7ed29d43ffd423e9ee75e98e306e63d3c521c92 # master, post-3.22.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Danger runs have been failing on every branch, before the Dangerfile is read:

```
ReferenceError: File is not defined
  at .../danger/node_modules/undici/lib/web/webidl/index.js:537
Node.js v18.20.8
```

`danger/swift` is a Docker action, so GitHub rebuilds the image from the pinned ref's `Dockerfile` on every run. That Dockerfile installs Node via nodesource `setup_18.x` and then runs `npm install -g danger` with no version pin. danger-js 14 depends on undici 7, which requires Node 20.18.1+ and dereferences the Node 20+ global `File` at require time — so the moment danger-js 14 published, the same pinned SHA started producing a broken image.

Pinning the action by SHA gave no protection: the breaking dependency is resolved during the image build, not by the pin. (Node 18 has also been EOL since April 2025.)

## Changes

- **`run-danger.yml`** — pin to [danger/swift#667](https://github.com/danger/swift/pull/667)'s merged commit, which moves the image to Node 24. The newest tag, 3.22.1, predates that fix, so there's no tag to move to yet. `f7ed29d` is a merged ancestor of `master` and its only delta from 3.22.1 is `setup_18.x` → `setup_24.x`; `master` HEAD would drag in four unrelated `Danger.swiftmodule` probing changes.
- **`dependabot.yml`** — ignore `danger/swift`. The pin isn't parseable as a version, and any bump Dependabot can compute lands back on the broken 3.22.1 tag. Drop the entry once 3.22.2 ships.

Focal's glibc 2.31 satisfies Node 24's 2.28+ requirement, so the base image is fine.

## Checklist

- [x] PR Description to summarize changes
- [x] Add sufficient test coverage — n/a; this PR's own Danger run is the test
- [x] Read [Contributing Guidelines](./CONTRIBUTING.md)
- [x] Agree to [Embrace CLA](https://docs.google.com/forms/d/e/1FAIpQLSct_OV9j5-yGCXkhMKOUKpwTxFWdwCQYTPeESk39lOM6k3uKA/viewform)
