### PR TITLE
[EMBR-13976] Extract FrameTimingSource from FrameRateMonitor (refactor-only)

### DIFF
--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/FrameRateMonitor.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/FrameRateMonitor.swift
@@ -5,25 +5,16 @@
 #if !os(watchOS) && !os(macOS)
 
     import Foundation
-    import QuartzCore
 
     #if !EMBRACE_COCOAPOD_BUILDING_SDK
         import EmbraceCommonInternal
     #endif
 
-    /// Monitors frame rendering timing to detect main-thread hangs.
+    /// Detects main-thread hangs from `FrameTimingSource`'s frame-delay reports.
     ///
-    /// `FrameRateMonitor` uses `CADisplayLink` to observe frame delivery on the
-    /// main thread. On each frame, it compares the actual delivery time against
-    /// the system's own committed schedule (`targetTimestamp` from the previous
-    /// tick). A delay exceeding `threshold` is reported as a completed hang to
-    /// the `hangObserver`.
-    ///
-    /// This approach is dynamic-rate–safe: using `targetTimestamp` rather than a
-    /// fixed frame duration means ProMotion, Low Power Mode, and
-    /// `preferredFrameRateRange` transitions never produce false positives.
-    /// `CADisplayLink` also pauses automatically in the background, so suspend
-    /// gaps are excluded without any extra bookkeeping.
+    /// On each frame delay report, a delay exceeding `threshold` is reported as a completed hang
+    /// to the `hangObserver`. Because `FrameTimingSource` only reports a delay once the hang is
+    /// already over, the hang is reported retroactively.
     final class FrameRateMonitor {
 
         /// Apple's own definition of a hang (≈ 250 ms).
@@ -44,62 +35,18 @@
         /// Must be called on the main thread.
         init(threshold: TimeInterval = FrameRateMonitor.defaultAppleHangThreshold) {
             self.threshold = threshold
-            self.proxy = DisplayLinkProxy()
+            self.timingSource = FrameTimingSource()
 
-            let link = CADisplayLink(target: proxy, selector: #selector(DisplayLinkProxy.tick(_:)))
-            link.add(to: .main, forMode: .common)
-            self.displayLink = link
-
-            proxy.monitor = self
-
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(resetOnForeground),
-                name: FrameRateMonitor.willEnterForegroundNotification,
-                object: nil
-            )
-        }
-
-        deinit {
-            NotificationCenter.default.removeObserver(self)
-            displayLink?.invalidate()
+            timingSource.onTick = { [weak self] delay in
+                self?.handle(delay: delay)
+            }
         }
 
         // MARK: - Private
 
-        private let proxy: DisplayLinkProxy
-        private var displayLink: CADisplayLink?
+        private let timingSource: FrameTimingSource
 
-        /// The previous frame's `targetTimestamp` — the system's promise of when
-        /// the current frame would fire.
-        private var previousTickExpectedTimestamp: CFTimeInterval?
-
-        /// Raw notification name to avoid a direct UIKit dependency.
-        private static let willEnterForegroundNotification =
-            Notification.Name("UIApplicationWillEnterForegroundNotification")
-
-        /// Resets state on foreground so the first tick after a background/foreground
-        /// transition is not misreported as a hang.
-        @objc private func resetOnForeground() {
-            previousTickExpectedTimestamp = nil
-        }
-    }
-
-    // MARK: - Frame tick
-
-    extension FrameRateMonitor {
-
-        fileprivate func tick(_ currentTick: CADisplayLink) {
-            defer {
-                previousTickExpectedTimestamp = currentTick.targetTimestamp
-            }
-
-            guard let expectedTimestamp = previousTickExpectedTimestamp else {
-                // First tick: arm for the next frame, nothing to compare yet.
-                return
-            }
-
-            let delay = currentTick.timestamp - expectedTimestamp
+        private func handle(delay: TimeInterval) {
             guard delay > threshold else { return }
 
             // The main thread was blocked beyond `threshold`.
@@ -113,21 +60,6 @@
 
             hangObserver?.hangStarted(at: previousTickDate, duration: delay)
             hangObserver?.hangEnded(at: now, duration: delay)
-        }
-    }
-
-    // MARK: - Weak proxy
-
-    extension FrameRateMonitor {
-
-        /// Holds a weak reference to `FrameRateMonitor` to break the retain cycle
-        /// that `CADisplayLink` would otherwise form with its target.
-        private final class DisplayLinkProxy: NSObject {
-            weak var monitor: FrameRateMonitor?
-
-            @objc func tick(_ link: CADisplayLink) {
-                monitor?.tick(link)
-            }
         }
     }
 

--- a/Sources/EmbraceCore/Capture/Hang/Watchdog/FrameTimingSource.swift
+++ b/Sources/EmbraceCore/Capture/Hang/Watchdog/FrameTimingSource.swift
@@ -1,0 +1,107 @@
+//
+//  Copyright © 2025 Embrace Mobile, Inc. All rights reserved.
+//
+
+#if !os(watchOS) && !os(macOS)
+
+    import Foundation
+    import QuartzCore
+
+    /// Observes frame delivery via `CADisplayLink` and reports, on each frame, how far the actual
+    /// delivery time drifted from the system's own committed schedule.
+    ///
+    /// On each tick, `FrameTimingSource` compares the current delivery time against the previous
+    /// frame's `targetTimestamp` — the system's promise of when that frame would fire — and reports
+    /// the difference via `onTick`.
+    ///
+    /// This approach is dynamic-rate–safe: using `targetTimestamp` rather than a fixed frame
+    /// duration means ProMotion, Low Power Mode, and `preferredFrameRateRange` transitions never
+    /// produce false deltas. `CADisplayLink` also pauses automatically in the background, so
+    /// suspend gaps are excluded without any extra bookkeeping.
+    final class FrameTimingSource {
+
+        /// Called on each frame tick (after the first, which only arms the comparison) with the
+        /// delay in seconds between the tick's actual timestamp and the previous tick's
+        /// `targetTimestamp`. A positive value means the frame arrived later than promised.
+        var onTick: ((TimeInterval) -> Void)?
+
+        /// Creates a new `FrameTimingSource` and immediately begins observing frame timing.
+        ///
+        /// Must be called on the main thread.
+        init() {
+            self.proxy = DisplayLinkProxy()
+
+            let link = CADisplayLink(target: proxy, selector: #selector(DisplayLinkProxy.tick(_:)))
+            link.add(to: .main, forMode: .common)
+            self.displayLink = link
+
+            proxy.source = self
+
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(resetOnForeground),
+                name: FrameTimingSource.willEnterForegroundNotification,
+                object: nil
+            )
+        }
+
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+            displayLink?.invalidate()
+        }
+
+        // MARK: - Private
+
+        private let proxy: DisplayLinkProxy
+        private var displayLink: CADisplayLink?
+
+        /// The previous frame's `targetTimestamp` — the system's promise of when
+        /// the current frame would fire.
+        private var previousTickExpectedTimestamp: CFTimeInterval?
+
+        /// Raw notification name to avoid a direct UIKit dependency.
+        private static let willEnterForegroundNotification =
+            Notification.Name("UIApplicationWillEnterForegroundNotification")
+
+        /// Resets state on foreground so the first tick after a background/foreground
+        /// transition does not report a spurious delta.
+        @objc private func resetOnForeground() {
+            previousTickExpectedTimestamp = nil
+        }
+    }
+
+    // MARK: - Frame tick
+
+    extension FrameTimingSource {
+
+        fileprivate func tick(_ currentTick: CADisplayLink) {
+            defer {
+                previousTickExpectedTimestamp = currentTick.targetTimestamp
+            }
+
+            guard let expectedTimestamp = previousTickExpectedTimestamp else {
+                // First tick: arm for the next frame, nothing to compare yet.
+                return
+            }
+
+            let delay = currentTick.timestamp - expectedTimestamp
+            onTick?(delay)
+        }
+    }
+
+    // MARK: - Weak proxy
+
+    extension FrameTimingSource {
+
+        /// Holds a weak reference to `FrameTimingSource` to break the retain cycle
+        /// that `CADisplayLink` would otherwise form with its target.
+        private final class DisplayLinkProxy: NSObject {
+            weak var source: FrameTimingSource?
+
+            @objc func tick(_ link: CADisplayLink) {
+                source?.tick(link)
+            }
+        }
+    }
+
+#endif  // !os(watchOS) && !os(macOS)


### PR DESCRIPTION
## Summary
- First of an 11-part hang-detection refactor series (1/11). Extracts the `CADisplayLink`/`targetTimestamp`-delta primitive out of `FrameRateMonitor` into a new `FrameTimingSource` type.
- `FrameRateMonitor` now owns only the hang-threshold policy and `HangObserver` callback logic, driven by `FrameTimingSource.onTick`.
- `HangCaptureService` is unchanged — it only depends on `FrameRateMonitor`'s existing public init/`hangObserver`/`logger` surface.
- Refactor-only: no behavior change.

## Test plan
- [x] `xcodebuild build` succeeds for `EmbraceIO-Package`
- [x] `swift format lint --strict` passes on both changed files
- [x] `FrameRateMonitorTests`, `HangCaptureServiceTests`, `HangCaptureServiceConcurrencyTests` all pass unmodified (19/19)